### PR TITLE
feat(converters): enforce `minProperties`/`maxProperties` on object conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -109,6 +109,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `pattern`                                    | string regex constraint                     | `pattern`                           |
 | `minItems`, `maxItems`                       | list length constraints                     | `min_length`, `max_length`          |
 | `uniqueItems: true`                          | array uniqueness constraint                 | `AfterValidator` rejecting dupes    |
+| `minProperties`, `maxProperties`             | object property-count constraints           | `before` validator / `dict` length  |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
 
@@ -121,7 +122,7 @@ for custom keywords) but do not yet affect the generated model's validation:
 |---------------|------------------------------------------------------------------------------------------------------------------|
 | composition   | `not`, `if` / `then` / `else`                                                                                    |
 | arrays        | `prefixItems`, `contains`                                                                                        |
-| objects       | `patternProperties`, `propertyNames`, `minProperties`, `maxProperties`, `dependentRequired`, `dependentSchemas`  |
+| objects       | `patternProperties`, `propertyNames`, `dependentRequired`, `dependentSchemas`                                    |
 
 ## Known Limitations
 

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -163,21 +163,59 @@ def _ensure_unique_items(value: list[PythonType], /) -> list[PythonType]:
     return value
 
 
-def _build_property_count_validator(
-    *,
-    min_properties: int | None,
-    max_properties: int | None,
-) -> PythonType:
-    """Build a `before` model validator enforcing `minProperties` / `maxProperties`.
+def _annotate(annotation: AnnotationType, metadata: list[PythonType], /) -> type:
+    """Wrap an annotation with `Annotated` metadata (validators / constraints).
+
+    :param annotation: Base annotation (e.g. `list[int]`, `dict[str, int]`).
+    :param metadata: `Annotated` metadata to attach (empty -> annotation returned as-is).
+    :returns: The annotation, wrapped only when there is metadata to attach.
+    """
+    if not metadata:
+        return cast("type", annotation)
+    return cast("type", Annotated[(annotation, *metadata)])
+
+
+def _array_metadata(schema: Schema, /) -> list[PythonType]:
+    """`Annotated` metadata for array constraint keywords.
+
+    :param schema: Array schema.
+    :returns: Metadata for the array's `list[...]` annotation (add a keyword's check here).
+    """
+    metadata: list[PythonType] = []
+    # `uniqueItems: false` (and absent) imposes no constraint; only `true` enforces.
+    if schema.unique_items is True:
+        metadata.append(AfterValidator(_ensure_unique_items))
+    return metadata
+
+
+def _object_dict_metadata(schema: Schema, /) -> list[PythonType]:
+    """`Annotated` metadata for object keywords on a `dict` mapping (no declared properties).
+
+    :param schema: Object schema mapped to `dict[str, ...]`.
+    :returns: Length metadata for `minProperties` / `maxProperties` (add a keyword's check here).
+    """
+    metadata: list[PythonType] = []
+    if schema.min_properties is not MISSING:
+        metadata.append(annotated_types.MinLen(schema.min_properties))
+    if schema.max_properties is not MISSING:
+        metadata.append(annotated_types.MaxLen(schema.max_properties))
+    return metadata
+
+
+def _property_count_validator(schema: Schema, /) -> PythonType | None:
+    """`minProperties` / `maxProperties`: bound the number of properties of an object model.
 
     Counts the raw input mapping's keys before field parsing. That key count is exactly the
     JSON Schema "number of properties" (declared fields plus `extra` keys) and is unambiguous
     regardless of which keys map to declared fields (validation §6.5.1 / §6.5.2).
 
-    :param min_properties: Lower bound on the property count, or `None`.
-    :param max_properties: Upper bound on the property count, or `None`.
-    :returns: A `model_validator(mode="before")` enforcing the bounds.
+    :param schema: Object schema.
+    :returns: A `model_validator(mode="before")`, or `None` when neither bound is set.
     """
+    min_properties = schema.min_properties if schema.min_properties is not MISSING else None
+    max_properties = schema.max_properties if schema.max_properties is not MISSING else None
+    if min_properties is None and max_properties is None:
+        return None
 
     def _check(data: PythonType) -> PythonType:
         # Non-mapping input is left for the normal type validation to reject.
@@ -195,6 +233,36 @@ def _build_property_count_validator(
         return data
 
     return model_validator(mode="before")(_check)
+
+
+class _ObjectValidatorBuilder(Protocol):
+    """Builds a `model_validator` for one object keyword, or `None` when the schema omits it."""
+
+    # Each builder is a module-level function; its name is the `__validators__` key.
+    __name__: str
+
+    def __call__(self, schema: Schema, /) -> PythonType | None:
+        """Return the keyword's validator for `schema`, or `None` to skip it."""
+        ...
+
+
+# Registry of object-model validators. To support a new object-level keyword, write a
+# builder `(schema) -> validator | None` and add it here — no other wiring is needed.
+_OBJECT_MODEL_VALIDATORS: Final[tuple[_ObjectValidatorBuilder, ...]] = (_property_count_validator,)
+
+
+def _build_object_validators(schema: Schema, /) -> dict[str, PythonType]:
+    """Collect the `model_validator`s for an object model from the keyword registry.
+
+    :param schema: Object schema to read keywords from.
+    :returns: A `create_model(__validators__=...)` mapping (empty when no keyword applies).
+    """
+    validators: dict[str, PythonType] = {}
+    for builder in _OBJECT_MODEL_VALIDATORS:
+        validator = builder(schema)
+        if validator is not None:
+            validators[builder.__name__] = validator
+    return validators
 
 
 class SchemaConverter:
@@ -406,7 +474,7 @@ class SchemaConverter:
         """
         fields = self._build_fields(schema)
         model_config = self._build_model_config(schema)
-        validators = self._build_property_count_validators(schema)
+        validators = _build_object_validators(schema)
 
         # For some reason, `create_model` "accepts" `fields` values as `tuple[str, Any]`,
         # when in reality it accepts `tuple[type, FieldInfo]`
@@ -420,28 +488,6 @@ class SchemaConverter:
             **fields,
         )
         return cast("type[BaseModel]", created_model)
-
-    @staticmethod
-    def _build_property_count_validators(
-        schema: Schema,
-        /,
-    ) -> dict[str, PythonType]:
-        """Build the `minProperties` / `maxProperties` validators for an object model.
-
-        :param schema: Object schema to read the bounds from.
-        :returns: A `__validators__` mapping (empty when neither bound is set).
-        """
-        min_properties = schema.min_properties if schema.min_properties is not MISSING else None
-        max_properties = schema.max_properties if schema.max_properties is not MISSING else None
-        if min_properties is None and max_properties is None:
-            return {}
-
-        return {
-            "_validate_property_count": _build_property_count_validator(
-                min_properties=min_properties,
-                max_properties=max_properties,
-            ),
-        }
 
     def _check_alias_target(
         self,
@@ -1097,20 +1143,14 @@ class SchemaConverter:
         """Convert an array schema to a `list` annotation, applying array constraints.
 
         :param schema: Array schema to convert.
-        :returns: `list[...]` annotation, wrapped with `uniqueItems` validation when set.
+        :returns: `list[...]` annotation, wrapped with array constraint metadata when set.
         """
         item_type: type | ForwardRef = Any
         if schema.items is not MISSING:
             with self._track_path("items"):
                 item_type = self._schema_to_annotation(schema.items)
         list_annotation = list[item_type]  # type: ignore[valid-type]
-
-        # `uniqueItems: false` (and absent) imposes no constraint; only `true` enforces.
-        if schema.unique_items is True:
-            unique_annotation = Annotated[list_annotation, AfterValidator(_ensure_unique_items)]
-            return cast("type", unique_annotation)
-
-        return cast("type", list_annotation)
+        return _annotate(list_annotation, _array_metadata(schema))
 
     def _object_annotation(
         self,
@@ -1132,38 +1172,9 @@ class SchemaConverter:
             with self._track_path("additionalProperties"):
                 value_annotation = self._schema_to_annotation(schema.additional_properties)
                 dict_annotation = dict[str, value_annotation]  # type: ignore[valid-type]
-                return self._apply_property_count(dict_annotation, schema)
+                return _annotate(dict_annotation, _object_dict_metadata(schema))
 
-        return self._apply_property_count(dict[str, Any], schema)
-
-    @staticmethod
-    def _apply_property_count(
-        annotation: AnnotationType,
-        schema: Schema,
-        /,
-    ) -> type:
-        """Wrap a `dict` object annotation with `minProperties` / `maxProperties` length bounds.
-
-        Object schemas without declared `properties` map to `dict[str, ...]`; their property
-        count is the `dict` length, so the bounds become `annotated_types` length metadata.
-        Object schemas *with* properties become models instead and are bounded by
-        `_build_property_count_validators`.
-
-        :param annotation: The `dict[str, ...]` annotation.
-        :param schema: Schema carrying optional `min_properties` / `max_properties`.
-        :returns: The annotation, wrapped with length metadata when a bound is set.
-        """
-        constraints: list[PythonType] = []
-        if schema.min_properties is not MISSING:
-            constraints.append(annotated_types.MinLen(schema.min_properties))
-        if schema.max_properties is not MISSING:
-            constraints.append(annotated_types.MaxLen(schema.max_properties))
-
-        if not constraints:
-            return cast("type", annotation)
-
-        constrained = Annotated[(annotation, *constraints)]
-        return cast("type", constrained)
+        return _annotate(dict[str, Any], _object_dict_metadata(schema))
 
     @staticmethod
     def _get_field_default(

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -31,6 +31,7 @@ from pydantic import (
     Field,
     RootModel,
     create_model,
+    model_validator,
 )
 from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
@@ -160,6 +161,37 @@ def _ensure_unique_items(value: list[PythonType], /) -> list[PythonType]:
             raise ValueError(msg)
         seen.append(item)
     return value
+
+
+def _build_property_count_validator(
+    *,
+    min_properties: int | None,
+    max_properties: int | None,
+) -> PythonType:
+    """Build a `before` model validator enforcing `minProperties` / `maxProperties`.
+
+    Counts the raw input mapping's keys before field parsing. That key count is exactly the
+    JSON Schema "number of properties" (declared fields plus `extra` keys) and is unambiguous
+    regardless of which keys map to declared fields (validation §6.5.1 / §6.5.2).
+
+    :param min_properties: Lower bound on the property count, or `None`.
+    :param max_properties: Upper bound on the property count, or `None`.
+    :returns: A `model_validator(mode="before")` enforcing the bounds.
+    """
+
+    def _check(data: PythonType) -> PythonType:
+        # Non-mapping input is left for the normal type validation to reject.
+        if isinstance(data, dict):
+            count: int = len(data)
+            if min_properties is not None and count < min_properties:
+                msg = f"Object must have at least {min_properties} properties"
+                raise ValueError(msg)
+            if max_properties is not None and count > max_properties:
+                msg = f"Object must have at most {max_properties} properties"
+                raise ValueError(msg)
+        return data
+
+    return model_validator(mode="before")(_check)
 
 
 class SchemaConverter:
@@ -371,6 +403,7 @@ class SchemaConverter:
         """
         fields = self._build_fields(schema)
         model_config = self._build_model_config(schema)
+        validators = self._build_property_count_validators(schema)
 
         # For some reason, `create_model` "accepts" `fields` values as `tuple[str, Any]`,
         # when in reality it accepts `tuple[type, FieldInfo]`
@@ -380,9 +413,32 @@ class SchemaConverter:
             __doc__=schema.description if schema.description is not MISSING else None,
             __base__=base_classes,
             __module__=__name__,
+            __validators__=validators,
             **fields,
         )
         return cast("type[BaseModel]", created_model)
+
+    @staticmethod
+    def _build_property_count_validators(
+        schema: Schema,
+        /,
+    ) -> dict[str, PythonType]:
+        """Build the `minProperties` / `maxProperties` validators for an object model.
+
+        :param schema: Object schema to read the bounds from.
+        :returns: A `__validators__` mapping (empty when neither bound is set).
+        """
+        min_properties = schema.min_properties if schema.min_properties is not MISSING else None
+        max_properties = schema.max_properties if schema.max_properties is not MISSING else None
+        if min_properties is None and max_properties is None:
+            return {}
+
+        return {
+            "_validate_property_count": _build_property_count_validator(
+                min_properties=min_properties,
+                max_properties=max_properties,
+            ),
+        }
 
     def _check_alias_target(
         self,
@@ -1073,9 +1129,38 @@ class SchemaConverter:
             with self._track_path("additionalProperties"):
                 value_annotation = self._schema_to_annotation(schema.additional_properties)
                 dict_annotation = dict[str, value_annotation]  # type: ignore[valid-type]
-                return cast("type", dict_annotation)
+                return self._apply_property_count(dict_annotation, schema)
 
-        return dict[str, Any]
+        return self._apply_property_count(dict[str, Any], schema)
+
+    @staticmethod
+    def _apply_property_count(
+        annotation: AnnotationType,
+        schema: Schema,
+        /,
+    ) -> type:
+        """Wrap a `dict` object annotation with `minProperties` / `maxProperties` length bounds.
+
+        Object schemas without declared `properties` map to `dict[str, ...]`; their property
+        count is the `dict` length, so the bounds become `annotated_types` length metadata.
+        Object schemas *with* properties become models instead and are bounded by
+        `_build_property_count_validators`.
+
+        :param annotation: The `dict[str, ...]` annotation.
+        :param schema: Schema carrying optional `min_properties` / `max_properties`.
+        :returns: The annotation, wrapped with length metadata when a bound is set.
+        """
+        constraints: list[PythonType] = []
+        if schema.min_properties is not MISSING:
+            constraints.append(annotated_types.MinLen(schema.min_properties))
+        if schema.max_properties is not MISSING:
+            constraints.append(annotated_types.MaxLen(schema.max_properties))
+
+        if not constraints:
+            return cast("type", annotation)
+
+        constrained = Annotated[(annotation, *constraints)]
+        return cast("type", constrained)
 
     @staticmethod
     def _get_field_default(

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -181,14 +181,17 @@ def _build_property_count_validator(
 
     def _check(data: PythonType) -> PythonType:
         # Non-mapping input is left for the normal type validation to reject.
-        if isinstance(data, dict):
-            count: int = len(data)
-            if min_properties is not None and count < min_properties:
-                msg = f"Object must have at least {min_properties} properties"
-                raise ValueError(msg)
-            if max_properties is not None and count > max_properties:
-                msg = f"Object must have at most {max_properties} properties"
-                raise ValueError(msg)
+        if not isinstance(data, dict):
+            return data
+
+        count: int = len(data)
+        if min_properties is not None and count < min_properties:
+            msg = f"Object must have at least `{min_properties}` properties"
+            raise ValueError(msg)
+        if max_properties is not None and count > max_properties:
+            msg = f"Object must have at most `{max_properties}` properties"
+            raise ValueError(msg)
+
         return data
 
     return model_validator(mode="before")(_check)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2024,6 +2024,110 @@ class TestConstraints:
         assert model.model_validate([1, 1, 1]).model_dump() == snapshot([1, 1, 1])
 
 
+class TestPropertyCount:
+    """Tests for `minProperties` / `maxProperties` enforcement."""
+
+    def test_min_properties_object(self) -> None:
+        """Test `minProperties` on an object with declared properties."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+                "minProperties": 2,
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"a": 1, "b": 2}).model_dump() == snapshot({"a": 1, "b": 2})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"a": 1})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Object must have at least 2 properties",
+                    "input": {"a": 1},
+                }
+            ]
+        )
+
+        # Non-mapping input passes through the count validator and is rejected by type validation.
+        with pytest.raises(ValidationError):
+            model.model_validate("not a mapping")
+
+    def test_max_properties_counts_extra_keys(self) -> None:
+        """Test `maxProperties` counts `extra` keys, not only declared fields."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "integer"}},
+                "maxProperties": 1,
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"a": 1}).model_dump() == snapshot({"a": 1})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"a": 1, "extra": 2})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Object must have at most 1 properties",
+                    "input": {"a": 1, "extra": 2},
+                }
+            ]
+        )
+
+    def test_property_count_dict_root(self) -> None:
+        """Test `minProperties` / `maxProperties` on a dict-root object (no declared properties)."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "additionalProperties": {"type": "integer"},
+                "minProperties": 1,
+                "maxProperties": 2,
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"a": 1, "b": 2}).model_dump() == snapshot({"a": 1, "b": 2})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "too_short",
+                    "loc": (),
+                    "msg": "Dictionary should have at least 1 item after validation, not 0",
+                    "input": {},
+                }
+            ]
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"a": 1, "b": 2, "c": 3})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "too_long",
+                    "loc": (),
+                    "msg": "Dictionary should have at most 2 items after validation, not 3",
+                    "input": {"a": 1, "b": 2, "c": 3},
+                }
+            ]
+        )
+
+
 class TestAdditionalProperties:
     """Tests for `additionalProperties` handling."""
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2048,7 +2048,7 @@ class TestPropertyCount:
                 {
                     "type": "value_error",
                     "loc": (),
-                    "msg": "Value error, Object must have at least 2 properties",
+                    "msg": "Value error, Object must have at least `2` properties",
                     "input": {"a": 1},
                 }
             ]
@@ -2079,7 +2079,7 @@ class TestPropertyCount:
                 {
                     "type": "value_error",
                     "loc": (),
-                    "msg": "Value error, Object must have at most 1 properties",
+                    "msg": "Value error, Object must have at most `1` properties",
                     "input": {"a": 1, "extra": 2},
                 }
             ]


### PR DESCRIPTION
## Summary

Make `to_model` enforce `minProperties` / `maxProperties`. Previously both were parsed onto `Schema` but ignored, so generated models did not constrain the object property count. Tier 1 of the converter-validation work (follows `uniqueItems`, #12).

## What changed

- `_build_property_count_validator`: a `model_validator(mode="before")` that counts the raw input mapping keys. That key count is exactly the JSON Schema "number of properties" (declared fields + `extra` keys), unambiguous regardless of which keys map to declared fields.
- `_create_object_model`: attaches the validator via `create_model(__validators__=...)` when a bound is set.
- `_apply_property_count`: object schemas without declared `properties` map to `dict[str, ...]`, so their bounds become `annotated_types.MinLen` / `MaxLen` (native `dict`-length validation). Wired into both `_object_annotation` dict branches (dict-root and dict-field).

## How tested

New `TestPropertyCount`:
- `minProperties` on an object with declared properties (valid + rejected + non-mapping passthrough);
- `maxProperties` counting `extra` keys;
- dict-root object enforcing both bounds (native `too_short` / `too_long`).

`just all` green — 695 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.