### PR TITLE
chore(lint): scope `ruff`/`mypy` via `pyproject.toml`, drop dead `exclude`

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ format:
 lint:
     uv run ruff format --check
     uv run ruff check
-    uv run mypy .
+    uv run mypy
     uv run codespell
     npx --yes markdownlint-cli2
 
@@ -192,7 +192,7 @@ ci-install-release: _check-uv
 ci-lint:
     uv run ruff format --check
     uv run ruff check
-    uv run mypy .
+    uv run mypy
     uv run codespell
     npx --yes markdownlint-cli2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,11 +121,12 @@ plugins = [
 strict = true
 warn_return_any = true
 warn_unused_configs = true
-exclude = ["check_.*\\.py$", "mre_.*\\.py$", "pydantic_mre\\.py$"]
+files = ["pydantic_jsonschema", "tests", "examples"]
 
 [tool.ruff]
 target-version = "py312"
 line-length = 100
+include = ["pydantic_jsonschema/**/*.py", "tests/**/*.py", "examples/**/*.py"]
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
## Summary

Scope `ruff` and `mypy` to the project source paths directly in `pyproject.toml` (pydantic-ai style), so the scoping applies to every invocation — `just` recipes, `pre-commit`, CI, and editors alike.

## What changed

- `[tool.ruff] include = ["pydantic_jsonschema/**/*.py", "tests/**/*.py", "examples/**/*.py"]`.
- `[tool.mypy] files = ["pydantic_jsonschema", "tests", "examples"]`.
- `justfile`: `mypy .` -> `mypy` (so it reads `files`); `ruff` recipes already take no path args.
- Removed the stale `[tool.mypy] exclude` (`check_*` / `mre_*` / `pydantic_mre` — no such files exist).

This is the same approach used by `pydantic-ai` (`[tool.ruff] include` + `[tool.mypy] files`); `pydantic` and `adaptix` instead pass an explicit path list from a `Makefile`/`tox` variable. The `pyproject` form keeps scoping in one place per tool and applies regardless of how the tools are invoked.

## How tested

- `just all` green (681 tests, 100% coverage, `mypy` clean on 34 files).
- `ruff check --show-files` confirms only `pydantic_jsonschema`, `tests`, `examples` are linted.