### PR TITLE
feat(converters): enforce `uniqueItems` on array conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -108,18 +108,19 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `minLength`, `maxLength`                     | string length constraints                   | `min_length`, `max_length`          |
 | `pattern`                                    | string regex constraint                     | `pattern`                           |
 | `minItems`, `maxItems`                       | list length constraints                     | `min_length`, `max_length`          |
+| `uniqueItems: true`                          | array uniqueness constraint                 | `AfterValidator` rejecting dupes    |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
 
 ## Unsupported Keywords
 
-Unknown keywords are preserved on the `Schema` model (`extra="allow"`) but do not affect the
-generated model's validation:
+These keywords are parsed and preserved on the `Schema` model (declared fields, or `extra="allow"`
+for custom keywords) but do not yet affect the generated model's validation:
 
 | Keyword group | Ignored keywords                                                                                                 |
 |---------------|------------------------------------------------------------------------------------------------------------------|
 | composition   | `not`, `if` / `then` / `else`                                                                                    |
-| arrays        | `prefixItems`, `contains`, `uniqueItems`                                                                         |
+| arrays        | `prefixItems`, `contains`                                                                                        |
 | objects       | `patternProperties`, `propertyNames`, `minProperties`, `maxProperties`, `dependentRequired`, `dependentSchemas`  |
 
 ## Known Limitations

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -1016,16 +1016,7 @@ class SchemaConverter:
         :returns: Type annotation (`Any` when `type` is absent).
         """
         if schema.type == DataType.ARRAY:
-            item_type: type | ForwardRef = Any
-            if schema.items is not MISSING:
-                with self._track_path("items"):
-                    item_type = self._schema_to_annotation(schema.items)
-            list_annotation = list[item_type]  # type: ignore[valid-type]
-            # `uniqueItems: false` (and absent) imposes no constraint; only `true` enforces.
-            if schema.unique_items is True:
-                unique_annotation = Annotated[list_annotation, AfterValidator(_ensure_unique_items)]
-                return cast("type", unique_annotation)
-            return cast("type", list_annotation)
+            return self._array_annotation(schema)
 
         if schema.type == DataType.OBJECT:
             return self._object_annotation(schema)
@@ -1038,6 +1029,29 @@ class SchemaConverter:
             return cast("type", union_annotation)
 
         return Any
+
+    def _array_annotation(
+        self,
+        schema: Schema,
+        /,
+    ) -> type:
+        """Convert an array schema to a `list` annotation, applying array constraints.
+
+        :param schema: Array schema to convert.
+        :returns: `list[...]` annotation, wrapped with `uniqueItems` validation when set.
+        """
+        item_type: type | ForwardRef = Any
+        if schema.items is not MISSING:
+            with self._track_path("items"):
+                item_type = self._schema_to_annotation(schema.items)
+        list_annotation = list[item_type]  # type: ignore[valid-type]
+
+        # `uniqueItems: false` (and absent) imposes no constraint; only `true` enforces.
+        if schema.unique_items is True:
+            unique_annotation = Annotated[list_annotation, AfterValidator(_ensure_unique_items)]
+            return cast("type", unique_annotation)
+
+        return cast("type", list_annotation)
 
     def _object_annotation(
         self,

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -23,7 +23,15 @@ from typing import (
 )
 
 import annotated_types
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, RootModel, create_model
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    RootModel,
+    create_model,
+)
 from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
 
@@ -125,6 +133,33 @@ class _FieldKwargs(TypedDict, total=False):
     min_length: int | None
     max_length: int | None
     pattern: str | None
+
+
+def _ensure_unique_items(value: list[PythonType], /) -> list[PythonType]:
+    """Reject arrays with duplicate items (`uniqueItems: true`, validation §6.4.3).
+
+    Items are compared by Python equality, which matches JSON structural equality for the
+    common scalar / object / array cases. The check is O(n^2) pairwise rather than `set`-based
+    because JSON values can be unhashable (`dict` / `list`).
+
+    NOTE: Python equates `True == 1` and `1 == 1.0`, so e.g. `[true, 1]` is treated as a
+    duplicate even though JSON Schema considers the two values distinct. Acceptable edge.
+
+    Reproduce:
+        to_model(Schema(type="array", unique_items=True)).model_validate([1, 1])
+        # -> ValidationError: Array items must be unique
+
+    :param value: The already-parsed array.
+    :returns: The array unchanged when all items are unique.
+    :raises ValueError: When two items are equal.
+    """
+    seen: list[PythonType] = []
+    for item in value:
+        if item in seen:
+            msg = "Array items must be unique"
+            raise ValueError(msg)
+        seen.append(item)
+    return value
 
 
 class SchemaConverter:
@@ -986,6 +1021,10 @@ class SchemaConverter:
                 with self._track_path("items"):
                     item_type = self._schema_to_annotation(schema.items)
             list_annotation = list[item_type]  # type: ignore[valid-type]
+            # `uniqueItems: false` (and absent) imposes no constraint; only `true` enforces.
+            if schema.unique_items is True:
+                unique_annotation = Annotated[list_annotation, AfterValidator(_ensure_unique_items)]
+                return cast("type", unique_annotation)
             return cast("type", list_annotation)
 
         if schema.type == DataType.OBJECT:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1978,6 +1978,7 @@ class TestConstraints:
 
         with pytest.raises(ValidationError) as exc_info:
             model(tags=["dup", "dup"])
+
         assert dump_errors(exc_info.value) == snapshot(
             [
                 {
@@ -2002,6 +2003,7 @@ class TestConstraints:
 
         with pytest.raises(ValidationError) as exc_info:
             model.model_validate([{"a": 1}, {"a": 1}])
+
         assert dump_errors(exc_info.value) == snapshot(
             [
                 {

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1954,7 +1954,7 @@ class TestConstraints:
             model(score=50.3)
 
     def test_unique_items_array(self) -> None:
-        """Test array with uniqueItems constraint."""
+        """Test `uniqueItems` accepts distinct items and rejects duplicates."""
         schema_raw: SchemaRaw = {
             "type": "object",
             "properties": {
@@ -1975,6 +1975,51 @@ class TestConstraints:
                 "tags": ["python", "coding", "dev"],
             }
         )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model(tags=["dup", "dup"])
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("tags",),
+                    "msg": "Value error, Array items must be unique",
+                    "input": ["dup", "dup"],
+                }
+            ]
+        )
+
+    def test_unique_items_unhashable(self) -> None:
+        """Test `uniqueItems` rejects duplicate object items (unhashable, no `set`)."""
+        schema = Schema.model_validate(
+            {"type": "array", "items": {"type": "object"}, "uniqueItems": True}
+        )
+        model = to_model(schema)
+
+        assert model.model_validate([{"a": 1}, {"b": 2}]).model_dump() == snapshot(
+            [{"a": 1}, {"b": 2}]
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate([{"a": 1}, {"a": 1}])
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Array items must be unique",
+                    "input": [{"a": 1}, {"a": 1}],
+                }
+            ]
+        )
+
+    def test_unique_items_false_is_noop(self) -> None:
+        """Test `uniqueItems: false` imposes no constraint."""
+        schema = Schema.model_validate(
+            {"type": "array", "items": {"type": "integer"}, "uniqueItems": False}
+        )
+        model = to_model(schema)
+        assert model.model_validate([1, 1, 1]).model_dump() == snapshot([1, 1, 1])
 
 
 class TestAdditionalProperties:


### PR DESCRIPTION
## Summary

Make `to_model` actually enforce `uniqueItems: true` on arrays. Previously the keyword was parsed onto `Schema` but ignored by the converter, so generated models accepted duplicate items.

This is the first slice of converter-side validation for the declared-but-unenforced keywords (Tier 1).

## What changed

- `_ensure_unique_items` helper: rejects duplicate array items. Uses O(n²) `==` comparison rather than a `set`, because JSON values can be unhashable (`dict` / `list`). Documented edge: Python equates `True == 1` / `1 == 1.0`.
- `_type_annotation` (array branch): wraps the `list[...]` annotation in `AfterValidator(_ensure_unique_items)` when `uniqueItems is True`. `false` / absent is a no-op. Applies to both root arrays and array properties.

## How tested

- `test_unique_items_array` extended to assert duplicates are rejected (error snapshot via `dump_errors`).
- New `test_unique_items_unhashable` (duplicate object items) and `test_unique_items_false_is_noop`.
- `just all` green — 692 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.