### PR TITLE
feat(converters): enforce `dependentRequired` on object conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -111,6 +111,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `uniqueItems: true`                          | array uniqueness constraint                 | `AfterValidator` rejecting dupes    |
 | `contains`, `minContains`, `maxContains`     | array match-count constraint                | `Contains` validator                |
 | `minProperties`, `maxProperties`             | object property-count constraints           | `before` validator / `dict` length  |
+| `dependentRequired`                          | conditionally required properties           | `before` validator                  |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
 
@@ -123,7 +124,7 @@ for custom keywords) but do not yet affect the generated model's validation:
 |---------------|------------------------------------------------------------------------------------------------------------------|
 | composition   | `not`, `if` / `then` / `else`                                                                                    |
 | arrays        | `prefixItems`                                                                                                    |
-| objects       | `patternProperties`, `propertyNames`, `dependentRequired`, `dependentSchemas`                                    |
+| objects       | `patternProperties`, `propertyNames`, `dependentSchemas`                                                         |
 
 ## Known Limitations
 

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -236,6 +236,39 @@ def _property_count_validator(schema: Schema, /) -> PythonType | None:
     return model_validator(mode="before")(_check)
 
 
+def _dependent_required_validator(schema: Schema, /) -> PythonType | None:
+    """`dependentRequired`: when a property is present, the listed properties are required too.
+
+    Checks the raw input mapping keys before field parsing, so it sees every present property
+    (declared fields plus `extra` keys) (validation §6.5.4).
+
+    :param schema: Object schema.
+    :returns: A `model_validator(mode="before")`, or `None` when the keyword is absent.
+    """
+    if schema.dependent_required is MISSING:
+        return None
+
+    dependent_required: dict[str, list[str]] = schema.dependent_required
+
+    def _check(data: PythonType) -> PythonType:
+        # Non-mapping input is left for the normal type validation to reject.
+        if not isinstance(data, dict):
+            return data
+
+        for trigger, required in dependent_required.items():
+            if trigger not in data:
+                continue
+            missing = [name for name in required if name not in data]
+            if missing:
+                missing_list = "`, `".join(missing)
+                msg = f"Property `{trigger}` requires `{missing_list}`"
+                raise ValueError(msg)
+
+        return data
+
+    return model_validator(mode="before")(_check)
+
+
 class _ObjectValidatorBuilder(Protocol):
     """Builds a `model_validator` for one object keyword, or `None` when the schema omits it."""
 
@@ -249,7 +282,10 @@ class _ObjectValidatorBuilder(Protocol):
 
 # Registry of object-model validators. To support a new object-level keyword, write a
 # builder `(schema) -> validator | None` and add it here — no other wiring is needed.
-_OBJECT_MODEL_VALIDATORS: Final[tuple[_ObjectValidatorBuilder, ...]] = (_property_count_validator,)
+_OBJECT_MODEL_VALIDATORS: Final[tuple[_ObjectValidatorBuilder, ...]] = (
+    _property_count_validator,
+    _dependent_required_validator,
+)
 
 
 def _build_object_validators(schema: Schema, /) -> dict[str, PythonType]:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2242,6 +2242,52 @@ class TestContains:
         )
 
 
+class TestDependentRequired:
+    """Tests for `dependentRequired` enforcement."""
+
+    def test_dependent_required(self) -> None:
+        """Test a trigger property makes its dependent properties required."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {
+                    "credit_card": {"type": "integer"},
+                    "billing_address": {"type": "string"},
+                    "cvv": {"type": "integer"},
+                },
+                "dependentRequired": {"credit_card": ["billing_address", "cvv"]},
+            }
+        )
+        model = to_model(schema)
+
+        # Trigger absent -> no dependency applies.
+        assert model.model_validate({}).model_dump() == snapshot({})
+
+        # Trigger present with all dependents.
+        assert model.model_validate(
+            {"credit_card": 1, "billing_address": "x", "cvv": 2}
+        ).model_dump() == snapshot({"credit_card": 1, "billing_address": "x", "cvv": 2})
+
+        # Trigger present, dependents missing.
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"credit_card": 1})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Property `credit_card` requires `billing_address`, `cvv`",
+                    "input": {"credit_card": 1},
+                }
+            ]
+        )
+
+        # Non-mapping input passes through and is rejected by type validation.
+        with pytest.raises(ValidationError):
+            model.model_validate("not a mapping")
+
+
 class TestAdditionalProperties:
     """Tests for `additionalProperties` handling."""
 


### PR DESCRIPTION
## Summary

Make `to_model` enforce `dependentRequired`: when a trigger property is present, its listed dependent properties become required. Previously parsed onto `Schema` but ignored. Tier 1.

## What changed

- `_dependent_required_validator`: a `model_validator(mode="before")` that inspects the raw input keys — so it sees every present property (declared fields plus `extra` keys) — and raises when a trigger is present without its dependents.
- Registered in `_OBJECT_MODEL_VALIDATORS`; no other wiring needed (the extensible registry from #13).

## How tested

New `TestDependentRequired`: trigger absent, trigger with all dependents, trigger with missing dependents (backtick-listed in the error), and non-mapping passthrough.

`just all` green — 702 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.