### PR TITLE
test(suite): full `ValidationError` snapshots + required schema fields

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,4 +2,23 @@
 
 from typing import Any
 
+from pydantic import ValidationError
+from pydantic_core import ErrorDetails
+
 type SchemaRaw = dict[str, Any]
+
+
+def dump_errors(exc: ValidationError) -> list[ErrorDetails]:
+    """Return a snapshot-friendly view of a `ValidationError`'s errors.
+
+    `include_url=False` drops the version-pinned URL; `include_context=False` drops `ctx`
+    (e.g. the non-roundtrippable `ValueError` from our own validators), leaving
+    `type` / `loc` / `msg` / `input` — stable across Pydantic versions and safe for `snapshot()`.
+
+    :param exc: The raised `ValidationError`.
+    :returns: The error list with only the snapshot-stable fields.
+    """
+    return exc.errors(
+        include_url=False,  # We don't care about URLs
+        include_context=False,  # We always know context
+    )

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -20,6 +20,7 @@ from pydantic_jsonschema.exceptions import SchemaConversionError, SchemaReferenc
 from pydantic_jsonschema.formats import UUID as UUID_FORMAT
 from pydantic_jsonschema.formats import DateTime, Email, IPv4, Uri
 from pydantic_jsonschema.types import Schema
+from tests.conftest import dump_errors
 
 if TYPE_CHECKING:
     from pydantic.fields import FieldInfo
@@ -1075,6 +1076,7 @@ class TestComposition:
                     ],
                 },
             },
+            "required": ["value"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1082,8 +1084,19 @@ class TestComposition:
         instance = model(value=1.5)
         assert instance.model_dump() == snapshot({"value": 1.5})
 
-        with pytest.raises(ValidationError, match=r"matches 2 `oneOf` branches"):
+        with pytest.raises(ValidationError) as exc_info:
             model(value=1)
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("value",),
+                    "msg": "Value error, Input matches 2 `oneOf` branches, expected exactly 1",
+                    "input": 1,
+                }
+            ]
+        )
 
     def test_oneof_no_matching_branch_rejected(self) -> None:
         """Test `oneOf` rejects a value matching zero branches."""
@@ -1097,12 +1110,24 @@ class TestComposition:
                     ],
                 },
             },
+            "required": ["value"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
 
-        with pytest.raises(ValidationError, match=r"matches 0 `oneOf` branches"):
+        with pytest.raises(ValidationError) as exc_info:
             model(value=[1, 2, 3])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("value",),
+                    "msg": "Value error, Input matches 0 `oneOf` branches, expected exactly 1",
+                    "input": [1, 2, 3],
+                }
+            ]
+        )
 
     def test_oneof_with_forward_ref(self) -> None:
         """Test `oneOf` with a forward reference branch resolved lazily."""
@@ -1250,7 +1275,7 @@ class TestDiscriminatedOneOf:
         with pytest.raises(ValidationError) as exc_info:
             model.model_validate({"type": "fish"})
 
-        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+        assert dump_errors(exc_info.value) == snapshot(
             [
                 {
                     "type": "union_tag_invalid",
@@ -1291,7 +1316,7 @@ class TestDiscriminatedOneOf:
         with pytest.raises(ValidationError) as exc_info:
             model(pet={"type": "fish"})
 
-        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+        assert dump_errors(exc_info.value) == snapshot(
             [
                 {
                     "type": "union_tag_invalid",
@@ -1340,7 +1365,7 @@ class TestDiscriminatedOneOf:
         with pytest.raises(ValidationError) as exc_info:
             model(pet={"type": "cat", "bark": True})
 
-        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+        assert dump_errors(exc_info.value) == snapshot(
             [
                 {
                     "type": "missing",
@@ -1440,7 +1465,7 @@ class TestDiscriminatedOneOf:
         with pytest.raises(ValidationError) as exc_info:
             model(pet={"kind": "bird"})
 
-        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+        assert dump_errors(exc_info.value) == snapshot(
             [
                 {
                     "type": "union_tag_invalid",
@@ -1485,7 +1510,7 @@ class TestDiscriminatedOneOf:
         with pytest.raises(ValidationError) as exc_info:
             model(shape={"kind": "triangle"})
 
-        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+        assert dump_errors(exc_info.value) == snapshot(
             [
                 {
                     "type": "union_tag_invalid",
@@ -1524,7 +1549,7 @@ class TestDiscriminatedOneOf:
         with pytest.raises(ValidationError) as exc_info:
             model(value={"x": 1})
 
-        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+        assert dump_errors(exc_info.value) == snapshot(
             [
                 {
                     "type": "value_error",
@@ -1563,7 +1588,7 @@ class TestDiscriminatedOneOf:
         with pytest.raises(ValidationError) as exc_info:
             model(value={"tag": "same"})
 
-        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+        assert dump_errors(exc_info.value) == snapshot(
             [
                 {
                     "type": "value_error",
@@ -1602,7 +1627,7 @@ class TestDiscriminatedOneOf:
         with pytest.raises(ValidationError) as exc_info:
             model(value={"kind": 9.9})
 
-        assert exc_info.value.errors(include_url=False, include_context=False) == snapshot(
+        assert dump_errors(exc_info.value) == snapshot(
             [
                 {
                     "type": "value_error",
@@ -2090,8 +2115,19 @@ class TestFormatValidators:
         instance = model(count=5)
         assert instance.model_dump() == snapshot({"count": 5})
 
-        with pytest.raises(ValidationError, match="Must be positive"):
+        with pytest.raises(ValidationError) as exc_info:
             model(count=-1)
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("count",),
+                    "msg": "Value error, Must be positive",
+                    "input": -1,
+                }
+            ]
+        )
 
     def test_annotated_validator_with_transformation(self) -> None:
         """Test Annotated type with value transformation."""
@@ -2141,8 +2177,19 @@ class TestFormatValidators:
         instance = model(email="test@example.com")
         assert instance.model_dump() == snapshot({"email": "test@example.com"})
 
-        with pytest.raises(ValidationError, match="Invalid email"):
+        with pytest.raises(ValidationError) as exc_info:
             model(email="invalid")
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("email",),
+                    "msg": "Value error, Invalid email",
+                    "input": "invalid",
+                }
+            ]
+        )
 
     def test_mixed_validators(self) -> None:
         """Test multiple validator types in one schema."""
@@ -2178,11 +2225,33 @@ class TestFormatValidators:
         instance = model(count=5, code="ABC")
         assert instance.model_dump() == snapshot({"count": 5, "code": "ABC"})
 
-        with pytest.raises(ValidationError, match="Must be positive"):
+        with pytest.raises(ValidationError) as exc_info:
             model(count=-1, code="ABC")
 
-        with pytest.raises(ValidationError, match="Must be uppercase"):
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("count",),
+                    "msg": "Value error, Must be positive",
+                    "input": -1,
+                }
+            ]
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
             model(count=5, code="abc")
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("code",),
+                    "msg": "Value error, Must be uppercase",
+                    "input": "abc",
+                }
+            ]
+        )
 
     def test_validator_as_type_class(self) -> None:
         """Test validator as type class."""

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -68,6 +68,7 @@ class TestBasicConversion:
                     "items": {"type": "string"},
                 },
             },
+            "required": ["tags"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -89,8 +90,10 @@ class TestBasicConversion:
                     "properties": {
                         "name": {"type": "string"},
                     },
+                    "required": ["name"],
                 },
             },
+            "required": ["user"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -115,10 +118,13 @@ class TestBasicConversion:
                             "properties": {
                                 "value": {"type": "integer"},
                             },
+                            "required": ["value"],
                         },
                     },
+                    "required": ["level2"],
                 },
             },
+            "required": ["level1"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -141,6 +147,7 @@ class TestBasicConversion:
             "properties": {
                 "anything": {},
             },
+            "required": ["anything"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -166,6 +173,7 @@ class TestBasicConversion:
             "properties": {
                 "value": {"type": ["string", "integer", "null"]},
             },
+            "required": ["value"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -186,6 +194,7 @@ class TestBasicConversion:
             "properties": {
                 "value": {"type": ["object", "string"]},
             },
+            "required": ["value"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -206,6 +215,7 @@ class TestBasicConversion:
             "properties": {
                 "data": {"type": "array"},
             },
+            "required": ["data"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -232,8 +242,10 @@ class TestReferences:
                         "street": {"type": "string"},
                         "city": {"type": "string"},
                     },
+                    "required": ["street", "city"],
                 },
             },
+            "required": ["address"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -265,6 +277,7 @@ class TestReferences:
             "properties": {
                 "home": {"$ref": "#/$defs/Address"},
             },
+            "required": ["home"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -289,18 +302,21 @@ class TestReferences:
                         "name": {"type": "string"},
                         "age": {"type": "integer"},
                     },
+                    "required": ["name", "age"],
                 },
                 "Address": {
                     "type": "object",
                     "properties": {
                         "street": {"type": "string"},
                     },
+                    "required": ["street"],
                 },
                 "Company": {
                     "type": "object",
                     "properties": {
                         "name": {"type": "string"},
                     },
+                    "required": ["name"],
                 },
             },
             "type": "object",
@@ -309,6 +325,7 @@ class TestReferences:
                 "address": {"$ref": "#/$defs/Address"},
                 "employer": {"$ref": "#/$defs/Company"},
             },
+            "required": ["owner", "address", "employer"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -335,6 +352,7 @@ class TestReferences:
                     "properties": {
                         "name": {"type": "string"},
                     },
+                    "required": ["name"],
                 },
                 "Address": {
                     "type": "object",
@@ -342,12 +360,14 @@ class TestReferences:
                         "street": {"type": "string"},
                         "city": {"$ref": "#/$defs/City"},
                     },
+                    "required": ["street", "city"],
                 },
             },
             "type": "object",
             "properties": {
                 "home": {"$ref": "#/$defs/Address"},
             },
+            "required": ["home"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -369,6 +389,7 @@ class TestReferences:
             "properties": {
                 "field": {"$ref": "#/$defs/DoesNotExist"},
             },
+            "required": ["field"],
         }
         schema = Schema.model_validate(schema_raw)
 
@@ -388,6 +409,7 @@ class TestReferences:
                         "email": {"type": "string", "format": "email"},
                         "phone": {"type": "string"},
                     },
+                    "required": ["email", "phone"],
                 },
             },
             "type": "object",
@@ -419,6 +441,7 @@ class TestReferences:
                         "name": {"type": "string"},
                         "value": {"type": "integer"},
                     },
+                    "required": ["name", "value"],
                 },
             },
             "type": "object",
@@ -428,6 +451,7 @@ class TestReferences:
                     "items": {"$ref": "#/$defs/Item"},
                 },
             },
+            "required": ["items"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -451,6 +475,7 @@ class TestReferences:
                     "properties": {
                         "name": {"type": "string"},
                     },
+                    "required": ["name"],
                 },
                 "Article": {
                     "type": "object",
@@ -458,12 +483,14 @@ class TestReferences:
                         "title": {"type": "string"},
                         "author": {"$ref": "#/$defs/Author"},
                     },
+                    "required": ["title", "author"],
                 },
             },
             "type": "object",
             "properties": {
                 "featured": {"$ref": "#/$defs/Article"},
             },
+            "required": ["featured"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -487,6 +514,7 @@ class TestReferences:
             "properties": {
                 "address": {"$ref": "#/$defs/CustomAddress"},
             },
+            "required": ["address"],
         }
         schema = Schema.model_validate(schema_raw)
 
@@ -513,6 +541,7 @@ class TestReferences:
                     "properties": {
                         "value": {"type": "string"},
                     },
+                    "required": ["value"],
                 },
             },
             "type": "object",
@@ -520,6 +549,7 @@ class TestReferences:
                 "field1": {"$ref": "#/$defs/CustomType"},
                 "field2": {"$ref": "#/$defs/CustomType"},
             },
+            "required": ["field1", "field2"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -544,6 +574,7 @@ class TestReferences:
                     "properties": {
                         "name": {"type": "string"},
                     },
+                    "required": ["name"],
                 },
             },
             "type": "array",
@@ -564,6 +595,7 @@ class TestReferences:
                     "properties": {
                         "street": {"type": "string"},
                     },
+                    "required": ["street"],
                 },
                 "Location": {"$ref": "#/$defs/Address"},
             },
@@ -571,6 +603,7 @@ class TestReferences:
             "properties": {
                 "home": {"$ref": "#/$defs/Location"},
             },
+            "required": ["home"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -593,12 +626,14 @@ class TestReferences:
                     "properties": {
                         "value": {"type": "integer"},
                     },
+                    "required": ["value"],
                 },
             },
             "type": "object",
             "properties": {
                 "field": {"$ref": "#/$defs/Primary"},
             },
+            "required": ["field"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -668,11 +703,13 @@ class TestReferences:
                                 "properties": {
                                     "nested": {"type": "string"},
                                 },
+                                "required": ["nested"],
                             },
                         ],
                     },
                 },
             },
+            "required": ["items"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -697,8 +734,10 @@ class TestReferences:
                     "properties": {
                         "field": {"type": "string"},
                     },
+                    "required": ["field"],
                 },
             },
+            "required": ["nested"],
         }
         schema = Schema.model_validate(schema_raw)
 
@@ -722,6 +761,7 @@ class TestReferences:
             "properties": {
                 "address": {"$ref": "#/$defs/CustomAddress"},
             },
+            "required": ["address"],
         }
         schema = Schema.model_validate(schema_raw)
 
@@ -746,6 +786,7 @@ class TestReferences:
                         "id": {"type": "integer"},
                         "name": {"type": "string"},
                     },
+                    "required": ["id", "name"],
                 },
             },
             "type": "object",
@@ -755,6 +796,7 @@ class TestReferences:
                     "items": {"$ref": "#/$defs/Item"},
                 },
             },
+            "required": ["items"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -786,6 +828,7 @@ class TestComposition:
                 {
                     "type": "object",
                     "properties": {"age": {"type": "integer"}},
+                    "required": ["age"],
                 },
             ],
         }
@@ -820,6 +863,7 @@ class TestComposition:
                     "properties": {
                         "name": {"type": "string"},
                     },
+                    "required": ["name"],
                 },
             ],
         }
@@ -844,14 +888,17 @@ class TestComposition:
                         {
                             "type": "object",
                             "properties": {"a": {"type": "string"}},
+                            "required": ["a"],
                         },
                         {
                             "type": "object",
                             "properties": {"b": {"type": "integer"}},
+                            "required": ["b"],
                         },
                     ],
                 },
             },
+            "required": ["combined"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -906,12 +953,14 @@ class TestComposition:
                     "properties": {
                         "age": {"type": "integer"},
                     },
+                    "required": ["age"],
                 },
                 {
                     "type": "object",
                     "properties": {
                         "email": {"type": "string"},
                     },
+                    "required": ["email"],
                 },
             ],
         }
@@ -939,6 +988,7 @@ class TestComposition:
                     ],
                 },
             },
+            "required": ["value"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -962,6 +1012,7 @@ class TestComposition:
                     ],
                 },
             },
+            "required": ["multi_value"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -987,6 +1038,7 @@ class TestComposition:
                     ],
                 },
             },
+            "required": ["value"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1012,18 +1064,21 @@ class TestComposition:
                             ],
                         },
                     },
+                    "required": ["a", "other"],
                 },
                 "TypeB": {
                     "type": "object",
                     "properties": {
                         "b": {"type": "integer"},
                     },
+                    "required": ["b"],
                 },
             },
             "type": "object",
             "properties": {
                 "item": {"$ref": "#/$defs/TypeA"},
             },
+            "required": ["item"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1054,6 +1109,7 @@ class TestComposition:
                     ],
                 },
             },
+            "required": ["value"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1143,18 +1199,21 @@ class TestComposition:
                             ],
                         },
                     },
+                    "required": ["other"],
                 },
                 "TypeB": {
                     "type": "object",
                     "properties": {
                         "b": {"type": "integer"},
                     },
+                    "required": ["b"],
                 },
             },
             "type": "object",
             "properties": {
                 "item": {"$ref": "#/$defs/TypeA"},
             },
+            "required": ["item"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1205,6 +1264,7 @@ class TestDiscriminatedOneOf:
                     ],
                 },
             },
+            "required": ["pet"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1398,6 +1458,7 @@ class TestDiscriminatedOneOf:
                     ],
                 },
             },
+            "required": ["pet"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1431,6 +1492,7 @@ class TestDiscriminatedOneOf:
                         "title": "Pet",
                     }
                 },
+                "required": ["pet"],
                 "title": "Model",
                 "type": "object",
             }
@@ -1737,6 +1799,7 @@ class TestRootModels:
                     "properties": {
                         "name": {"type": "string"},
                     },
+                    "required": ["name"],
                 },
             },
             "type": "object",
@@ -1871,6 +1934,7 @@ class TestConstraints:
                     "multipleOf": 0.5,
                 },
             },
+            "required": ["score"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1898,6 +1962,7 @@ class TestConstraints:
                     "uniqueItems": True,
                 },
             },
+            "required": ["tags"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1920,6 +1985,7 @@ class TestAdditionalProperties:
             "properties": {
                 "metadata": {"type": "object", "additionalProperties": {"type": "integer"}},
             },
+            "required": ["metadata"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1938,6 +2004,7 @@ class TestAdditionalProperties:
             "properties": {
                 "data": {"type": "object", "additionalProperties": False},
             },
+            "required": ["data"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -1958,6 +2025,7 @@ class TestAdditionalProperties:
                     "additionalProperties": True,
                 },
             },
+            "required": ["data"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema)
@@ -2010,6 +2078,7 @@ class TestAdditionalProperties:
             "properties": {
                 "name": {"type": "string"},
             },
+            "required": ["name"],
             "additionalProperties": {
                 "type": "integer",
             },
@@ -2286,6 +2355,7 @@ class TestFormatValidators:
             "properties": {
                 "field": {"type": "string", "format": "custom"},
             },
+            "required": ["field"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(schema, format_validators={"custom": CustomType})
@@ -2466,6 +2536,7 @@ class TestFormatValidators:
                 "id": {"type": "string", "format": "uuid"},
                 "ip": {"type": "string", "format": "ipv4"},
             },
+            "required": ["email", "website", "created_at", "id", "ip"],
         }
         schema = Schema.model_validate(schema_raw)
         model = to_model(
@@ -2578,6 +2649,7 @@ class TestConverterCaching:
             "properties": {
                 "name": {"type": "string"},
             },
+            "required": ["name"],
         }
 
         converter = SchemaConverter()
@@ -2596,6 +2668,7 @@ class TestConverterCaching:
             "properties": {
                 "name": {"type": "string"},
             },
+            "required": ["name"],
         }
 
         schema_raw2 = {
@@ -2603,6 +2676,7 @@ class TestConverterCaching:
             "properties": {
                 "age": {"type": "integer"},
             },
+            "required": ["age"],
         }
 
         converter = SchemaConverter()

--- a/tests/test_one_of.py
+++ b/tests/test_one_of.py
@@ -7,6 +7,7 @@ from inline_snapshot import snapshot
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from pydantic_jsonschema import OneOf, Schema, to_model
+from tests.conftest import dump_errors
 
 
 class Pet(BaseModel):
@@ -33,8 +34,19 @@ class TestOneOfValidation:
         class Model(BaseModel):
             value: Annotated[int | float, OneOf(branches=[int, float])]
 
-        with pytest.raises(ValidationError, match=r"matches 2 `oneOf` branches"):
+        with pytest.raises(ValidationError) as exc_info:
             Model(value=1)
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("value",),
+                    "msg": "Value error, Input matches 2 `oneOf` branches, expected exactly 1",
+                    "input": 1,
+                }
+            ]
+        )
 
     def test_zero_matches_rejected(self) -> None:
         """Value matching no branch is rejected."""
@@ -42,8 +54,19 @@ class TestOneOfValidation:
         class Model(BaseModel):
             value: Annotated[str | bool, OneOf(branches=[str, bool])]
 
-        with pytest.raises(ValidationError, match=r"matches 0 `oneOf` branches"):
+        with pytest.raises(ValidationError) as exc_info:
             Model(value=[1, 2, 3])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("value",),
+                    "msg": "Value error, Input matches 0 `oneOf` branches, expected exactly 1",
+                    "input": [1, 2, 3],
+                }
+            ]
+        )
 
     def test_branches_accept_any_iterable(self) -> None:
         """`branches` accepts any iterable, not only sequences."""
@@ -62,8 +85,19 @@ class TestOneOfValidation:
 
         assert adapter.validate_python(1.5) == snapshot(1.5)
 
-        with pytest.raises(ValidationError, match=r"matches 2 `oneOf` branches"):
+        with pytest.raises(ValidationError) as exc_info:
             adapter.validate_python(1)
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Input matches 2 `oneOf` branches, expected exactly 1",
+                    "input": 1,
+                }
+            ]
+        )
 
     def test_forward_ref_branch_resolved_after_binding(self) -> None:
         """`ForwardRef` branches resolve through the bound namespace."""

--- a/tests/test_one_of.py
+++ b/tests/test_one_of.py
@@ -165,6 +165,7 @@ class TestOneOfJsonSchema:
                         ],
                     },
                 },
+                "required": ["value"],
             }
         )
         model = to_model(schema)
@@ -178,6 +179,7 @@ class TestOneOfJsonSchema:
                         "title": "Value",
                     }
                 },
+                "required": ["value"],
                 "title": "Model",
                 "type": "object",
             }


### PR DESCRIPTION
# Summary

Make `ValidationError` assertions snapshot the full error, and mark test-schema fields required where it makes sense.

## What changed

- Add a `dump_errors(exc)` helper in `conftest.py` (`errors(include_url=False, include_context=False)`) and use it to snapshot the **entire** error list for our own errors (`OneOf`, custom validators, conversion errors) instead of `match=` substrings or `errors()[0]` cherry-picks.
- Built-in Pydantic rejections stay as bare `pytest.raises(ValidationError)` — their messages change across versions, so snapshotting them would be brittle.
- Add `required` to test schemas across the suite where applicable (kept optional only where a test is specifically about optional/default/missing behavior). This also removes `missing_sentinel_error` noise from error snapshots.

## How it was tested

`just all` — ruff, mypy, 681 tests, 100% coverage, docs build.