### PR TITLE
feat(converters): enforce `prefixItems` positional validation

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -110,6 +110,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `minItems`, `maxItems`                       | list length constraints                     | `min_length`, `max_length`          |
 | `uniqueItems: true`                          | array uniqueness constraint                 | `AfterValidator` rejecting dupes    |
 | `contains`, `minContains`, `maxContains`     | array match-count constraint                | `Contains` validator                |
+| `prefixItems`                                | positional (tuple-style) array validation   | `PrefixItems` validator             |
 | `minProperties`, `maxProperties`             | object property-count constraints           | `before` validator / `dict` length  |
 | `dependentRequired`                          | conditionally required properties           | `before` validator                  |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
@@ -123,7 +124,6 @@ for custom keywords) but do not yet affect the generated model's validation:
 | Keyword group | Ignored keywords                                                                                                 |
 |---------------|------------------------------------------------------------------------------------------------------------------|
 | composition   | `not`, `if` / `then` / `else`                                                                                    |
-| arrays        | `prefixItems`                                                                                                    |
 | objects       | `patternProperties`, `propertyNames`, `dependentSchemas`                                                         |
 
 ## Known Limitations

--- a/pydantic_jsonschema/_prefix_items.py
+++ b/pydantic_jsonschema/_prefix_items.py
@@ -1,0 +1,129 @@
+"""JSON Schema `prefixItems` validator.
+
+See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.1
+"""
+
+from collections.abc import Iterable
+from typing import Any, ForwardRef
+
+from pydantic import (
+    BaseModel,
+    GetCoreSchemaHandler,
+    TypeAdapter,
+    ValidationError,
+)
+from pydantic_core import CoreSchema, core_schema
+
+__all__ = ["PrefixItems"]
+
+# Type aliases
+type AnnotationType = (
+    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
+)
+
+
+class PrefixItems:
+    """Enforce JSON Schema `prefixItems`: positional (tuple-style) array validation.
+
+    Element `i` is validated against `prefixItems[i]`; elements past the prefix are validated
+    against the array's `items` schema (the 2020-12 tail), or left unconstrained when `items`
+    is absent. Attached as `Annotated` metadata on a `list[Any]` base; prefix / tail subschemas
+    may be `ForwardRef` (pointing at a `$ref`), resolved lazily via `bind_namespace`.
+    """
+
+    def __init__(
+        self,
+        *,
+        prefixes: Iterable[AnnotationType],
+        tail: AnnotationType | None,
+    ) -> None:
+        """Initialize with the positional subschema annotations and the tail schema.
+
+        :param prefixes: One annotation per `prefixItems` entry (each may be a `ForwardRef`).
+        :param tail: The `items` annotation for elements past the prefix, or `None` when `items`
+            is absent (extra elements are then unconstrained).
+        """
+        self._prefixes: tuple[AnnotationType, ...] = tuple(prefixes)
+        self._tail: AnnotationType | None = tail
+        self._namespace: dict[str, type[BaseModel]] = {}
+        self._prefix_adapters: list[TypeAdapter[AnnotationType]] | None = None
+        self._tail_adapter: TypeAdapter[AnnotationType] | None = None
+
+    def bind_namespace(
+        self,
+        namespace: dict[str, type[BaseModel]],
+        /,
+    ) -> None:
+        """Provide the namespace used to resolve `ForwardRef` subschemas.
+
+        :param namespace: Mapping of sanitized reference names to models.
+        """
+        self._namespace = namespace
+
+    def __get_pydantic_core_schema__(
+        self,
+        source_type: AnnotationType,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Wrap the array schema with positional validation."""
+        return core_schema.no_info_after_validator_function(self._validate, handler(source_type))
+
+    def _resolve(
+        self,
+        branch: AnnotationType,
+        /,
+    ) -> AnnotationType:
+        """Resolve a `ForwardRef` subschema against the bound namespace.
+
+        :param branch: A subschema annotation, possibly a `ForwardRef`.
+        :returns: The resolved model, or the annotation unchanged.
+        """
+        return self._namespace[branch.__forward_arg__] if isinstance(branch, ForwardRef) else branch
+
+    def _build_adapters(self) -> None:
+        """Build the per-position and tail adapters, resolving `ForwardRef`s on first use."""
+        # NOTE: Built lazily: at conversion time subschemas may be `ForwardRef`s that only
+        #       become resolvable after the whole schema (including `$defs`) is converted and
+        #       the namespace is bound via `bind_namespace`.
+        if self._prefix_adapters is None:
+            self._prefix_adapters = [
+                TypeAdapter(self._resolve(branch)) for branch in self._prefixes
+            ]
+            if self._tail is not None:
+                self._tail_adapter = TypeAdapter(self._resolve(self._tail))
+
+    def _validate(
+        self,
+        value: AnnotationType,
+    ) -> AnnotationType:
+        """Validate each element against its positional subschema.
+
+        :param value: The validated array.
+        :returns: The array with each element validated (and coerced) by its position's schema.
+        :raises ValueError: When an element does not match its `prefixItems` / `items` schema.
+        """
+        self._build_adapters()
+        prefix_adapters = self._prefix_adapters or []
+
+        result: list[AnnotationType] = []
+        for index, item in enumerate(value):
+            adapter: TypeAdapter[AnnotationType] | None
+            if index < len(prefix_adapters):
+                adapter = prefix_adapters[index]
+                keyword = "prefixItems"
+            else:
+                adapter = self._tail_adapter
+                keyword = "items"
+
+            # Past the prefix with no `items` schema: the element is unconstrained.
+            if adapter is None:
+                result.append(item)
+                continue
+
+            try:
+                result.append(adapter.validate_python(item))
+            except ValidationError:
+                msg = f"Item at index `{index}` does not match the `{keyword}` schema"
+                raise ValueError(msg) from None
+
+        return result

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -38,6 +38,7 @@ from pydantic.fields import FieldInfo
 
 from ._contains import Contains
 from ._one_of import OneOf
+from ._prefix_items import PrefixItems
 from ._utils import sanitize_identifier
 from .exceptions import SchemaConversionError, SchemaReferenceError
 from .types import DataType, Reference, Schema
@@ -327,6 +328,7 @@ class SchemaConverter:
         self._resolution_path: list[str] = []  # Track path for error reporting
         self._one_of_validators: list[OneOf] = []
         self._contains_validators: list[Contains] = []
+        self._prefix_items_validators: list[PrefixItems] = []
 
     @staticmethod
     def _hash_schema(
@@ -384,6 +386,8 @@ class SchemaConverter:
             one_of_validator.bind_namespace(namespace)
         for contains_validator in self._contains_validators:
             contains_validator.bind_namespace(namespace)
+        for prefix_items_validator in self._prefix_items_validators:
+            prefix_items_validator.bind_namespace(namespace)
 
         return model
 
@@ -1185,19 +1189,56 @@ class SchemaConverter:
         :param schema: Array schema to convert.
         :returns: `list[...]` annotation, wrapped with array constraint metadata when set.
         """
+        # With `prefixItems`, element types are positional, so the base stays `list[Any]` and
+        # `PrefixItems` validates each position (including the `items` tail). Without it, `items`
+        # is the homogeneous element type.
+        prefix_items = self._build_prefix_items(schema)
+
         item_type: type | ForwardRef = Any
-        if schema.items is not MISSING:
+        if prefix_items is None and schema.items is not MISSING:
             with self._track_path("items"):
                 item_type = self._schema_to_annotation(schema.items)
         list_annotation = list[item_type]  # type: ignore[valid-type]
 
-        # `uniqueItems` is stateless; `contains` needs the converter (subschema + namespace).
+        # `uniqueItems` is stateless; `contains` / `prefixItems` need the converter.
         metadata: list[PythonType] = _array_metadata(schema)
+        if prefix_items is not None:
+            metadata.append(prefix_items)
         contains = self._build_contains(schema)
         if contains is not None:
             metadata.append(contains)
 
         return _annotate(list_annotation, metadata)
+
+    def _build_prefix_items(
+        self,
+        schema: Schema,
+        /,
+    ) -> PrefixItems | None:
+        """Build the `prefixItems` positional validator for an array.
+
+        Registers the validator so its `ForwardRef` subschemas (a prefix / tail pointing at a
+        `$ref`) are namespace-bound after the whole schema is converted.
+
+        :param schema: Array schema.
+        :returns: A `PrefixItems` validator, or `None` when `prefixItems` is absent.
+        """
+        if schema.prefix_items is MISSING:
+            return None
+
+        prefixes: list[PythonType] = []
+        for index, sub_schema in enumerate(schema.prefix_items):
+            with self._track_path(f"prefixItems[{index}]"):
+                prefixes.append(self._schema_to_annotation(sub_schema))
+
+        tail: PythonType | None = None
+        if schema.items is not MISSING:
+            with self._track_path("items"):
+                tail = self._schema_to_annotation(schema.items)
+
+        prefix_items = PrefixItems(prefixes=prefixes, tail=tail)
+        self._prefix_items_validators.append(prefix_items)
+        return prefix_items
 
     def _build_contains(
         self,

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2288,6 +2288,107 @@ class TestDependentRequired:
             model.model_validate("not a mapping")
 
 
+class TestPrefixItems:
+    """Tests for `prefixItems` positional validation."""
+
+    def test_prefix_items_with_tail(self) -> None:
+        """Test positional `prefixItems` plus an `items` tail schema."""
+        schema = Schema.model_validate(
+            {
+                "type": "array",
+                "prefixItems": [{"type": "string"}, {"type": "integer"}],
+                "items": {"type": "boolean"},
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate(["a", 1, True, False]).model_dump() == snapshot(
+            ["a", 1, True, False]
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate([1, 1])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Item at index `0` does not match the `prefixItems` schema",
+                    "input": [1, 1],
+                }
+            ]
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate(["a", 1, "x"])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Item at index `2` does not match the `items` schema",
+                    "input": ["a", 1, "x"],
+                }
+            ]
+        )
+
+    def test_prefix_items_extra_unconstrained(self) -> None:
+        """Test elements past the prefix are unconstrained when `items` is absent."""
+        schema = Schema.model_validate({"type": "array", "prefixItems": [{"type": "string"}]})
+        model = to_model(schema)
+
+        assert model.model_validate(["a", 1, {"x": 2}]).model_dump() == snapshot(["a", 1, {"x": 2}])
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate([5])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Item at index `0` does not match the `prefixItems` schema",
+                    "input": [5],
+                }
+            ]
+        )
+
+    def test_prefix_items_ref(self) -> None:
+        """Test a `prefixItems` entry pointing at a `$ref` (resolved via the bound namespace)."""
+        schema = Schema.model_validate(
+            {
+                "type": "array",
+                "prefixItems": [{"$ref": "#/$defs/Point"}],
+                "$defs": {
+                    "Point": {
+                        "type": "object",
+                        "properties": {"k": {"type": "integer"}},
+                        "required": ["k"],
+                    },
+                },
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate([{"k": 1}]).model_dump() == snapshot([{"k": 1}])
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate([{"no": 1}])
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Item at index `0` does not match the `prefixItems` schema",
+                    "input": [{"no": 1}],
+                }
+            ]
+        )
+
+
 class TestAdditionalProperties:
     """Tests for `additionalProperties` handling."""
 


### PR DESCRIPTION
## Summary

Make `to_model` enforce `prefixItems`: element `i` is validated against `prefixItems[i]`, and elements past the prefix against the `items` tail (2020-12 semantics). Previously parsed onto `Schema` but ignored. Tier 2.

## What changed

- `_prefix_items.py`: new `PrefixItems` validator (mirrors `Contains`). Attached as `Annotated` metadata on a `list[Any]` base, it validates each position against its subschema (prefix or `items` tail), coercing per position; elements past the prefix are unconstrained when `items` is absent. Prefix / tail subschemas may be `ForwardRef` (a `$ref`), resolved lazily via `bind_namespace`.
- `converters.py`: `_build_prefix_items` in `_array_annotation` — with `prefixItems`, the base becomes `list[Any]` and the validator handles every position; registered for namespace binding alongside `OneOf` / `Contains`.

NOTE: Pydantic does not support PEP 646 variadic tuples, so positional validation uses a validator rather than a `tuple` type. `items: false` (forbidding extra items) needs boolean-schema support, which the `Schema` model does not have yet — out of scope.

## How tested

New `TestPrefixItems`: prefix + `items` tail, extra elements unconstrained, a `$ref` prefix entry, and per-index error messages.

`just all` green — 705 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.