### PR TITLE
feat(schema): declare remaining JSON Schema 2020-12 keywords

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -181,6 +181,18 @@ Some declared keywords round-trip through parsing and serialization but are not 
 | `all_of`     | `allOf`     | [core §10.2.1.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.1)   |
 | `any_of`     | `anyOf`     | [core §10.2.1.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.2)   |
 | `one_of`     | `oneOf`     | [core §10.2.1.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3)   |
+| `not_`       | `not`       | [core §10.2.1.4](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.4)   |
+
+### Conditional
+
+`if` / `else` are Python reserved words, so the fields use a trailing underscore with an alias.
+`populate_by_name=True` keeps both forms loadable (`Schema(if_=...)` and `{"if": ...}`).
+
+| Python field | JSON Schema | Spec                                                                                        |
+|--------------|-------------|---------------------------------------------------------------------------------------------|
+| `if_`        | `if`        | [core §10.2.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.1)   |
+| `then`       | `then`      | [core §10.2.2.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.2)   |
+| `else_`      | `else`      | [core §10.2.2.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.3)   |
 
 ### Subschemas
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -171,8 +171,8 @@ All members: `NULL`, `STRING`, `NUMBER`, `INTEGER`, `BOOLEAN`, `ARRAY`, `OBJECT`
 
 ## Field Reference
 
-`Schema` fields map directly to JSON Schema keywords. Only fields used by the converter are declared explicitly.
-Unknown keywords are preserved via `extra="allow"`.
+`Schema` fields map directly to JSON Schema keywords. Other or custom keywords are preserved via `extra="allow"`.
+Some declared keywords round-trip through parsing and serialization but are not yet consumed by the converter.
 
 ### Composition
 
@@ -187,8 +187,11 @@ Unknown keywords are preserved via `extra="allow"`.
 | Python field            | JSON Schema            | Spec                                                                                        |
 |-------------------------|------------------------|---------------------------------------------------------------------------------------------|
 | `items`                 | `items`                | [core §10.3.1.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.2)   |
+| `prefix_items`          | `prefixItems`          | [core §10.3.1.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.1)   |
+| `contains`              | `contains`             | [core §10.3.1.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.3)   |
 | `properties`            | `properties`           | [core §10.3.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.1)   |
 | `additional_properties` | `additionalProperties` | [core §10.3.2.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.3)   |
+| `pattern_properties`    | `patternProperties`    | [core §10.3.2.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2)   |
 
 ### Type and constants
 
@@ -218,16 +221,21 @@ Unknown keywords are preserved via `extra="allow"`.
 
 ### Array constraints
 
-| Python field | JSON Schema | Spec                                                                                            |
-|--------------|-------------|-------------------------------------------------------------------------------------------------|
-| `min_items`  | `minItems`  | [validation §6.4.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.2) |
-| `max_items`  | `maxItems`  | [validation §6.4.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.1) |
+| Python field   | JSON Schema   | Spec                                                                                            |
+|----------------|---------------|-------------------------------------------------------------------------------------------------|
+| `min_items`    | `minItems`    | [validation §6.4.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.2) |
+| `max_items`    | `maxItems`    | [validation §6.4.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.1) |
+| `unique_items` | `uniqueItems` | [validation §6.4.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.3) |
 
 ### Object constraints
 
-| Python field | JSON Schema | Spec                                                                                            |
-|--------------|-------------|-------------------------------------------------------------------------------------------------|
-| `required`   | `required`  | [validation §6.5.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3) |
+| Python field         | JSON Schema         | Spec                                                                                            |
+|----------------------|---------------------|-------------------------------------------------------------------------------------------------|
+| `required`           | `required`          | [validation §6.5.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3) |
+| `min_properties`     | `minProperties`     | [validation §6.5.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.2) |
+| `max_properties`     | `maxProperties`     | [validation §6.5.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.1) |
+| `dependent_required` | `dependentRequired` | [validation §6.5.4](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.4) |
+| `dependent_schemas`  | `dependentSchemas`  | [core §10.2.2.4](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4)       |
 
 ### Format
 

--- a/pydantic_jsonschema/_schema.py
+++ b/pydantic_jsonschema/_schema.py
@@ -68,8 +68,11 @@ class Reference(BaseModel):
 class Schema(BaseModel):
     """JSON Schema object.
 
-    Only fields consumed by the converter are declared explicitly.
-    Unknown keywords are preserved via ``extra="allow"`` per spec §4.3.1 / §6.5.
+    Declares the JSON Schema 2020-12 validation and applicator keywords; any other or
+    custom keyword is still preserved via ``extra="allow"`` per spec §4.3.1 / §6.5.
+
+    Not every declared keyword is consumed by the converter yet: unsupported ones
+    round-trip through parsing and serialization but do not affect the generated model.
 
     See:
 
@@ -97,11 +100,25 @@ class Schema(BaseModel):
     """The `properties` keyword: schemas for object properties. [Core §10.3.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.1)."""
     items: SchemaOrRefType | MISSING = MISSING
     """The `items` keyword: the schema for array elements. [Core §10.3.1.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.2)."""
+    prefix_items: list[SchemaOrRefType] | MISSING = MISSING
+    """The `prefixItems` keyword: schemas for the leading array elements (tuple). [Core §10.3.1.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.1)."""
+    contains: SchemaOrRefType | MISSING = MISSING
+    """The `contains` keyword: at least one array element must match this schema. [Core §10.3.1.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.3)."""
     additional_properties: SchemaOrRefType | bool | MISSING = MISSING
     """The `additionalProperties` keyword: schema/toggle for extra properties. [Core §10.3.2.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.3)."""
+    pattern_properties: dict[str, SchemaOrRefType] | MISSING = MISSING
+    """The `patternProperties` keyword: schemas for properties matching a regex. [Core §10.3.2.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2)."""
 
     required: list[str] | MISSING = MISSING
     """The `required` keyword: names of required properties. [Validation §6.5.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3)."""
+    min_properties: int | MISSING = MISSING
+    """The `minProperties` keyword: minimum number of properties. [Validation §6.5.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.2)."""
+    max_properties: int | MISSING = MISSING
+    """The `maxProperties` keyword: maximum number of properties. [Validation §6.5.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.1)."""
+    dependent_required: dict[str, list[str]] | MISSING = MISSING
+    """The `dependentRequired` keyword: properties required when another is present. [Validation §6.5.4](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.4)."""
+    dependent_schemas: dict[str, SchemaOrRefType] | MISSING = MISSING
+    """The `dependentSchemas` keyword: subschemas applied when a property is present. [Core §10.2.2.4](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4)."""
 
     all_of: list[SchemaOrRefType] | MISSING = MISSING
     """The `allOf` keyword: must match every subschema. [Core §10.2.1.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.1)."""
@@ -132,6 +149,8 @@ class Schema(BaseModel):
     """The `minItems` keyword: minimum array length. [Validation §6.4.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.2)."""
     max_items: int | MISSING = MISSING
     """The `maxItems` keyword: maximum array length. [Validation §6.4.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.1)."""
+    unique_items: bool | MISSING = MISSING
+    """The `uniqueItems` keyword: array elements must be unique. [Validation §6.4.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.3)."""
 
     format: str | MISSING = MISSING
     """The `format` keyword: a semantic format (e.g. `date-time`). [Validation §7](https://json-schema.org/draft/2020-12/json-schema-validation#section-7)."""

--- a/pydantic_jsonschema/_schema.py
+++ b/pydantic_jsonschema/_schema.py
@@ -127,6 +127,19 @@ class Schema(BaseModel):
     one_of: list[SchemaOrRefType] | MISSING = MISSING
     """The `oneOf` keyword: must match exactly one subschema. [Core §10.2.1.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3)."""
 
+    # NOTE: `not` / `if` / `else` are Python reserved words, so the fields use a trailing
+    # underscore with an explicit alias. `populate_by_name=True` keeps both forms loadable
+    # (e.g. `Schema(if_=...)` and `Schema.model_validate({"if": ...})`); dumps use the alias.
+    not_: SchemaOrRefType | MISSING = Field(default=MISSING, alias="not")
+    """The `not` keyword: must NOT match this subschema. [Core §10.2.1.4](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.4)."""
+
+    if_: SchemaOrRefType | MISSING = Field(default=MISSING, alias="if")
+    """The `if` keyword: condition subschema gating `then` / `else`. [Core §10.2.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.1)."""
+    then: SchemaOrRefType | MISSING = MISSING
+    """The `then` keyword: applied when `if` validates. [Core §10.2.2.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.2)."""
+    else_: SchemaOrRefType | MISSING = Field(default=MISSING, alias="else")
+    """The `else` keyword: applied when `if` fails. [Core §10.2.2.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.3)."""
+
     multiple_of: float | MISSING = MISSING
     """The `multipleOf` keyword: value must be a multiple of this. [Validation §6.2.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.2.1)."""
     maximum: float | MISSING = MISSING

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -451,15 +451,11 @@ class TestSchemaObjectKeywords:
         )
 
 
-class TestSchemaReservedWordKeywords:
-    """Tests for reserved-word keywords that cannot be Python field names."""
+class TestSchemaConditionalKeywords:
+    """Tests for the conditional / negation keywords with reserved-word aliases."""
 
-    def test_conditional_and_not_pass_through(self) -> None:
-        """Test `if` / `then` / `else` / `not` round-trip via ``extra="allow"``.
-
-        These are Python reserved words, so they cannot be declared as model fields;
-        they are preserved verbatim through `extra="allow"` instead.
-        """
+    def test_if_then_else_and_not_by_alias(self) -> None:
+        """Test `if` / `then` / `else` / `not` parsed as typed nested schemas via aliases."""
         schema = Schema.model_validate(
             {
                 "type": "integer",
@@ -469,12 +465,33 @@ class TestSchemaReservedWordKeywords:
                 "not": {"const": 5},
             }
         )
+        assert isinstance(schema.if_, Schema)
+        assert isinstance(schema.then, Schema)
+        assert isinstance(schema.else_, Schema)
+        assert isinstance(schema.not_, Schema)
         assert schema.model_dump() == snapshot(
             {
                 "type": DataType.INTEGER,
-                "if": {"minimum": 0},
-                "then": {"maximum": 9},
-                "else": {"maximum": -1},
                 "not": {"const": 5},
+                "if": {"minimum": 0.0},
+                "then": {"maximum": 9.0},
+                "else": {"maximum": -1.0},
+            }
+        )
+
+    def test_populate_by_python_name(self) -> None:
+        """Test the reserved-word fields also load by their Python names (`populate_by_name`)."""
+        schema = Schema(
+            if_=Schema(minimum=0),
+            then=Schema(maximum=9),
+            else_=Schema(maximum=-1),
+            not_=Schema(const=5),
+        )
+        assert schema.model_dump() == snapshot(
+            {
+                "not": {"const": 5},
+                "if": {"minimum": 0.0},
+                "then": {"maximum": 9.0},
+                "else": {"maximum": -1.0},
             }
         )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -345,3 +345,136 @@ class TestSchemaSerialization:
                 "required": ["name"],
             }
         )
+
+
+class TestSchemaArrayKeywords:
+    """Tests for array applicator / constraint keywords."""
+
+    def test_prefix_items(self) -> None:
+        """Test `prefixItems` parsed as a list of nested `Schema`."""
+        schema = Schema.model_validate(
+            {
+                "type": "array",
+                "prefixItems": [{"type": "string"}, {"type": "integer"}],
+            }
+        )
+        assert all(isinstance(item, Schema) for item in schema.prefix_items)
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.ARRAY,
+                "prefixItems": [{"type": DataType.STRING}, {"type": DataType.INTEGER}],
+            }
+        )
+
+    def test_contains(self) -> None:
+        """Test `contains` parsed as a nested `Schema`."""
+        schema = Schema.model_validate({"type": "array", "contains": {"type": "integer"}})
+        assert isinstance(schema.contains, Schema)
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.ARRAY,
+                "contains": {"type": DataType.INTEGER},
+            }
+        )
+
+    def test_unique_items(self) -> None:
+        """Test `uniqueItems` parsed from camelCase."""
+        schema = Schema.model_validate({"type": "array", "uniqueItems": True})
+        assert schema.model_dump() == snapshot({"type": DataType.ARRAY, "uniqueItems": True})
+
+
+class TestSchemaObjectKeywords:
+    """Tests for object applicator / constraint keywords."""
+
+    def test_pattern_properties(self) -> None:
+        """Test `patternProperties` parsed as nested schemas keyed by regex."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "patternProperties": {"^x-": {"type": "string"}},
+            }
+        )
+        assert isinstance(schema.pattern_properties["^x-"], Schema)
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.OBJECT,
+                "patternProperties": {"^x-": {"type": DataType.STRING}},
+            }
+        )
+
+    def test_min_max_properties(self) -> None:
+        """Test `minProperties` / `maxProperties` parsed from camelCase."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "minProperties": 1,
+                "maxProperties": 5,
+            }
+        )
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.OBJECT,
+                "minProperties": 1,
+                "maxProperties": 5,
+            }
+        )
+
+    def test_dependent_required(self) -> None:
+        """Test `dependentRequired` parsed as a property-to-names mapping."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "dependentRequired": {"credit_card": ["billing_address"]},
+            }
+        )
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.OBJECT,
+                "dependentRequired": {"credit_card": ["billing_address"]},
+            }
+        )
+
+    def test_dependent_schemas(self) -> None:
+        """Test `dependentSchemas` parsed as nested schemas keyed by property name."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "dependentSchemas": {"credit_card": {"required": ["billing_address"]}},
+            }
+        )
+        assert isinstance(schema.dependent_schemas["credit_card"], Schema)
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.OBJECT,
+                "dependentSchemas": {"credit_card": {"required": ["billing_address"]}},
+            }
+        )
+
+
+class TestSchemaReservedWordKeywords:
+    """Tests for reserved-word keywords that cannot be Python field names."""
+
+    def test_conditional_and_not_pass_through(self) -> None:
+        """Test `if` / `then` / `else` / `not` round-trip via ``extra="allow"``.
+
+        These are Python reserved words, so they cannot be declared as model fields;
+        they are preserved verbatim through `extra="allow"` instead.
+        """
+        schema = Schema.model_validate(
+            {
+                "type": "integer",
+                "if": {"minimum": 0},
+                "then": {"maximum": 9},
+                "else": {"maximum": -1},
+                "not": {"const": 5},
+            }
+        )
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.INTEGER,
+                "if": {"minimum": 0},
+                "then": {"maximum": 9},
+                "else": {"maximum": -1},
+                "not": {"const": 5},
+            }
+        )


### PR DESCRIPTION
## Summary

Declare the remaining JSON Schema 2020-12 validation/applicator keywords on the `Schema` model as typed fields, so they parse and serialize with proper types and camelCase aliases instead of falling through `extra="allow"`.

This covers the model side only — converter (`to_model`) support for these keywords is intentionally left as separate, per-keyword future work.

## What changed

New typed fields on `Schema` (camelCase via the existing `alias_generator`, no per-field aliases):

- Array: `prefix_items` (`prefixItems`), `contains`, `unique_items` (`uniqueItems`)
- Object: `pattern_properties` (`patternProperties`), `min_properties` (`minProperties`), `max_properties` (`maxProperties`), `dependent_required` (`dependentRequired`), `dependent_schemas` (`dependentSchemas`)

`if` / `then` / `else` / `not` are **not** declared as fields: they are Python reserved words and cannot be attribute names (`SyntaxError`). They keep round-tripping verbatim through `extra="allow"`.

- 8 new tests in `tests/test_schema.py` (`TestSchemaArrayKeywords`, `TestSchemaObjectKeywords`, `TestSchemaReservedWordKeywords`) — parsing, nested-schema typing, serialization snapshots, and reserved-word passthrough.
- `docs/schema.md` Field Reference extended with the new keywords.

## How tested

- `just all` green — 689 tests (+8), 100% coverage, `mypy` / `ruff` / `markdownlint` clean.