### PR TITLE
docs(project): fix duplicated copy buttons, refactor `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@
 [![mypy](https://img.shields.io/badge/types-mypy-blue.svg)](https://github.com/python/mypy)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
-Convert JSON Schema definitions into Pydantic models with runtime validation.
+**Pydantic turns models into JSON Schema. This library does the reverse** — it turns a
+JSON Schema into a Pydantic model, so you can validate data against a schema you already
+have, with all of Pydantic's runtime checks and editor support.
+
+Reach for it when the schema comes first: API contracts, config files, tool definitions,
+or validating LLM output against a fixed shape.
 
 ## Installation
 
@@ -19,10 +24,11 @@ Convert JSON Schema definitions into Pydantic models with runtime validation.
 uv add pydantic-jsonschema
 ```
 
-Requires Python 3.12+.
-See the [installation guide](https://danipulok.github.io/pydantic-jsonschema/latest/install/) for third-party validator libraries.
+Requires Python 3.12+. See the
+[installation guide](https://danipulok.github.io/pydantic-jsonschema/latest/install/)
+for optional validator libraries.
 
-## Quick Start
+## Quick start
 
 ```python
 from pydantic_jsonschema import Schema, to_model
@@ -43,42 +49,61 @@ print(user.model_dump())
 #> {'name': 'Alice', 'age': 30}
 ```
 
-## Schema Model
+## What's inside
 
-The `Schema` class is a Pydantic model representing a JSON Schema object.
-Use it to parse, inspect, and serialize schemas with full type safety:
+Three building blocks — and a fourth on the way.
+
+### 1. The schema model — `Schema` & `Reference`
+
+A Pydantic model for JSON Schema itself: parse, inspect, and serialize schemas with full
+type safety. `$ref`s are parsed as `Reference` objects and resolved during conversion.
 
 ```python
 from pydantic_jsonschema import DataType, Schema
 
 schema = Schema(
     type=DataType.OBJECT,
-    properties={
-        "name": Schema(type=DataType.STRING),
-    },
+    properties={"name": Schema(type=DataType.STRING)},
     required=["name"],
 )
 
-print(schema.model_dump_json(indent=4))
-"""
-{
-    "type": "object",
-    "properties": {
-        "name": {
-            "type": "string"
-        }
-    },
-    "required": [
-        "name"
-    ]
-}
-"""
+print(schema.model_dump_json())
+#> {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
 ```
 
-`Schema` supports `$ref` and `$defs` for reusable definitions — properties referencing a `$ref` are parsed as `Reference` objects and resolved automatically during conversion.
+### 2. The converter — `to_model` / `SchemaConverter`
 
-See the [Schema documentation](https://danipulok.github.io/pydantic-jsonschema/latest/schema/)
-for field reference and usage examples.
+Turns a `Schema` into a Pydantic model (see [Quick start](#quick-start)). It resolves
+`$ref` / `$defs`, maps `anyOf` / `oneOf` (including discriminated unions) / `allOf` to
+Python types, and applies string, number, array, and object constraints as Pydantic
+validation.
+
+### 3. Format validators
+
+Built-in validators for every `format` in the JSON Schema spec (`email`, `uri`, `uuid`,
+`date-time`, `hostname`, `json-pointer`, `regex`, and more) — with zero extra
+dependencies. Pass your own callable for custom formats.
+
+```python
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.formats import Email
+
+schema = Schema.model_validate({
+    "type": "object",
+    "properties": {"email": {"type": "string", "format": "email"}},
+    "required": ["email"],
+})
+
+User = to_model(schema, format_validators={"email": Email})
+
+print(User(email="alice@example.com").email)
+#> alice@example.com
+```
+
+### Planned: configurable loading by type
+
+Per-object control over how each type is loaded, inspired by
+[adaptix](https://github.com/reagento/adaptix).
 
 ## Documentation
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -171,24 +171,84 @@ All members: `NULL`, `STRING`, `NUMBER`, `INTEGER`, `BOOLEAN`, `ARRAY`, `OBJECT`
 
 ## Field Reference
 
-`Schema` fields map directly to JSON Schema keywords. Names convert between `snake_case` and
-`camelCase` automatically (via `alias_generator`). Only fields used by the converter are declared
-explicitly; unknown keywords are preserved via `extra="allow"`.
+`Schema` fields map directly to JSON Schema keywords. Only fields used by the converter are declared explicitly.
+Unknown keywords are preserved via `extra="allow"`.
 
-Fields by category:
+### Composition
 
-- **Type & values:** `type`, `enum`, `const`
-- **Composition:** `all_of`, `any_of`, `one_of`
-- **Subschemas:** `properties`, `items`, `additional_properties`
-- **Numeric:** `multiple_of`, `maximum`, `exclusive_maximum`, `minimum`, `exclusive_minimum`
-- **String:** `min_length`, `max_length`, `pattern`
-- **Array:** `min_items`, `max_items`
-- **Object:** `required`
-- **Format:** `format`
-- **Metadata:** `title`, `description`, `default`, `examples`
-- **Definitions:** `defs` (`$defs`)
+| Python field | JSON Schema | Spec                                                                                        |
+|--------------|-------------|---------------------------------------------------------------------------------------------|
+| `all_of`     | `allOf`     | [core §10.2.1.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.1)   |
+| `any_of`     | `anyOf`     | [core §10.2.1.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.2)   |
+| `one_of`     | `oneOf`     | [core §10.2.1.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3)   |
 
-See the [API reference](api/types.md) for each field's description and JSON Schema spec link.
+### Subschemas
+
+| Python field            | JSON Schema            | Spec                                                                                        |
+|-------------------------|------------------------|---------------------------------------------------------------------------------------------|
+| `items`                 | `items`                | [core §10.3.1.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.2)   |
+| `properties`            | `properties`           | [core §10.3.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.1)   |
+| `additional_properties` | `additionalProperties` | [core §10.3.2.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.3)   |
+
+### Type and constants
+
+| Python field | JSON Schema | Spec                                                                                                |
+|--------------|-------------|-----------------------------------------------------------------------------------------------------|
+| `type`       | `type`      | [validation §6.1.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.1)     |
+| `enum`       | `enum`      | [validation §6.1.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2)     |
+| `const`      | `const`     | [validation §6.1.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.3)     |
+
+### Numeric constraints
+
+| Python field         | JSON Schema        | Spec                                                                                            |
+|----------------------|--------------------|-------------------------------------------------------------------------------------------------|
+| `multiple_of`        | `multipleOf`       | [validation §6.2.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.1) |
+| `maximum`            | `maximum`          | [validation §6.2.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.2) |
+| `exclusive_maximum`  | `exclusiveMaximum` | [validation §6.2.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.3) |
+| `minimum`            | `minimum`          | [validation §6.2.4](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.4) |
+| `exclusive_minimum`  | `exclusiveMinimum` | [validation §6.2.5](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.5) |
+
+### String constraints
+
+| Python field | JSON Schema | Spec                                                                                            |
+|--------------|-------------|-------------------------------------------------------------------------------------------------|
+| `min_length` | `minLength` | [validation §6.3.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3.2) |
+| `max_length` | `maxLength` | [validation §6.3.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3.1) |
+| `pattern`    | `pattern`   | [validation §6.3.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3.3) |
+
+### Array constraints
+
+| Python field | JSON Schema | Spec                                                                                            |
+|--------------|-------------|-------------------------------------------------------------------------------------------------|
+| `min_items`  | `minItems`  | [validation §6.4.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.2) |
+| `max_items`  | `maxItems`  | [validation §6.4.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.1) |
+
+### Object constraints
+
+| Python field | JSON Schema | Spec                                                                                            |
+|--------------|-------------|-------------------------------------------------------------------------------------------------|
+| `required`   | `required`  | [validation §6.5.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3) |
+
+### Format
+
+| Python field | JSON Schema | Spec                                                                                    |
+|--------------|-------------|-----------------------------------------------------------------------------------------|
+| `format`     | `format`    | [validation §7](https://json-schema.org/draft/2020-12/json-schema-validation#section-7) |
+
+### Metadata
+
+| Python field  | JSON Schema   | Spec                                                                                        |
+|---------------|---------------|---------------------------------------------------------------------------------------------|
+| `title`       | `title`       | [validation §9.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.1) |
+| `description` | `description` | [validation §9.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.1) |
+| `default`     | `default`     | [validation §9.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.2) |
+| `examples`    | `examples`    | [validation §9.5](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.5) |
+
+### Definitions
+
+| Python field | JSON Schema | Spec                                                                                      |
+|--------------|-------------|-------------------------------------------------------------------------------------------|
+| `defs`       | `$defs`     | [core §8.2.4](https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.4)       |
 
 ## Extra Keywords
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -171,84 +171,24 @@ All members: `NULL`, `STRING`, `NUMBER`, `INTEGER`, `BOOLEAN`, `ARRAY`, `OBJECT`
 
 ## Field Reference
 
-`Schema` fields map directly to JSON Schema keywords. Only fields used by the converter are declared explicitly.
-Unknown keywords are preserved via `extra="allow"`.
+`Schema` fields map directly to JSON Schema keywords. Names convert between `snake_case` and
+`camelCase` automatically (via `alias_generator`). Only fields used by the converter are declared
+explicitly; unknown keywords are preserved via `extra="allow"`.
 
-### Composition
+Fields by category:
 
-| Python field | JSON Schema | Spec                                                                                        |
-|--------------|-------------|---------------------------------------------------------------------------------------------|
-| `all_of`     | `allOf`     | [core §10.2.1.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.1)   |
-| `any_of`     | `anyOf`     | [core §10.2.1.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.2)   |
-| `one_of`     | `oneOf`     | [core §10.2.1.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3)   |
+- **Type & values:** `type`, `enum`, `const`
+- **Composition:** `all_of`, `any_of`, `one_of`
+- **Subschemas:** `properties`, `items`, `additional_properties`
+- **Numeric:** `multiple_of`, `maximum`, `exclusive_maximum`, `minimum`, `exclusive_minimum`
+- **String:** `min_length`, `max_length`, `pattern`
+- **Array:** `min_items`, `max_items`
+- **Object:** `required`
+- **Format:** `format`
+- **Metadata:** `title`, `description`, `default`, `examples`
+- **Definitions:** `defs` (`$defs`)
 
-### Subschemas
-
-| Python field            | JSON Schema            | Spec                                                                                        |
-|-------------------------|------------------------|---------------------------------------------------------------------------------------------|
-| `items`                 | `items`                | [core §10.3.1.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.2)   |
-| `properties`            | `properties`           | [core §10.3.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.1)   |
-| `additional_properties` | `additionalProperties` | [core §10.3.2.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.3)   |
-
-### Type and constants
-
-| Python field | JSON Schema | Spec                                                                                                |
-|--------------|-------------|-----------------------------------------------------------------------------------------------------|
-| `type`       | `type`      | [validation §6.1.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.1)     |
-| `enum`       | `enum`      | [validation §6.1.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.2)     |
-| `const`      | `const`     | [validation §6.1.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.3)     |
-
-### Numeric constraints
-
-| Python field         | JSON Schema        | Spec                                                                                            |
-|----------------------|--------------------|-------------------------------------------------------------------------------------------------|
-| `multiple_of`        | `multipleOf`       | [validation §6.2.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.1) |
-| `maximum`            | `maximum`          | [validation §6.2.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.2) |
-| `exclusive_maximum`  | `exclusiveMaximum` | [validation §6.2.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.3) |
-| `minimum`            | `minimum`          | [validation §6.2.4](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.4) |
-| `exclusive_minimum`  | `exclusiveMinimum` | [validation §6.2.5](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.5) |
-
-### String constraints
-
-| Python field | JSON Schema | Spec                                                                                            |
-|--------------|-------------|-------------------------------------------------------------------------------------------------|
-| `min_length` | `minLength` | [validation §6.3.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3.2) |
-| `max_length` | `maxLength` | [validation §6.3.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3.1) |
-| `pattern`    | `pattern`   | [validation §6.3.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3.3) |
-
-### Array constraints
-
-| Python field | JSON Schema | Spec                                                                                            |
-|--------------|-------------|-------------------------------------------------------------------------------------------------|
-| `min_items`  | `minItems`  | [validation §6.4.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.2) |
-| `max_items`  | `maxItems`  | [validation §6.4.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.1) |
-
-### Object constraints
-
-| Python field | JSON Schema | Spec                                                                                            |
-|--------------|-------------|-------------------------------------------------------------------------------------------------|
-| `required`   | `required`  | [validation §6.5.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3) |
-
-### Format
-
-| Python field | JSON Schema | Spec                                                                                    |
-|--------------|-------------|-----------------------------------------------------------------------------------------|
-| `format`     | `format`    | [validation §7](https://json-schema.org/draft/2020-12/json-schema-validation#section-7) |
-
-### Metadata
-
-| Python field  | JSON Schema   | Spec                                                                                        |
-|---------------|---------------|---------------------------------------------------------------------------------------------|
-| `title`       | `title`       | [validation §9.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.1) |
-| `description` | `description` | [validation §9.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.1) |
-| `default`     | `default`     | [validation §9.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.2) |
-| `examples`    | `examples`    | [validation §9.5](https://json-schema.org/draft/2020-12/json-schema-validation#section-9.5) |
-
-### Definitions
-
-| Python field | JSON Schema | Spec                                                                                      |
-|--------------|-------------|-------------------------------------------------------------------------------------------|
-| `defs`       | `$defs`     | [core §8.2.4](https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.4)       |
+See the [API reference](api/types.md) for each field's description and JSON Schema spec link.
 
 ## Extra Keywords
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -98,3 +98,10 @@
 .md-content__inner {
   padding-bottom: 3em;
 }
+
+/* De-duplicate code-block copy buttons: `mkdocs-copy-to-llm` adds its own per-block
+   button next to Material's built-in code-copy. Keep Material's (plain copy) and hide
+   the copy-to-llm one; its page-level "copy / open in LLM" buttons stay. */
+.copy-to-llm-code {
+  display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,9 +154,16 @@ plugins:
         Development:
           - contributing.md
           - changelog.md
-  # "Copy page as Markdown" split button (copy / open in ChatGPT / open in Claude).
+  # "Copy page as Markdown" split button (copy / view / open in ChatGPT / open in Claude).
   - copy-to-llm:
       button_hover_color: "var(--md-primary-fg-color)"
+      buttons:
+        copy_page: true
+        view_as_markdown: true
+        open_in_chatgpt: true
+        open_in_claude: true
+        # Niche — a Markdown link to the page is rarely what readers want.
+        copy_markdown_link: false
   - mkdocstrings:
       enabled: true
       default_handler: python


### PR DESCRIPTION
# Summary

Documentation polish: de-duplicate code-block copy buttons, trim the copy-to-llm menu, and rewrite the README around the core features.

## What changed

- Hide the duplicate `mkdocs-copy-to-llm` per-code-block button (Material's built-in code-copy stays).
- Drop the niche "copy markdown link" entry from the `copy-to-llm` page menu.
- Rewrite the `README` to be feature-focused: schema model (`Schema`/`Reference`), converter (`to_model`), format validators.

## How it was tested

`just all` — ruff, mypy, 681 tests, 100% coverage, docs build. README code examples run via `test_docs`.