### PR TITLE
feat(converters): map discriminated `oneOf` to Pydantic tagged unions

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -93,7 +93,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `{"enum": [...]}`                            | `Literal[...]`                              | `Literal["draft", "published"]`     |
 | `{"const": "active"}`                        | single-value `Literal[...]`                 | `Literal["active"]`                 |
 | `anyOf`                                      | union annotation                            | `str` or `int`                      |
-| `oneOf`                                      | union with exactly-one-branch validation    | ambiguous matches rejected          |
+| `oneOf`                                      | discriminated or exactly-one-branch union   | tagged union or ambiguous rejected  |
 | `allOf`                                      | generated model inheritance or nested model | combined Pydantic model             |
 | nested object property                       | nested generated model                      | `post.author.name`                  |
 | property with `$ref: "#/$defs/Person"`       | model generated from `$defs.Person`         | shared `Person` field type          |
@@ -316,6 +316,72 @@ except ValidationError as er:
 
 print(Model.model_json_schema()["properties"]["value"]["oneOf"])
 #> [{'type': 'integer'}, {'type': 'number'}]
+```
+
+### Discriminated `oneOf`
+
+When every `oneOf` branch is an object schema tagged by a shared property — a required field
+whose value is a single constant (`const` or single-value `enum`) with a distinct value per
+branch — the union maps to a native Pydantic
+[discriminated union](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions)
+via `Field(discriminator=...)`.
+
+Pydantic then routes to a single branch by the tag value instead of probing every branch:
+validation is faster and errors point at the selected branch rather than reporting an
+ambiguous match. When the branches do not form a tagged union, the converter falls back to
+the exactly-one-branch validator above.
+
+```python title="discriminated_one_of.py"
+from pydantic import ValidationError
+
+from pydantic_jsonschema import Schema, to_model
+
+schema = Schema.model_validate(
+    {
+        "type": "object",
+        "properties": {
+            "pet": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "title": "Cat",
+                        "properties": {
+                            "type": {"const": "cat"},
+                            "meow": {"type": "boolean"},
+                        },
+                        "required": ["type", "meow"],
+                    },
+                    {
+                        "type": "object",
+                        "title": "Dog",
+                        "properties": {
+                            "type": {"const": "dog"},
+                            "bark": {"type": "boolean"},
+                        },
+                        "required": ["type", "bark"],
+                    },
+                ]
+            }
+        },
+    }
+)
+
+Model = to_model(schema)
+
+pet = Model(pet={"type": "cat", "meow": True}).pet
+# the `cat` tag routed to the generated `Cat` model
+print(type(pet).__name__)
+#> Cat
+
+try:
+    # `fish` matches no branch tag -> rejected by the discriminator
+    Model(pet={"type": "fish"})
+except ValidationError as er:
+    print(er.errors()[0]["type"])
+    #> union_tag_invalid
+
+print(Model.model_json_schema()["properties"]["pet"]["oneOf"])
+#> [{'$ref': '#/$defs/Cat'}, {'$ref': '#/$defs/Dog'}]
 ```
 
 ## Nested Objects

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 import annotated_types
-from pydantic import BaseModel, BeforeValidator, ConfigDict, RootModel, create_model
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, RootModel, create_model
 from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
 
@@ -46,6 +46,8 @@ _PYDANTIC_DEFAULT_MISSING: Final[Ellipsis] = ...  # type: ignore[valid-type]
 # JSON Schema 2020-12 definitions key
 # See: https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.4
 _DEFS_KEY: Final[str] = "$defs"
+# A discriminated union needs at least two members for Pydantic to tag-dispatch.
+_MIN_DISCRIMINATED_UNION_MEMBERS: Final[int] = 2
 
 # NOTE: `ARRAY` / `OBJECT` entries are only reachable from multi-type unions
 # (`{"type": ["object", "string"]}`) — single `array` / `object` schemas are handled
@@ -70,6 +72,7 @@ type AnnotationType = Any  # `type`, `Annotated`, `Union`, `Literal`, `ForwardRe
 type PythonType = Any  # Anything that Pydantic supports
 type FieldKindType = Literal["required", "optional", "root"]  # How a field is used in a model
 type FormatValidatorType = FormatValidator | type  # `FormatValidator` or `Annotated`
+type TagType = str | int | None  # Scalar discriminator tag value (`bool` is an `int`)
 
 
 class FormatValidator(Protocol):
@@ -824,17 +827,142 @@ class SchemaConverter:
             union_annotation = Union[tuple(union_args)]  # type: ignore[valid-type]  # noqa: UP007
             return cast("type", union_annotation)
 
-        # `oneOf` -> union of branches + exactly-one-branch validation:
+        # `oneOf` -> discriminated union or exactly-one-branch validation:
         if schema.one_of is not MISSING:
-            one_of_validator = OneOf(branches=self._union_args(schema.one_of, kind="oneOf"))
-            self._one_of_validators.append(one_of_validator)
-            return cast("type", one_of_validator.as_annotation())
+            return self._one_of_annotation(schema)
 
         # `allOf` -> nested model:
         if schema.all_of is not MISSING:
             return self._convert_nested_schema(schema)
 
         return None
+
+    def _one_of_annotation(
+        self,
+        schema: Schema,
+        /,
+    ) -> type:
+        """Convert a `oneOf` composition to an annotation.
+
+        When all branches are object schemas tagged by a shared discriminator
+        property, the union maps to a native Pydantic discriminated (tagged) union
+        via `Field(discriminator=...)`:
+        Pydantic routes to a single branch by the tag value instead of probing
+        every branch, which is faster and yields branch-specific errors.
+
+        Otherwise it falls back to the `OneOf` wrap-validator,
+        which enforces exactly-one-branch semantics by probing.
+
+        :param schema: Schema with `oneOf` set.
+        :returns: Discriminated `Union` annotation or `OneOf`-wrapped union.
+        """
+        union_args = self._union_args(schema.one_of, kind="oneOf")
+        discriminator = self._discriminator_property(schema.one_of)
+
+        # A discriminated union needs >= 2 concrete members to introspect the tag field.
+        # Unresolved `ForwardRef` branches keep the `OneOf` lazy path.
+        if (
+            discriminator is not None
+            and len(union_args) >= _MIN_DISCRIMINATED_UNION_MEMBERS
+            and not any(isinstance(arg, ForwardRef) for arg in union_args)
+        ):
+            union_annotation = Union[tuple(union_args)]  # type: ignore[valid-type]  # noqa: UP007
+            discriminated = Annotated[union_annotation, Field(discriminator=discriminator)]  # type: ignore[valid-type]
+            return cast("type", discriminated)
+
+        one_of_validator = OneOf(branches=union_args)
+        self._one_of_validators.append(one_of_validator)
+        return cast("type", one_of_validator.as_annotation())
+
+    def _discriminator_property(
+        self,
+        one_of_schemas: list[Schema | Reference],
+        /,
+    ) -> str | None:
+        """Find the property that tags every `oneOf` branch with a distinct constant.
+
+        A property qualifies as a discriminator when, in *every* branch, it is a required
+        property whose schema is a single constant (`const` or single-value `enum`),
+        and its constant value is distinct across branches.
+
+        :param one_of_schemas: Sub-schemas of the `oneOf` composition.
+        :returns: The discriminator property name, or `None` when zero or more than
+            one property qualifies (ambiguous discriminators stay on the `OneOf` path).
+        """
+        branch_count: int = len(one_of_schemas)
+
+        # Collect each branch's tag value per property name.
+        tags_by_property: dict[str, list[TagType]] = {}
+        for branch in one_of_schemas:
+            branch_schema = self._resolve_branch_schema(branch)
+            if branch_schema is None or branch_schema.properties is MISSING:
+                return None
+
+            for name, tag in self._branch_tag_values(branch_schema).items():
+                tags_by_property.setdefault(name, []).append(tag)
+
+        # A discriminator tags every branch (count of tags == branch count)
+        # with a distinct value (count of unique tags == branch count).
+        qualified: list[str] = [
+            name
+            for name, tags in tags_by_property.items()
+            if len(tags) == branch_count == len(set(tags))
+        ]
+
+        # Exactly one qualifying property keeps promotion predictable.
+        if len(qualified) != 1:
+            return None
+        return qualified[0]
+
+    def _resolve_branch_schema(
+        self,
+        branch: Schema | Reference,
+        /,
+    ) -> Schema | None:
+        """Resolve a `oneOf` branch to a concrete object schema, if known.
+
+        :param branch: A `oneOf` sub-schema or reference.
+        :returns: The inline schema, the cached schema for a local `$ref`, or `None`
+            when the reference can't be introspected (external / forward / pre-built).
+        """
+        if isinstance(branch, Reference):
+            return self._defs_cache.get(branch.ref)
+        return branch
+
+    @staticmethod
+    def _branch_tag_values(
+        schema: Schema,
+        /,
+    ) -> dict[str, TagType]:
+        """Map each required single-constant property of a branch to its tag value.
+
+        Only scalar constants (`str` / `int` / `bool` / `None`) are eligible tags —
+        they are the hashable, `Literal`-compatible values Pydantic accepts as discriminators.
+
+        :param schema: Object branch schema.
+        :returns: Mapping of property name to its constant tag value.
+        """
+        required: set[str] = set(schema.required) if schema.required is not MISSING else set()
+        tags: dict[str, TagType] = {}
+        for name, prop in schema.properties.items():
+            if name not in required or isinstance(prop, Reference):
+                continue
+
+            if prop.const is not MISSING:
+                tag = prop.const
+            elif prop.enum is not MISSING and len(prop.enum) == 1:
+                tag = prop.enum[0]
+            else:
+                continue
+
+            # NOTE: Only scalar tags are accepted. `_discriminator_property` puts these
+            # values in a `set()` to check distinctness across branches, so a non-hashable
+            # `const` (array/object) would crash. `float` is excluded on purpose:
+            # float-equality discrimination is fragile, so such unions fall back to `OneOf`.
+            if isinstance(tag, (str, int, NoneType)):
+                tags[name] = tag
+
+        return tags
 
     def _type_annotation(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,9 @@ ignore = [
 "tests/*" = [
     "S101",     # Use of `assert` detected
 ]
+"tests/test_converters.py" = [
+    "E501",     # Long lines in `inline_snapshot` literals (Pydantic error messages)
+]
 "tests/formats/test_hostname.py" = [
     "RUF001",   # Ambiguous unicode (intentional in IDN hostname test data)
 ]
@@ -173,5 +176,5 @@ skip_covered = true # Omit fully covered files from report output
 show_missing = true # Show line numbers of missing coverage in report
 precision = 2       # Number of decimal places in coverage percentages
 exclude_lines = [
-    "\\(Protocol\\):$",     # Do not count Protocol definitions
+    "\\(Protocol\\):$",     # It's impossible to test `Protocol`
 ]

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1149,6 +1149,471 @@ class TestComposition:
         )
 
 
+class TestDiscriminatedOneOf:
+    """`oneOf` branches sharing a const tag map to a Pydantic discriminated union."""
+
+    def test_routes_by_tag(self) -> None:
+        """A const-tagged `oneOf` validates each branch by its discriminator value."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {
+                "pet": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "title": "Cat",
+                            "properties": {
+                                "type": {"const": "cat"},
+                                "meow": {"type": "boolean"},
+                            },
+                            "required": ["type", "meow"],
+                        },
+                        {
+                            "type": "object",
+                            "title": "Dog",
+                            "properties": {
+                                "type": {"const": "dog"},
+                                "bark": {"type": "boolean"},
+                            },
+                            "required": ["type", "bark"],
+                        },
+                    ],
+                },
+            },
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        cat = model(pet={"type": "cat", "meow": True})
+        assert cat.model_dump() == snapshot({"pet": {"type": "cat", "meow": True}})
+
+        dog = model(pet={"type": "dog", "bark": False})
+        assert dog.model_dump() == snapshot({"pet": {"type": "dog", "bark": False}})
+
+    def test_root_level_discriminated_union(self) -> None:
+        """A root `oneOf` of tagged objects becomes a discriminated `RootModel`."""
+        schema_raw: SchemaRaw = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "title": "Cat",
+                    "properties": {"type": {"const": "cat"}, "meow": {"type": "boolean"}},
+                    "required": ["type", "meow"],
+                },
+                {
+                    "type": "object",
+                    "title": "Dog",
+                    "properties": {"type": {"const": "dog"}, "bark": {"type": "boolean"}},
+                    "required": ["type", "bark"],
+                },
+            ],
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        pet = model.model_validate({"type": "cat", "meow": True})
+        assert pet.model_dump() == snapshot({"type": "cat", "meow": True})
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Cat": {
+                        "additionalProperties": True,
+                        "properties": {
+                            "type": {"const": "cat", "title": "Type", "type": "string"},
+                            "meow": {"title": "Meow", "type": "boolean"},
+                        },
+                        "required": ["type", "meow"],
+                        "title": "Cat",
+                        "type": "object",
+                    },
+                    "Dog": {
+                        "additionalProperties": True,
+                        "properties": {
+                            "type": {"const": "dog", "title": "Type", "type": "string"},
+                            "bark": {"title": "Bark", "type": "boolean"},
+                        },
+                        "required": ["type", "bark"],
+                        "title": "Dog",
+                        "type": "object",
+                    },
+                },
+                "discriminator": {
+                    "mapping": {"cat": "#/$defs/Cat", "dog": "#/$defs/Dog"},
+                    "propertyName": "type",
+                },
+                "oneOf": [{"$ref": "#/$defs/Cat"}, {"$ref": "#/$defs/Dog"}],
+                "title": "Model",
+            }
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"type": "fish"})
+
+        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+            [
+                {
+                    "type": "union_tag_invalid",
+                    "loc": (),
+                    "msg": "Input tag 'fish' found using 'type' does not match any of the expected tags: 'cat', 'dog'",
+                    "input": {"type": "fish"},
+                }
+            ]
+        )
+
+    def test_unknown_tag_rejected(self) -> None:
+        """A value whose tag matches no branch is rejected as an invalid tag."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {
+                "pet": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "title": "Cat",
+                            "properties": {"type": {"const": "cat"}},
+                            "required": ["type"],
+                        },
+                        {
+                            "type": "object",
+                            "title": "Dog",
+                            "properties": {"type": {"const": "dog"}},
+                            "required": ["type"],
+                        },
+                    ],
+                },
+            },
+            "required": ["pet"],
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        with pytest.raises(ValidationError) as exc_info:
+            model(pet={"type": "fish"})
+
+        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+            [
+                {
+                    "type": "union_tag_invalid",
+                    "loc": ("pet",),
+                    "msg": "Input tag 'fish' found using 'type' does not match any of the expected tags: 'cat', 'dog'",
+                    "input": {"type": "fish"},
+                }
+            ]
+        )
+
+    def test_routing_uses_tag_not_structure(self) -> None:
+        """Validation routes by the tag value, then checks that one branch's shape."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {
+                "pet": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "title": "Cat",
+                            "properties": {
+                                "type": {"const": "cat"},
+                                "meow": {"type": "boolean"},
+                            },
+                            "required": ["type", "meow"],
+                        },
+                        {
+                            "type": "object",
+                            "title": "Dog",
+                            "properties": {
+                                "type": {"const": "dog"},
+                                "bark": {"type": "boolean"},
+                            },
+                            "required": ["type", "bark"],
+                        },
+                    ],
+                },
+            },
+            "required": ["pet"],
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        # Tag says `cat`, so the `cat` branch is checked: its required `meow` is missing.
+        # The error is branch-specific (`pet.cat.meow`), not "matches N oneOf branches".
+        with pytest.raises(ValidationError) as exc_info:
+            model(pet={"type": "cat", "bark": True})
+
+        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+            [
+                {
+                    "type": "missing",
+                    "loc": ("pet", "cat", "meow"),
+                    "msg": "Field required",
+                    "input": {"type": "cat", "bark": True},
+                }
+            ]
+        )
+
+    def test_dump_round_trips_one_of_with_discriminator(self) -> None:
+        """A discriminated union dumps back as `oneOf` plus a `discriminator`."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {
+                "pet": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "title": "Cat",
+                            "properties": {"type": {"const": "cat"}},
+                            "required": ["type"],
+                        },
+                        {
+                            "type": "object",
+                            "title": "Dog",
+                            "properties": {"type": {"const": "dog"}},
+                            "required": ["type"],
+                        },
+                    ],
+                },
+            },
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Cat": {
+                        "additionalProperties": True,
+                        "properties": {"type": {"const": "cat", "title": "Type", "type": "string"}},
+                        "required": ["type"],
+                        "title": "Cat",
+                        "type": "object",
+                    },
+                    "Dog": {
+                        "additionalProperties": True,
+                        "properties": {"type": {"const": "dog", "title": "Type", "type": "string"}},
+                        "required": ["type"],
+                        "title": "Dog",
+                        "type": "object",
+                    },
+                },
+                "additionalProperties": True,
+                "properties": {
+                    "pet": {
+                        "discriminator": {
+                            "mapping": {"cat": "#/$defs/Cat", "dog": "#/$defs/Dog"},
+                            "propertyName": "type",
+                        },
+                        "oneOf": [{"$ref": "#/$defs/Cat"}, {"$ref": "#/$defs/Dog"}],
+                        "title": "Pet",
+                    }
+                },
+                "title": "Model",
+                "type": "object",
+            }
+        )
+
+    def test_from_references(self) -> None:
+        """`oneOf` of `$ref` branches with a shared tag becomes discriminated."""
+        schema_raw: SchemaRaw = {
+            "$defs": {
+                "Cat": {
+                    "type": "object",
+                    "properties": {"kind": {"const": "cat"}},
+                    "required": ["kind"],
+                },
+                "Dog": {
+                    "type": "object",
+                    "properties": {"kind": {"const": "dog"}},
+                    "required": ["kind"],
+                },
+            },
+            "type": "object",
+            "properties": {
+                "pet": {"oneOf": [{"$ref": "#/$defs/Cat"}, {"$ref": "#/$defs/Dog"}]},
+            },
+            "required": ["pet"],
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        assert model(pet={"kind": "dog"}).model_dump() == snapshot({"pet": {"kind": "dog"}})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model(pet={"kind": "bird"})
+
+        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+            [
+                {
+                    "type": "union_tag_invalid",
+                    "loc": ("pet",),
+                    "msg": "Input tag 'bird' found using 'kind' does not match any of the expected tags: 'cat', 'dog'",
+                    "input": {"kind": "bird"},
+                }
+            ]
+        )
+
+    def test_single_value_enum_tag(self) -> None:
+        """A single-value `enum` acts as a const tag for discrimination."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {
+                "shape": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "title": "Circle",
+                            "properties": {"kind": {"enum": ["circle"]}},
+                            "required": ["kind"],
+                        },
+                        {
+                            "type": "object",
+                            "title": "Square",
+                            "properties": {"kind": {"enum": ["square"]}},
+                            "required": ["kind"],
+                        },
+                    ],
+                },
+            },
+            "required": ["shape"],
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        assert model(shape={"kind": "circle"}).model_dump() == snapshot(
+            {"shape": {"kind": "circle"}}
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model(shape={"kind": "triangle"})
+
+        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+            [
+                {
+                    "type": "union_tag_invalid",
+                    "loc": ("shape",),
+                    "msg": "Input tag 'triangle' found using 'kind' does not match any of the expected tags: 'circle', 'square'",
+                    "input": {"kind": "triangle"},
+                }
+            ]
+        )
+
+    def test_untagged_branches_fall_back_to_one_of(self) -> None:
+        """Without a required const tag, `oneOf` keeps the wrap-validator semantics."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {"tag": {"const": "a"}, "x": {"type": "integer"}},
+                        },
+                        {
+                            "type": "object",
+                            "properties": {"tag": {"const": "b"}, "y": {"type": "integer"}},
+                        },
+                    ],
+                },
+            },
+            "required": ["value"],
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        # No tag field: both untagged branches match, so the `OneOf` validator
+        # reports the multi-branch match instead of routing by a discriminator.
+        with pytest.raises(ValidationError) as exc_info:
+            model(value={"x": 1})
+
+        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("value",),
+                    "msg": "Value error, Input matches 2 `oneOf` branches, expected exactly 1",
+                    "input": {"x": 1},
+                }
+            ]
+        )
+
+    def test_non_distinct_tag_falls_back_to_one_of(self) -> None:
+        """A const shared with the same value across branches is not a discriminator."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {"tag": {"const": "same"}, "x": {"type": "integer"}},
+                            "required": ["tag"],
+                        },
+                        {
+                            "type": "object",
+                            "properties": {"tag": {"const": "same"}, "y": {"type": "integer"}},
+                            "required": ["tag"],
+                        },
+                    ],
+                },
+            },
+            "required": ["value"],
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        with pytest.raises(ValidationError) as exc_info:
+            model(value={"tag": "same"})
+
+        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("value",),
+                    "msg": "Value error, Input matches 2 `oneOf` branches, expected exactly 1",
+                    "input": {"tag": "same"},
+                }
+            ]
+        )
+
+    def test_non_scalar_tag_falls_back_to_one_of(self) -> None:
+        """A non-scalar const (only `str` / `int` / `bool` / `None` tag) is not a discriminator."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {"kind": {"const": 1.5}},
+                            "required": ["kind"],
+                        },
+                        {
+                            "type": "object",
+                            "properties": {"kind": {"const": 2.5}},
+                            "required": ["kind"],
+                        },
+                    ],
+                },
+            },
+            "required": ["value"],
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        with pytest.raises(ValidationError) as exc_info:
+            model(value={"kind": 9.9})
+
+        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("value",),
+                    "msg": "Value error, Input matches 0 `oneOf` branches, expected exactly 1",
+                    "input": {"kind": 9.9},
+                }
+            ]
+        )
+
+
 class TestRootModels:
     """Tests for `RootModel` creation from non-object root schemas."""
 


### PR DESCRIPTION
## Description

feat(converters): map discriminated `oneOf` to Pydantic tagged unions

## Type of change

- [x] New feature
- [x] Documentation

## Checklist

- [x] I followed the contribution guide in [`docs/contributing.md`](../docs/contributing.md)
