### PR TITLE
feat(converters): enforce `contains`/`minContains`/`maxContains` on array conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -109,6 +109,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `pattern`                                    | string regex constraint                     | `pattern`                           |
 | `minItems`, `maxItems`                       | list length constraints                     | `min_length`, `max_length`          |
 | `uniqueItems: true`                          | array uniqueness constraint                 | `AfterValidator` rejecting dupes    |
+| `contains`, `minContains`, `maxContains`     | array match-count constraint                | `Contains` validator                |
 | `minProperties`, `maxProperties`             | object property-count constraints           | `before` validator / `dict` length  |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
@@ -121,7 +122,7 @@ for custom keywords) but do not yet affect the generated model's validation:
 | Keyword group | Ignored keywords                                                                                                 |
 |---------------|------------------------------------------------------------------------------------------------------------------|
 | composition   | `not`, `if` / `then` / `else`                                                                                    |
-| arrays        | `prefixItems`, `contains`                                                                                        |
+| arrays        | `prefixItems`                                                                                                    |
 | objects       | `patternProperties`, `propertyNames`, `dependentRequired`, `dependentSchemas`                                    |
 
 ## Known Limitations

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -238,6 +238,8 @@ Some declared keywords round-trip through parsing and serialization but are not 
 | `min_items`    | `minItems`    | [validation §6.4.2](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.2) |
 | `max_items`    | `maxItems`    | [validation §6.4.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.1) |
 | `unique_items` | `uniqueItems` | [validation §6.4.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.3) |
+| `max_contains` | `maxContains` | [validation §6.4.4](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.4) |
+| `min_contains` | `minContains` | [validation §6.4.5](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.5) |
 
 ### Object constraints
 

--- a/pydantic_jsonschema/_contains.py
+++ b/pydantic_jsonschema/_contains.py
@@ -1,0 +1,123 @@
+"""JSON Schema `contains` validator.
+
+See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.3
+"""
+
+from typing import Any, ForwardRef
+
+from pydantic import (
+    BaseModel,
+    GetCoreSchemaHandler,
+    TypeAdapter,
+    ValidationError,
+)
+from pydantic_core import CoreSchema, core_schema
+
+__all__ = ["Contains"]
+
+# Type aliases
+type AnnotationType = (
+    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
+)
+
+
+class Contains:
+    """Enforce JSON Schema `contains` / `minContains` / `maxContains` on an array.
+
+    Counts how many array elements validate against the `contains` subschema and requires that
+    count to stay within `[min_contains, max_contains]`. Attached as `Annotated` metadata on the
+    array's `list[...]` annotation; the subschema may be a `ForwardRef` resolved lazily via
+    `bind_namespace` (a `contains` that points at a `$ref`).
+    """
+
+    def __init__(
+        self,
+        *,
+        branch: AnnotationType,
+        min_contains: int,
+        max_contains: int | None,
+    ) -> None:
+        """Initialize with the `contains` subschema annotation and the match-count bounds.
+
+        :param branch: The `contains` subschema annotation (may be a `ForwardRef`).
+        :param min_contains: Minimum number of matching elements (`minContains`, default 1).
+        :param max_contains: Maximum number of matching elements (`maxContains`), or `None`.
+        """
+        self._branch: AnnotationType = branch
+        self._min_contains: int = min_contains
+        self._max_contains: int | None = max_contains
+        self._namespace: dict[str, type[BaseModel]] = {}
+        self._adapter: TypeAdapter[AnnotationType] | None = None
+
+    def bind_namespace(
+        self,
+        namespace: dict[str, type[BaseModel]],
+        /,
+    ) -> None:
+        """Provide the namespace used to resolve a `ForwardRef` subschema.
+
+        :param namespace: Mapping of sanitized reference names to models.
+        """
+        self._namespace = namespace
+
+    def __get_pydantic_core_schema__(
+        self,
+        source_type: AnnotationType,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Wrap the array schema with the match-count check."""
+        return core_schema.no_info_after_validator_function(self._validate, handler(source_type))
+
+    def _get_adapter(self) -> TypeAdapter[AnnotationType]:
+        """Build the `contains` adapter, resolving a `ForwardRef` subschema on first use.
+
+        :returns: A `TypeAdapter` for the `contains` subschema.
+        """
+        # NOTE: Built lazily: at conversion time the subschema may be a `ForwardRef` that only
+        #       becomes resolvable after the whole schema (including `$defs`) is converted and
+        #       the namespace is bound via `bind_namespace`.
+        if self._adapter is None:
+            branch = (
+                self._namespace[self._branch.__forward_arg__]
+                if isinstance(self._branch, ForwardRef)
+                else self._branch
+            )
+            self._adapter = TypeAdapter(branch)
+        return self._adapter
+
+    def _matches(
+        self,
+        item: AnnotationType,
+        /,
+    ) -> bool:
+        """Return whether a single element validates against the `contains` subschema.
+
+        :param item: An array element (already parsed by the array's item type).
+        :returns: `True` when the element validates against `contains`.
+        """
+        try:
+            self._get_adapter().validate_python(item)
+        except ValidationError:
+            return False
+        return True
+
+    def _validate(
+        self,
+        value: AnnotationType,
+    ) -> AnnotationType:
+        """Count matching elements and enforce the `contains` bounds.
+
+        :param value: The validated array.
+        :returns: The array unchanged when the match count is within bounds.
+        :raises ValueError: When too few or too many elements match `contains`.
+        """
+        matched: int = sum(1 for item in value if self._matches(item))
+
+        if matched < self._min_contains:
+            msg = f"Array must contain at least `{self._min_contains}` matches, got `{matched}`"
+            raise ValueError(msg)
+        if self._max_contains is not None and matched > self._max_contains:
+            msg = f"Array must contain at most `{self._max_contains}` matches, got `{matched}`"
+            raise ValueError(msg)
+
+        return value

--- a/pydantic_jsonschema/_schema.py
+++ b/pydantic_jsonschema/_schema.py
@@ -164,6 +164,10 @@ class Schema(BaseModel):
     """The `maxItems` keyword: maximum array length. [Validation §6.4.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.1)."""
     unique_items: bool | MISSING = MISSING
     """The `uniqueItems` keyword: array elements must be unique. [Validation §6.4.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.3)."""
+    max_contains: int | MISSING = MISSING
+    """The `maxContains` keyword: max elements matching `contains`. [Validation §6.4.4](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.4)."""
+    min_contains: int | MISSING = MISSING
+    """The `minContains` keyword: min elements matching `contains`. [Validation §6.4.5](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.4.5)."""
 
     format: str | MISSING = MISSING
     """The `format` keyword: a semantic format (e.g. `date-time`). [Validation §7](https://json-schema.org/draft/2020-12/json-schema-validation#section-7)."""

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -36,6 +36,7 @@ from pydantic import (
 from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
 
+from ._contains import Contains
 from ._one_of import OneOf
 from ._utils import sanitize_identifier
 from .exceptions import SchemaConversionError, SchemaReferenceError
@@ -289,6 +290,7 @@ class SchemaConverter:
         self._models_cache: dict[SchemaHash, type[BaseModel]] = {}
         self._resolution_path: list[str] = []  # Track path for error reporting
         self._one_of_validators: list[OneOf] = []
+        self._contains_validators: list[Contains] = []
 
     @staticmethod
     def _hash_schema(
@@ -339,11 +341,13 @@ class SchemaConverter:
         # Build model using common logic
         model = self._build_model(schema, model_name=model_name)
 
-        # Bind the forward-refs namespace so `OneOf` validators can resolve
+        # Bind the forward-refs namespace so `OneOf` / `Contains` validators can resolve
         # `ForwardRef` branches lazily at validation time.
         namespace = self._get_forward_refs_namespace()
         for one_of_validator in self._one_of_validators:
             one_of_validator.bind_namespace(namespace)
+        for contains_validator in self._contains_validators:
+            contains_validator.bind_namespace(namespace)
 
         return model
 
@@ -1150,7 +1154,41 @@ class SchemaConverter:
             with self._track_path("items"):
                 item_type = self._schema_to_annotation(schema.items)
         list_annotation = list[item_type]  # type: ignore[valid-type]
-        return _annotate(list_annotation, _array_metadata(schema))
+
+        # `uniqueItems` is stateless; `contains` needs the converter (subschema + namespace).
+        metadata: list[PythonType] = _array_metadata(schema)
+        contains = self._build_contains(schema)
+        if contains is not None:
+            metadata.append(contains)
+
+        return _annotate(list_annotation, metadata)
+
+    def _build_contains(
+        self,
+        schema: Schema,
+        /,
+    ) -> Contains | None:
+        """Build the `contains` / `minContains` / `maxContains` validator for an array.
+
+        Registers the validator so its `ForwardRef` subschema (a `contains` pointing at a
+        `$ref`) is namespace-bound after the whole schema is converted.
+
+        :param schema: Array schema.
+        :returns: A `Contains` validator, or `None` when `contains` is absent.
+        """
+        if schema.contains is MISSING:
+            return None
+
+        with self._track_path("contains"):
+            branch = self._schema_to_annotation(schema.contains)
+
+        # `minContains` defaults to 1; `maxContains` is unbounded when absent.
+        min_contains = schema.min_contains if schema.min_contains is not MISSING else 1
+        max_contains = schema.max_contains if schema.max_contains is not MISSING else None
+
+        contains = Contains(branch=branch, min_contains=min_contains, max_contains=max_contains)
+        self._contains_validators.append(contains)
+        return contains
 
     def _object_annotation(
         self,

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2128,6 +2128,120 @@ class TestPropertyCount:
         )
 
 
+class TestContains:
+    """Tests for `contains` / `minContains` / `maxContains` enforcement."""
+
+    def test_contains_at_least_one(self) -> None:
+        """Test `contains` requires at least one matching element by default."""
+        schema = Schema.model_validate({"type": "array", "contains": {"type": "integer"}})
+        model = to_model(schema)
+
+        assert model.model_validate([1, "a"]).model_dump() == snapshot([1, "a"])
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate(["a", "b"])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Array must contain at least `1` matches, got `0`",
+                    "input": ["a", "b"],
+                }
+            ]
+        )
+
+    def test_min_contains(self) -> None:
+        """Test `minContains` raises the required match count."""
+        schema = Schema.model_validate(
+            {"type": "array", "contains": {"type": "integer"}, "minContains": 2}
+        )
+        model = to_model(schema)
+
+        assert model.model_validate([1, 2, "a"]).model_dump() == snapshot([1, 2, "a"])
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate([1, "a"])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Array must contain at least `2` matches, got `1`",
+                    "input": [1, "a"],
+                }
+            ]
+        )
+
+    def test_max_contains(self) -> None:
+        """Test `maxContains` caps the allowed match count."""
+        schema = Schema.model_validate(
+            {"type": "array", "contains": {"type": "integer"}, "maxContains": 1}
+        )
+        model = to_model(schema)
+
+        assert model.model_validate([1, "a"]).model_dump() == snapshot([1, "a"])
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate([1, 2])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Array must contain at most `1` matches, got `2`",
+                    "input": [1, 2],
+                }
+            ]
+        )
+
+    def test_min_contains_zero_allows_no_match(self) -> None:
+        """Test `minContains: 0` makes `contains` satisfiable with zero matches."""
+        schema = Schema.model_validate(
+            {"type": "array", "contains": {"type": "integer"}, "minContains": 0}
+        )
+        model = to_model(schema)
+        assert model.model_validate(["a", "b"]).model_dump() == snapshot(["a", "b"])
+
+    def test_contains_ref(self) -> None:
+        """Test `contains` pointing at a `$ref` (resolved via the bound namespace)."""
+        schema = Schema.model_validate(
+            {
+                "type": "array",
+                "contains": {"$ref": "#/$defs/Point"},
+                "$defs": {
+                    "Point": {
+                        "type": "object",
+                        "properties": {"x": {"type": "integer"}},
+                        "required": ["x"],
+                    },
+                },
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate([{"x": 1}, {"y": 2}]).model_dump() == snapshot(
+            [{"x": 1}, {"y": 2}]
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate([{"y": 2}])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Array must contain at least `1` matches, got `0`",
+                    "input": [{"y": 2}],
+                }
+            ]
+        )
+
+
 class TestAdditionalProperties:
     """Tests for `additionalProperties` handling."""
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -382,6 +382,25 @@ class TestSchemaArrayKeywords:
         schema = Schema.model_validate({"type": "array", "uniqueItems": True})
         assert schema.model_dump() == snapshot({"type": DataType.ARRAY, "uniqueItems": True})
 
+    def test_min_max_contains(self) -> None:
+        """Test `minContains` / `maxContains` parsed from camelCase."""
+        schema = Schema.model_validate(
+            {
+                "type": "array",
+                "contains": {"type": "integer"},
+                "minContains": 1,
+                "maxContains": 3,
+            }
+        )
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.ARRAY,
+                "contains": {"type": DataType.INTEGER},
+                "maxContains": 3,
+                "minContains": 1,
+            }
+        )
+
 
 class TestSchemaObjectKeywords:
     """Tests for object applicator / constraint keywords."""


### PR DESCRIPTION
## Summary

Make `to_model` enforce `contains` (plus `minContains` / `maxContains`). Previously `contains` was parsed onto `Schema` but ignored; `minContains` / `maxContains` were not even declared. Tier 2 of the converter-validation work.

## What changed

- `Schema`: new `min_contains` / `max_contains` fields (validation §6.4.5 / §6.4.4).
- `_contains.py`: new `Contains` validator (mirrors `OneOf`). Attached as `Annotated` metadata on the array `list[...]`, it counts how many elements validate against the `contains` subschema and requires `min_contains <= count <= max_contains`. The subschema may be a `ForwardRef` (a `contains` pointing at a `$ref`), resolved lazily via `bind_namespace` — bound alongside `OneOf` at the end of `convert_schema`.
- `converters.py`: `_build_contains` constructs and registers the validator in `_array_annotation`.

Semantics: `minContains` defaults to `1`, `maxContains` is unbounded when absent; `minContains: 0` makes `contains` satisfiable with zero matches.

## How tested

New `TestContains`: at-least-one, `minContains`, `maxContains`, `minContains: 0`, and a `$ref` subschema. Round-trip test for `min/maxContains` in `test_schema.py`.

`just all` green — 701 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.