### PR TITLE
feat(converters): enforce `not` on conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -111,6 +111,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `uniqueItems: true`                          | array uniqueness constraint                 | `AfterValidator` rejecting dupes    |
 | `contains`, `minContains`, `maxContains`     | array match-count constraint                | `Contains` validator                |
 | `prefixItems`                                | positional (tuple-style) array validation   | `PrefixItems` validator             |
+| `not`                                        | value must not match the subschema          | `Not` validator                     |
 | `minProperties`, `maxProperties`             | object property-count constraints           | `before` validator / `dict` length  |
 | `dependentRequired`                          | conditionally required properties           | `before` validator                  |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
@@ -123,7 +124,7 @@ for custom keywords) but do not yet affect the generated model's validation:
 
 | Keyword group | Ignored keywords                                                                                                 |
 |---------------|------------------------------------------------------------------------------------------------------------------|
-| composition   | `not`, `if` / `then` / `else`                                                                                    |
+| composition   | `if` / `then` / `else`                                                                                           |
 | objects       | `patternProperties`, `propertyNames`, `dependentSchemas`                                                         |
 
 ## Known Limitations
@@ -140,6 +141,9 @@ for custom keywords) but do not yet affect the generated model's validation:
 - `format` is metadata unless a matching entry is passed in `format_validators` — see [Format Validators](formats.md).
   Built-in aliases cover all 19 spec-defined formats;
   `idn-*` formats use the stdlib IDNA 2003 codec and `regex` uses the Python `re` dialect (see the differences from the specification in [Format Validators](formats.md)).
+- `not` is only as precise as the converter's coverage of its subschema. A subschema that maps to
+  `Any` (an empty schema, or `required` without `type` / `properties`) matches every value, so
+  `not` then rejects everything.
 
 ## Common Conversions
 

--- a/pydantic_jsonschema/_not.py
+++ b/pydantic_jsonschema/_not.py
@@ -1,0 +1,118 @@
+"""JSON Schema `not` validator.
+
+See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.4
+"""
+
+from typing import Any, ForwardRef
+
+from pydantic import (
+    BaseModel,
+    GetCoreSchemaHandler,
+    TypeAdapter,
+    ValidationError,
+)
+from pydantic_core import CoreSchema, core_schema
+
+__all__ = ["Not"]
+
+# Type aliases
+type AnnotationType = (
+    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
+)
+
+
+class Not:
+    """Enforce JSON Schema `not`: the instance must NOT validate against the subschema.
+
+    Used two ways, both checking the *raw* input (before the host type coerces it):
+
+    - as `Annotated` metadata on a value annotation (a wrap-validator), for non-object values
+      and nested objects/dicts;
+    - via `matches`, from a `before` model validator on a root object model (which bypasses the
+      annotation path).
+
+    The subschema may be a `ForwardRef` (a `not` pointing at a `$ref`), resolved lazily through
+    `bind_namespace`.
+    """
+
+    def __init__(
+        self,
+        *,
+        branch: AnnotationType,
+    ) -> None:
+        """Initialize with the `not` subschema annotation.
+
+        :param branch: The `not` subschema annotation (may be a `ForwardRef`).
+        """
+        self._branch: AnnotationType = branch
+        self._namespace: dict[str, type[BaseModel]] = {}
+        self._adapter: TypeAdapter[AnnotationType] | None = None
+
+    def bind_namespace(
+        self,
+        namespace: dict[str, type[BaseModel]],
+        /,
+    ) -> None:
+        """Provide the namespace used to resolve a `ForwardRef` subschema.
+
+        :param namespace: Mapping of sanitized reference names to models.
+        """
+        self._namespace = namespace
+
+    def __get_pydantic_core_schema__(
+        self,
+        source_type: AnnotationType,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Wrap the value schema with the `not` check (on the raw input)."""
+        return core_schema.no_info_wrap_validator_function(self._validate, handler(source_type))
+
+    def matches(
+        self,
+        value: AnnotationType,
+        /,
+    ) -> bool:
+        """Return whether a value validates against the `not` subschema.
+
+        :param value: The raw input value.
+        :returns: `True` when the value validates against `not` (and so must be rejected).
+        """
+        try:
+            self._get_adapter().validate_python(value)
+        except ValidationError:
+            return False
+        return True
+
+    def _get_adapter(self) -> TypeAdapter[AnnotationType]:
+        """Build the `not` adapter, resolving a `ForwardRef` subschema on first use.
+
+        :returns: A `TypeAdapter` for the `not` subschema.
+        """
+        # NOTE: Built lazily: at conversion time the subschema may be a `ForwardRef` that only
+        #       becomes resolvable after the whole schema (including `$defs`) is converted and
+        #       the namespace is bound via `bind_namespace`.
+        if self._adapter is None:
+            branch = (
+                self._namespace[self._branch.__forward_arg__]
+                if isinstance(self._branch, ForwardRef)
+                else self._branch
+            )
+            self._adapter = TypeAdapter(branch)
+        return self._adapter
+
+    def _validate(
+        self,
+        value: AnnotationType,
+        handler: core_schema.ValidatorFunctionWrapHandler,
+    ) -> AnnotationType:
+        """Reject inputs matching the `not` subschema, then delegate to the host schema.
+
+        :param value: Raw input value.
+        :param handler: Wrapped host-type validator.
+        :returns: The validated value.
+        :raises ValueError: When the value matches the `not` subschema.
+        """
+        if self.matches(value):
+            msg = "Value must not match the `not` schema"
+            raise ValueError(msg)
+        return handler(value)

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -37,6 +37,7 @@ from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
 
 from ._contains import Contains
+from ._not import Not
 from ._one_of import OneOf
 from ._prefix_items import PrefixItems
 from ._utils import sanitize_identifier
@@ -329,6 +330,7 @@ class SchemaConverter:
         self._one_of_validators: list[OneOf] = []
         self._contains_validators: list[Contains] = []
         self._prefix_items_validators: list[PrefixItems] = []
+        self._not_validators: list[Not] = []
 
     @staticmethod
     def _hash_schema(
@@ -379,6 +381,13 @@ class SchemaConverter:
         # Build model using common logic
         model = self._build_model(schema, model_name=model_name)
 
+        # A root object becomes a plain `BaseModel` (not a `RootModel`), so it bypasses the
+        # annotation path where `not` is otherwise attached — wrap it explicitly here. Every
+        # other shape (root non-object / dict-root, and all nested values) carries `not` via
+        # its annotation already.
+        if schema.not_ is not MISSING and not issubclass(model, RootModel):
+            model = self._wrap_root_not(model, schema)
+
         # Bind the forward-refs namespace so `OneOf` / `Contains` validators can resolve
         # `ForwardRef` branches lazily at validation time.
         namespace = self._get_forward_refs_namespace()
@@ -388,6 +397,8 @@ class SchemaConverter:
             contains_validator.bind_namespace(namespace)
         for prefix_items_validator in self._prefix_items_validators:
             prefix_items_validator.bind_namespace(namespace)
+        for not_validator in self._not_validators:
+            not_validator.bind_namespace(namespace)
 
         return model
 
@@ -962,15 +973,84 @@ class SchemaConverter:
 
         # `enum` / `const` -> `Literal`:
         if schema.enum is not MISSING or schema.const is not MISSING:
-            return self._literal_annotation(schema)
+            annotation: type | ForwardRef = self._literal_annotation(schema)
+        else:
+            # `anyOf` / `oneOf` / `allOf` -> union or nested model; else `type` (or `Any`).
+            composition_annotation = self._composition_annotation(schema)
+            annotation = (
+                composition_annotation
+                if composition_annotation is not None
+                else self._type_annotation(schema)
+            )
 
-        # `anyOf` / `oneOf` / `allOf` -> union or nested model:
-        composition_annotation = self._composition_annotation(schema)
-        if composition_annotation is not None:
-            return composition_annotation
+        # `not` is checked against the raw value before the host type (a wrap-validator).
+        if schema.not_ is not MISSING:
+            annotation = self._apply_not(annotation, schema)
 
-        # `type` -> Python type (or `Any` when absent):
-        return self._type_annotation(schema)
+        return annotation
+
+    def _apply_not(
+        self,
+        annotation: AnnotationType,
+        schema: Schema,
+        /,
+    ) -> type:
+        """Wrap a value annotation with the `not` check.
+
+        :param annotation: The value's base annotation.
+        :param schema: Schema carrying `not`.
+        :returns: `Annotated[annotation, Not(...)]`.
+        """
+        not_validator = self._build_not(schema)
+        return cast("type", Annotated[annotation, not_validator])
+
+    def _build_not(
+        self,
+        schema: Schema,
+        /,
+    ) -> Not:
+        """Build the `not` validator, registering it for namespace binding.
+
+        :param schema: Schema carrying `not`.
+        :returns: A `Not` validator for the subschema.
+        """
+        with self._track_path("not"):
+            branch = self._schema_to_annotation(schema.not_)
+
+        not_validator = Not(branch=branch)
+        self._not_validators.append(not_validator)
+        return not_validator
+
+    def _wrap_root_not(
+        self,
+        model: type[BaseModel],
+        schema: Schema,
+        /,
+    ) -> type[BaseModel]:
+        """Wrap a root object model with a `before` validator enforcing `not`.
+
+        :param model: The root object `BaseModel`.
+        :param schema: Root schema carrying `not`.
+        :returns: A subclass of `model` that rejects inputs matching the `not` subschema.
+        """
+        not_validator = self._build_not(schema)
+
+        def _check(data: PythonType) -> PythonType:
+            if not_validator.matches(data):
+                msg = "Value must not match the `not` schema"
+                raise ValueError(msg)
+            return data
+
+        validators: dict[str, PythonType] = {
+            "_validate_not": model_validator(mode="before")(_check),
+        }
+        wrapped = create_model(
+            model.__name__,
+            __base__=model,
+            __module__=__name__,
+            __validators__=validators,
+        )
+        return cast("type[BaseModel]", wrapped)
 
     def _reference_annotation(
         self,

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2389,6 +2389,128 @@ class TestPrefixItems:
         )
 
 
+class TestNot:
+    """Tests for `not` enforcement.
+
+    `not` is only as precise as the converter's coverage of its subschema: a subschema that maps
+    to `Any` (e.g. an empty schema, or `required` without `type` / `properties`) matches every
+    value, so `not` then rejects everything. These tests use subschemas the converter enforces.
+    """
+
+    def test_not_scalar(self) -> None:
+        """Test `not` on a scalar root value (a forbidden constant)."""
+        schema = Schema.model_validate({"type": "string", "not": {"const": "admin"}})
+        model = to_model(schema)
+
+        assert model.model_validate("alice").model_dump() == snapshot("alice")
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate("admin")
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Value must not match the `not` schema",
+                    "input": "admin",
+                }
+            ]
+        )
+
+    def test_not_field(self) -> None:
+        """Test `not` on an object property."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string", "not": {"const": "root"}}},
+                "required": ["name"],
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"name": "bob"}).model_dump() == snapshot({"name": "bob"})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"name": "root"})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("name",),
+                    "msg": "Value error, Value must not match the `not` schema",
+                    "input": "root",
+                }
+            ]
+        )
+
+    def test_not_root_object(self) -> None:
+        """Test `not` on a root object model (wrapped via a `before` validator)."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"role": {"type": "string"}},
+                "not": {
+                    "type": "object",
+                    "properties": {"secret": {"type": "integer"}},
+                    "required": ["secret"],
+                },
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"role": "user"}).model_dump() == snapshot({"role": "user"})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"role": "user", "secret": 1})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Value must not match the `not` schema",
+                    "input": {"role": "user", "secret": 1},
+                }
+            ]
+        )
+
+    def test_not_ref(self) -> None:
+        """Test `not` pointing at a `$ref` (resolved via the bound namespace)."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "not": {"$ref": "#/$defs/Banned"},
+                "properties": {"x": {"type": "integer"}},
+                "$defs": {
+                    "Banned": {
+                        "type": "object",
+                        "properties": {"evil": {"type": "integer"}},
+                        "required": ["evil"],
+                    },
+                },
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"x": 1}).model_dump() == snapshot({"x": 1})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"evil": 1})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Value must not match the `not` schema",
+                    "input": {"evil": 1},
+                }
+            ]
+        )
+
+
 class TestAdditionalProperties:
     """Tests for `additionalProperties` handling."""
 


### PR DESCRIPTION
## Summary

Make `to_model` enforce `not`: the instance must NOT validate against the subschema. Previously parsed onto `Schema` but ignored. Completes Tier 1.

## What changed

- `_not.py`: new `Not` validator (mirrors `OneOf`). A wrap-validator that checks the **raw** input against the `not` subschema and rejects it on a match. The subschema may be a `ForwardRef` (a `not` pointing at a `$ref`), resolved lazily via `bind_namespace`.
- `converters.py`:
  - non-object values and nested objects/dicts get `not` via the annotation (`_apply_not` in `_schema_to_annotation`);
  - a root object becomes a plain `BaseModel` that bypasses the annotation path, so it is wrapped with a `before` validator (`_wrap_root_not`); `issubclass(model, RootModel)` avoids double-wrapping every other shape.

NOTE: `not` is only as precise as the converters coverage of its subschema. A subschema that maps to `Any` (an empty schema, or `required` without `type` / `properties`) matches every value, so `not` then rejects everything. Documented in Known Limitations.

## How tested

New `TestNot`: scalar root, object property, root object model, and a `$ref` subschema.

`just all` green — 709 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.