### PR TITLE
feat(converters): enforce `dependentSchemas` on object conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -114,6 +114,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `not`                                        | value must not match the subschema          | `Not` validator                     |
 | `minProperties`, `maxProperties`             | object property-count constraints           | `before` validator / `dict` length  |
 | `dependentRequired`                          | conditionally required properties           | `before` validator                  |
+| `dependentSchemas`                           | conditionally applied object subschema      | `DependentSchemas` validator        |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
 
@@ -125,7 +126,7 @@ for custom keywords) but do not yet affect the generated model's validation:
 | Keyword group | Ignored keywords                                                                                                 |
 |---------------|------------------------------------------------------------------------------------------------------------------|
 | composition   | `if` / `then` / `else`                                                                                           |
-| objects       | `patternProperties`, `propertyNames`, `dependentSchemas`                                                         |
+| objects       | `patternProperties`, `propertyNames`                                                                             |
 
 ## Known Limitations
 

--- a/pydantic_jsonschema/_dependent_schemas.py
+++ b/pydantic_jsonschema/_dependent_schemas.py
@@ -1,0 +1,98 @@
+"""JSON Schema `dependentSchemas` validator.
+
+See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4
+"""
+
+from typing import Any, ForwardRef
+
+from pydantic import (
+    BaseModel,
+    TypeAdapter,
+    ValidationError,
+)
+
+__all__ = ["DependentSchemas"]
+
+# Type aliases
+type AnnotationType = (
+    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
+)
+
+
+class DependentSchemas:
+    """Enforce JSON Schema `dependentSchemas`: a present property triggers a whole-object schema.
+
+    For each `{property: subschema}` pair, when the property is present in the object the entire
+    instance must also validate against the subschema. Used from a `before` model validator on
+    object models; subschemas may be `ForwardRef` (pointing at a `$ref`), resolved lazily via
+    `bind_namespace`.
+    """
+
+    def __init__(
+        self,
+        *,
+        branches: dict[str, AnnotationType],
+    ) -> None:
+        """Initialize with the property-to-subschema mapping.
+
+        :param branches: Mapping of trigger property name to its subschema annotation (each may
+            be a `ForwardRef`).
+        """
+        self._branches: dict[str, AnnotationType] = dict(branches)
+        self._namespace: dict[str, type[BaseModel]] = {}
+        self._adapters: dict[str, TypeAdapter[AnnotationType]] | None = None
+
+    def bind_namespace(
+        self,
+        namespace: dict[str, type[BaseModel]],
+        /,
+    ) -> None:
+        """Provide the namespace used to resolve `ForwardRef` subschemas.
+
+        :param namespace: Mapping of sanitized reference names to models.
+        """
+        self._namespace = namespace
+
+    def _get_adapters(self) -> dict[str, TypeAdapter[AnnotationType]]:
+        """Build the per-trigger adapters, resolving `ForwardRef` subschemas on first use.
+
+        :returns: Mapping of trigger property name to its subschema `TypeAdapter`.
+        """
+        # NOTE: Built lazily: at conversion time subschemas may be `ForwardRef`s that only become
+        #       resolvable after the whole schema (including `$defs`) is converted and the
+        #       namespace is bound via `bind_namespace`.
+        if self._adapters is None:
+            self._adapters = {
+                trigger: TypeAdapter(
+                    self._namespace[branch.__forward_arg__]
+                    if isinstance(branch, ForwardRef)
+                    else branch
+                )
+                for trigger, branch in self._branches.items()
+            }
+        return self._adapters
+
+    def validate(
+        self,
+        data: AnnotationType,
+        /,
+    ) -> AnnotationType:
+        """Apply each triggered subschema to the whole instance.
+
+        :param data: The raw input mapping (other input is left for type validation to reject).
+        :returns: The input unchanged when every triggered subschema validates.
+        :raises ValueError: When a present property's subschema does not validate the instance.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        for trigger, adapter in self._get_adapters().items():
+            if trigger not in data:
+                continue
+            try:
+                adapter.validate_python(data)
+            except ValidationError:
+                msg = f"Property `{trigger}` does not satisfy its `dependentSchemas` schema"
+                raise ValueError(msg) from None
+
+        return data

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -37,6 +37,7 @@ from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
 
 from ._contains import Contains
+from ._dependent_schemas import DependentSchemas
 from ._not import Not
 from ._one_of import OneOf
 from ._prefix_items import PrefixItems
@@ -331,6 +332,7 @@ class SchemaConverter:
         self._contains_validators: list[Contains] = []
         self._prefix_items_validators: list[PrefixItems] = []
         self._not_validators: list[Not] = []
+        self._dependent_schemas_validators: list[DependentSchemas] = []
 
     @staticmethod
     def _hash_schema(
@@ -399,6 +401,8 @@ class SchemaConverter:
             prefix_items_validator.bind_namespace(namespace)
         for not_validator in self._not_validators:
             not_validator.bind_namespace(namespace)
+        for dependent_schemas_validator in self._dependent_schemas_validators:
+            dependent_schemas_validator.bind_namespace(namespace)
 
         return model
 
@@ -529,7 +533,10 @@ class SchemaConverter:
         """
         fields = self._build_fields(schema)
         model_config = self._build_model_config(schema)
+        # Converter-free keyword validators from the registry, plus converter-aware ones
+        # (subschemas need conversion + namespace binding) that the registry cannot build.
         validators = _build_object_validators(schema)
+        validators.update(self._build_dependent_schemas_validators(schema))
 
         # For some reason, `create_model` "accepts" `fields` values as `tuple[str, Any]`,
         # when in reality it accepts `tuple[type, FieldInfo]`
@@ -543,6 +550,35 @@ class SchemaConverter:
             **fields,
         )
         return cast("type[BaseModel]", created_model)
+
+    def _build_dependent_schemas_validators(
+        self,
+        schema: Schema,
+        /,
+    ) -> dict[str, PythonType]:
+        """Build the `dependentSchemas` validator for an object model.
+
+        Registers the validator so its `ForwardRef` subschemas (a dependent pointing at a `$ref`)
+        are namespace-bound after the whole schema is converted.
+
+        :param schema: Object schema.
+        :returns: A `__validators__` mapping (empty when `dependentSchemas` is absent).
+        """
+        if schema.dependent_schemas is MISSING:
+            return {}
+
+        branches: dict[str, PythonType] = {}
+        for trigger, sub_schema in schema.dependent_schemas.items():
+            with self._track_path(f"dependentSchemas.{trigger}"):
+                branches[trigger] = self._schema_to_annotation(sub_schema)
+
+        dependent_schemas = DependentSchemas(branches=branches)
+        self._dependent_schemas_validators.append(dependent_schemas)
+
+        def _check(data: PythonType) -> PythonType:
+            return dependent_schemas.validate(data)
+
+        return {"_validate_dependent_schemas": model_validator(mode="before")(_check)}
 
     def _check_alias_target(
         self,

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2288,6 +2288,91 @@ class TestDependentRequired:
             model.model_validate("not a mapping")
 
 
+class TestDependentSchemas:
+    """Tests for `dependentSchemas` enforcement."""
+
+    def test_dependent_schemas(self) -> None:
+        """Test a present property applies its subschema to the whole instance."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {
+                    "credit_card": {"type": "integer"},
+                    "billing_address": {"type": "string"},
+                },
+                "dependentSchemas": {
+                    "credit_card": {
+                        "type": "object",
+                        "properties": {"billing_address": {"type": "string"}},
+                        "required": ["billing_address"],
+                    },
+                },
+            }
+        )
+        model = to_model(schema)
+
+        # Trigger absent -> dependency does not apply.
+        assert model.model_validate({}).model_dump() == snapshot({})
+
+        # Trigger present and the subschema is satisfied.
+        assert model.model_validate(
+            {"credit_card": 1, "billing_address": "x"}
+        ).model_dump() == snapshot({"credit_card": 1, "billing_address": "x"})
+
+        # Trigger present, subschema not satisfied.
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"credit_card": 1})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Property `credit_card` does not satisfy its `dependentSchemas` schema",
+                    "input": {"credit_card": 1},
+                }
+            ]
+        )
+
+        # Non-mapping input passes through and is rejected by type validation.
+        with pytest.raises(ValidationError):
+            model.model_validate("not a mapping")
+
+    def test_dependent_schemas_ref(self) -> None:
+        """Test a `dependentSchemas` subschema pointing at a `$ref`."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"a": {"type": "integer"}},
+                "dependentSchemas": {"a": {"$ref": "#/$defs/Req"}},
+                "$defs": {
+                    "Req": {
+                        "type": "object",
+                        "properties": {"b": {"type": "integer"}},
+                        "required": ["b"],
+                    },
+                },
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"a": 1, "b": 2}).model_dump() == snapshot({"a": 1, "b": 2})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"a": 1})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Property `a` does not satisfy its `dependentSchemas` schema",
+                    "input": {"a": 1},
+                }
+            ]
+        )
+
+
 class TestPrefixItems:
     """Tests for `prefixItems` positional validation."""
 


### PR DESCRIPTION
## Summary

Make `to_model` enforce `dependentSchemas`: when a trigger property is present, the whole instance must also validate against its subschema. Previously parsed onto `Schema` but ignored. Tier 3.

## What changed

- `_dependent_schemas.py`: new `DependentSchemas` validator. For each `{property: subschema}` pair, a `before` model validator applies the subschema to the entire raw instance when the property is present. Subschemas may be `ForwardRef` (a dependent pointing at a `$ref`), resolved lazily via `bind_namespace`.
- `converters.py`: `_build_dependent_schemas_validators` builds the converter-aware validator and merges it into the object models `__validators__` alongside the module-level registry.

Unlike `not`, a subschema that maps to `Any` fails open (the dependency is simply not enforced), so this is lower-risk.

## How tested

New `TestDependentSchemas`: trigger absent, trigger satisfied, trigger unsatisfied, non-mapping passthrough, and a `$ref` subschema.

`just all` green — 711 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.