### PR TITLE
feat(converters): enforce `if`/`then`/`else` on conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -112,6 +112,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `contains`, `minContains`, `maxContains`     | array match-count constraint                | `Contains` validator                |
 | `prefixItems`                                | positional (tuple-style) array validation   | `PrefixItems` validator             |
 | `not`                                        | value must not match the subschema          | `Not` validator                     |
+| `if` / `then` / `else`                       | conditional subschema application           | `IfThenElse` validator              |
 | `minProperties`, `maxProperties`             | object property-count constraints           | `before` validator / `dict` length  |
 | `dependentRequired`                          | conditionally required properties           | `before` validator                  |
 | `dependentSchemas`                           | conditionally applied object subschema      | `DependentSchemas` validator        |
@@ -125,7 +126,6 @@ for custom keywords) but do not yet affect the generated model's validation:
 
 | Keyword group | Ignored keywords                                                                                                 |
 |---------------|------------------------------------------------------------------------------------------------------------------|
-| composition   | `if` / `then` / `else`                                                                                           |
 | objects       | `patternProperties`, `propertyNames`                                                                             |
 
 ## Known Limitations

--- a/pydantic_jsonschema/_if_then_else.py
+++ b/pydantic_jsonschema/_if_then_else.py
@@ -1,0 +1,160 @@
+"""JSON Schema `if` / `then` / `else` validator.
+
+See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2
+"""
+
+from typing import Any, ForwardRef
+
+from pydantic import (
+    BaseModel,
+    GetCoreSchemaHandler,
+    TypeAdapter,
+    ValidationError,
+)
+from pydantic_core import CoreSchema, core_schema
+
+__all__ = ["IfThenElse"]
+
+# Type aliases
+type AnnotationType = (
+    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
+)
+
+
+class IfThenElse:
+    """Enforce JSON Schema `if` / `then` / `else` conditional application.
+
+    If the instance validates against `if`, it must also validate against `then`; otherwise it
+    must validate against `else`. `then` / `else` are optional (a missing branch imposes no
+    constraint). All checks run on the *raw* input. Used both as `Annotated` metadata (a
+    wrap-validator) on value annotations and via `check` from a `before` model validator on a
+    root object model. Subschemas may be `ForwardRef` (pointing at a `$ref`), resolved lazily
+    via `bind_namespace`.
+    """
+
+    def __init__(
+        self,
+        *,
+        if_branch: AnnotationType,
+        then_branch: AnnotationType | None,
+        else_branch: AnnotationType | None,
+    ) -> None:
+        """Initialize with the `if` / `then` / `else` subschema annotations.
+
+        :param if_branch: The `if` condition subschema (may be a `ForwardRef`).
+        :param then_branch: The `then` subschema applied on a match, or `None`.
+        :param else_branch: The `else` subschema applied on no match, or `None`.
+        """
+        self._if: AnnotationType = if_branch
+        self._then: AnnotationType | None = then_branch
+        self._else: AnnotationType | None = else_branch
+        self._namespace: dict[str, type[BaseModel]] = {}
+        self._if_adapter: TypeAdapter[AnnotationType] | None = None
+        self._then_adapter: TypeAdapter[AnnotationType] | None = None
+        self._else_adapter: TypeAdapter[AnnotationType] | None = None
+
+    def bind_namespace(
+        self,
+        namespace: dict[str, type[BaseModel]],
+        /,
+    ) -> None:
+        """Provide the namespace used to resolve `ForwardRef` subschemas.
+
+        :param namespace: Mapping of sanitized reference names to models.
+        """
+        self._namespace = namespace
+
+    def __get_pydantic_core_schema__(
+        self,
+        source_type: AnnotationType,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Wrap the value schema with the conditional check (on the raw input)."""
+        return core_schema.no_info_wrap_validator_function(self._validate, handler(source_type))
+
+    def _resolve(
+        self,
+        branch: AnnotationType,
+        /,
+    ) -> AnnotationType:
+        """Resolve a `ForwardRef` subschema against the bound namespace.
+
+        :param branch: A subschema annotation, possibly a `ForwardRef`.
+        :returns: The resolved model, or the annotation unchanged.
+        """
+        return self._namespace[branch.__forward_arg__] if isinstance(branch, ForwardRef) else branch
+
+    def _build_adapters(self) -> TypeAdapter[AnnotationType]:
+        """Build the `if` / `then` / `else` adapters, resolving `ForwardRef`s on first use.
+
+        :returns: The `if` adapter (always present).
+        """
+        # NOTE: Built lazily: at conversion time subschemas may be `ForwardRef`s that only become
+        #       resolvable after the whole schema (including `$defs`) is converted and the
+        #       namespace is bound via `bind_namespace`.
+        if self._if_adapter is not None:
+            return self._if_adapter
+
+        if_adapter: TypeAdapter[AnnotationType] = TypeAdapter(self._resolve(self._if))
+        self._if_adapter = if_adapter
+        if self._then is not None:
+            self._then_adapter = TypeAdapter(self._resolve(self._then))
+        if self._else is not None:
+            self._else_adapter = TypeAdapter(self._resolve(self._else))
+        return if_adapter
+
+    @staticmethod
+    def _matches(
+        adapter: TypeAdapter[AnnotationType],
+        value: AnnotationType,
+        /,
+    ) -> bool:
+        """Return whether a value validates against a subschema adapter.
+
+        :param adapter: The subschema adapter.
+        :param value: The raw input value.
+        :returns: `True` when the value validates.
+        """
+        try:
+            adapter.validate_python(value)
+        except ValidationError:
+            return False
+        return True
+
+    def check(
+        self,
+        value: AnnotationType,
+        /,
+    ) -> AnnotationType:
+        """Apply the `then` / `else` branch selected by the `if` condition.
+
+        :param value: The raw input value.
+        :returns: The value unchanged when the selected branch validates.
+        :raises ValueError: When the selected branch does not validate the value.
+        """
+        if_adapter = self._build_adapters()
+
+        if self._matches(if_adapter, value):
+            if self._then_adapter is not None and not self._matches(self._then_adapter, value):
+                msg = "Value matches `if` but not `then`"
+                raise ValueError(msg)
+        elif self._else_adapter is not None and not self._matches(self._else_adapter, value):
+            msg = "Value does not match `if` and not `else`"
+            raise ValueError(msg)
+
+        return value
+
+    def _validate(
+        self,
+        value: AnnotationType,
+        handler: core_schema.ValidatorFunctionWrapHandler,
+    ) -> AnnotationType:
+        """Run the conditional check, then delegate to the host schema.
+
+        :param value: Raw input value.
+        :param handler: Wrapped host-type validator.
+        :returns: The validated value.
+        :raises ValueError: When the conditional check fails.
+        """
+        self.check(value)
+        return handler(value)

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -38,6 +38,7 @@ from pydantic.fields import FieldInfo
 
 from ._contains import Contains
 from ._dependent_schemas import DependentSchemas
+from ._if_then_else import IfThenElse
 from ._not import Not
 from ._one_of import OneOf
 from ._prefix_items import PrefixItems
@@ -333,6 +334,7 @@ class SchemaConverter:
         self._prefix_items_validators: list[PrefixItems] = []
         self._not_validators: list[Not] = []
         self._dependent_schemas_validators: list[DependentSchemas] = []
+        self._if_then_else_validators: list[IfThenElse] = []
 
     @staticmethod
     def _hash_schema(
@@ -384,11 +386,14 @@ class SchemaConverter:
         model = self._build_model(schema, model_name=model_name)
 
         # A root object becomes a plain `BaseModel` (not a `RootModel`), so it bypasses the
-        # annotation path where `not` is otherwise attached — wrap it explicitly here. Every
-        # other shape (root non-object / dict-root, and all nested values) carries `not` via
-        # its annotation already.
-        if schema.not_ is not MISSING and not issubclass(model, RootModel):
-            model = self._wrap_root_not(model, schema)
+        # annotation path where whole-value assertions are otherwise attached — wrap it
+        # explicitly here. Every other shape (root non-object / dict-root, and all nested
+        # values) carries these via its annotation already.
+        if not issubclass(model, RootModel):
+            if schema.not_ is not MISSING:
+                model = self._wrap_root_not(model, schema)
+            if self._has_conditional(schema):
+                model = self._wrap_root_conditional(model, schema)
 
         # Bind the forward-refs namespace so `OneOf` / `Contains` validators can resolve
         # `ForwardRef` branches lazily at validation time.
@@ -403,6 +408,8 @@ class SchemaConverter:
             not_validator.bind_namespace(namespace)
         for dependent_schemas_validator in self._dependent_schemas_validators:
             dependent_schemas_validator.bind_namespace(namespace)
+        for if_then_else_validator in self._if_then_else_validators:
+            if_then_else_validator.bind_namespace(namespace)
 
         return model
 
@@ -570,7 +577,7 @@ class SchemaConverter:
         branches: dict[str, PythonType] = {}
         for trigger, sub_schema in schema.dependent_schemas.items():
             with self._track_path(f"dependentSchemas.{trigger}"):
-                branches[trigger] = self._schema_to_annotation(sub_schema)
+                branches[trigger] = self._constrained_annotation(sub_schema)
 
         dependent_schemas = DependentSchemas(branches=branches)
         self._dependent_schemas_validators.append(dependent_schemas)
@@ -1019,10 +1026,38 @@ class SchemaConverter:
                 else self._type_annotation(schema)
             )
 
-        # `not` is checked against the raw value before the host type (a wrap-validator).
+        # `not` and `if` / `then` / `else` are checked against the raw value before the host
+        # type (wrap-validators).
         if schema.not_ is not MISSING:
             annotation = self._apply_not(annotation, schema)
+        if self._has_conditional(schema):
+            annotation = self._apply_conditional(annotation, schema)
 
+        return annotation
+
+    def _constrained_annotation(
+        self,
+        schema: Schema | Reference,
+        /,
+    ) -> AnnotationType:
+        """Build a subschema annotation with field-level constraints baked in.
+
+        The marker validators (`Not`, `Contains`, `PrefixItems`, `IfThenElse`, `DependentSchemas`)
+        validate values against subschemas via a `TypeAdapter`. Plain `_schema_to_annotation` omits
+        constraints that the converter normally applies through `FieldInfo` (`minimum`, `maxLength`,
+        `pattern`, `multipleOf`, ...), so they are re-applied here as `Annotated` `Field` metadata.
+
+        :param schema: The subschema (or reference) to convert.
+        :returns: The annotation, wrapped with `Field(...)` when it carries field-level constraints.
+        """
+        annotation = self._schema_to_annotation(schema)
+        if isinstance(schema, Reference):
+            return annotation
+
+        annotation = self._apply_validators(annotation, schema)
+        kwargs = self._build_field_kwargs(schema)
+        if kwargs:
+            annotation = cast("type", Annotated[annotation, Field(**kwargs)])
         return annotation
 
     def _apply_not(
@@ -1051,11 +1086,71 @@ class SchemaConverter:
         :returns: A `Not` validator for the subschema.
         """
         with self._track_path("not"):
-            branch = self._schema_to_annotation(schema.not_)
+            branch = self._constrained_annotation(schema.not_)
 
         not_validator = Not(branch=branch)
         self._not_validators.append(not_validator)
         return not_validator
+
+    @staticmethod
+    def _has_conditional(
+        schema: Schema,
+        /,
+    ) -> bool:
+        """Return whether `if` gates an actual `then` / `else` branch.
+
+        :param schema: Schema to inspect.
+        :returns: `True` when `if` is present together with `then` and/or `else`.
+        """
+        return schema.if_ is not MISSING and (
+            schema.then is not MISSING or schema.else_ is not MISSING
+        )
+
+    def _apply_conditional(
+        self,
+        annotation: AnnotationType,
+        schema: Schema,
+        /,
+    ) -> type:
+        """Wrap a value annotation with the `if` / `then` / `else` check.
+
+        :param annotation: The value's base annotation.
+        :param schema: Schema carrying `if` / `then` / `else`.
+        :returns: `Annotated[annotation, IfThenElse(...)]`.
+        """
+        conditional = self._build_conditional(schema)
+        return cast("type", Annotated[annotation, conditional])
+
+    def _build_conditional(
+        self,
+        schema: Schema,
+        /,
+    ) -> IfThenElse:
+        """Build the `if` / `then` / `else` validator, registering it for namespace binding.
+
+        :param schema: Schema carrying `if` / `then` / `else`.
+        :returns: An `IfThenElse` validator for the subschemas.
+        """
+        with self._track_path("if"):
+            if_branch = self._constrained_annotation(schema.if_)
+
+        then_branch: AnnotationType | None = None
+        if schema.then is not MISSING:
+            with self._track_path("then"):
+                then_branch = self._constrained_annotation(schema.then)
+
+        else_branch: AnnotationType | None = None
+        if schema.else_ is not MISSING:
+            with self._track_path("else"):
+                else_branch = self._constrained_annotation(schema.else_)
+
+        conditional = IfThenElse(
+            if_branch=if_branch,
+            then_branch=then_branch,
+            else_branch=else_branch,
+        )
+        self._if_then_else_validators.append(conditional)
+        return conditional
 
     def _wrap_root_not(
         self,
@@ -1077,9 +1172,43 @@ class SchemaConverter:
                 raise ValueError(msg)
             return data
 
-        validators: dict[str, PythonType] = {
-            "_validate_not": model_validator(mode="before")(_check),
-        }
+        return self._wrap_root_before(model, key="_validate_not", check=_check)
+
+    def _wrap_root_conditional(
+        self,
+        model: type[BaseModel],
+        schema: Schema,
+        /,
+    ) -> type[BaseModel]:
+        """Wrap a root object model with a `before` validator enforcing `if` / `then` / `else`.
+
+        :param model: The root object `BaseModel`.
+        :param schema: Root schema carrying `if` / `then` / `else`.
+        :returns: A subclass of `model` applying the conditional check.
+        """
+        conditional = self._build_conditional(schema)
+
+        def _check(data: PythonType) -> PythonType:
+            return conditional.check(data)
+
+        return self._wrap_root_before(model, key="_validate_conditional", check=_check)
+
+    @staticmethod
+    def _wrap_root_before(
+        model: type[BaseModel],
+        /,
+        *,
+        key: str,
+        check: PythonType,
+    ) -> type[BaseModel]:
+        """Subclass a root object model, attaching one `before` model validator.
+
+        :param model: The root object `BaseModel`.
+        :param key: The `__validators__` key for the validator.
+        :param check: The `(data) -> data` validation function.
+        :returns: A subclass of `model` with the validator attached.
+        """
+        validators: dict[str, PythonType] = {key: model_validator(mode="before")(check)}
         wrapped = create_model(
             model.__name__,
             __base__=model,
@@ -1345,12 +1474,12 @@ class SchemaConverter:
         prefixes: list[PythonType] = []
         for index, sub_schema in enumerate(schema.prefix_items):
             with self._track_path(f"prefixItems[{index}]"):
-                prefixes.append(self._schema_to_annotation(sub_schema))
+                prefixes.append(self._constrained_annotation(sub_schema))
 
         tail: PythonType | None = None
         if schema.items is not MISSING:
             with self._track_path("items"):
-                tail = self._schema_to_annotation(schema.items)
+                tail = self._constrained_annotation(schema.items)
 
         prefix_items = PrefixItems(prefixes=prefixes, tail=tail)
         self._prefix_items_validators.append(prefix_items)
@@ -1373,7 +1502,7 @@ class SchemaConverter:
             return None
 
         with self._track_path("contains"):
-            branch = self._schema_to_annotation(schema.contains)
+            branch = self._constrained_annotation(schema.contains)
 
         # `minContains` defaults to 1; `maxContains` is unbounded when absent.
         min_contains = schema.min_contains if schema.min_contains is not MISSING else 1

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2596,6 +2596,154 @@ class TestNot:
         )
 
 
+class TestIfThenElse:
+    """Tests for `if` / `then` / `else` conditional validation."""
+
+    def test_if_then_root_object(self) -> None:
+        """Test `if` / `then` on a root object (no `else`)."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"country": {"type": "string"}, "postal_code": {"type": "string"}},
+                "if": {
+                    "type": "object",
+                    "properties": {"country": {"const": "US"}},
+                    "required": ["country"],
+                },
+                "then": {
+                    "type": "object",
+                    "properties": {"postal_code": {"type": "string"}},
+                    "required": ["postal_code"],
+                },
+            }
+        )
+        model = to_model(schema)
+
+        # `if` matches and `then` is satisfied.
+        assert model.model_validate(
+            {"country": "US", "postal_code": "12345"}
+        ).model_dump() == snapshot({"country": "US", "postal_code": "12345"})
+
+        # `if` does not match -> no `else`, so it passes.
+        assert model.model_validate({"country": "CA"}).model_dump() == snapshot({"country": "CA"})
+
+        # `if` matches but `then` fails.
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"country": "US"})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Value matches `if` but not `then`",
+                    "input": {"country": "US"},
+                }
+            ]
+        )
+
+    def test_if_then_else_scalar(self) -> None:
+        """Test `if` / `then` / `else` on a scalar root (the `else` branch and a constraint)."""
+        schema = Schema.model_validate(
+            {
+                "type": "integer",
+                "if": {"const": 0},
+                "then": {"const": 0},
+                "else": {"type": "integer", "exclusiveMinimum": 0},
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate(0).model_dump() == snapshot(0)
+        assert model.model_validate(5).model_dump() == snapshot(5)
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate(-3)
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Value does not match `if` and not `else`",
+                    "input": -3,
+                }
+            ]
+        )
+
+    def test_if_else_only(self) -> None:
+        """Test `if` / `else` without `then` (a matching `if` imposes no extra constraint)."""
+        schema = Schema.model_validate(
+            {
+                "type": "string",
+                "if": {"const": "x"},
+                "else": {"type": "string", "minLength": 3},
+            }
+        )
+        model = to_model(schema)
+
+        # `if` matches -> no `then`, so it passes.
+        assert model.model_validate("x").model_dump() == snapshot("x")
+        # `if` does not match -> `else` is satisfied.
+        assert model.model_validate("abc").model_dump() == snapshot("abc")
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate("ab")
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Value does not match `if` and not `else`",
+                    "input": "ab",
+                }
+            ]
+        )
+
+    def test_if_then_ref(self) -> None:
+        """Test `if` / `then` pointing at `$ref`s (resolved via the bound namespace)."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"kind": {"type": "string"}, "size": {"type": "integer"}},
+                "if": {"$ref": "#/$defs/IsBox"},
+                "then": {"$ref": "#/$defs/HasSize"},
+                "$defs": {
+                    "IsBox": {
+                        "type": "object",
+                        "properties": {"kind": {"const": "box"}},
+                        "required": ["kind"],
+                    },
+                    "HasSize": {
+                        "type": "object",
+                        "properties": {"size": {"type": "integer"}},
+                        "required": ["size"],
+                    },
+                },
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"kind": "box", "size": 1}).model_dump() == snapshot(
+            {"kind": "box", "size": 1}
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"kind": "box"})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Value matches `if` but not `then`",
+                    "input": {"kind": "box"},
+                }
+            ]
+        )
+
+
 class TestAdditionalProperties:
     """Tests for `additionalProperties` handling."""
 


### PR DESCRIPTION
## Summary

Make `to_model` enforce `if` / `then` / `else`: if the instance validates against `if`, it must also validate against `then`; otherwise against `else` (both optional). Previously parsed onto `Schema` but ignored. Tier 3.

## What changed

- `_if_then_else.py`: new `IfThenElse` validator (mirrors `Not`). Checks the **raw** input: matches it against `if`, then requires the selected `then` / `else` branch. Subschemas may be `ForwardRef` (a branch pointing at a `$ref`), resolved lazily via `bind_namespace`.
- `converters.py`: dual hook like `not` — attached via the annotation for non-object / nested values, and via `_wrap_root_conditional` for root object models (extracted a shared `_wrap_root_before` helper).

### Fix: field-level constraints in marker subschema adapters

While adding this I found a latent bug affecting **all** marker validators (`Not`, `Contains`, `PrefixItems`, `IfThenElse`, `DependentSchemas`): they built subschema adapters from `_schema_to_annotation`, which omits constraints the converter applies through `FieldInfo` (`minimum`, `maxLength`, `pattern`, `multipleOf`, ...). So e.g. a `contains` subschema `{"minimum": 10}` was not enforced.

New `_constrained_annotation` re-applies those constraints as `Annotated` `Field(...)` metadata; every marker builder now uses it. No regression — type-only subschemas produce no `Field` wrapper.

## How tested

New `TestIfThenElse`: `if`/`then` on a root object, `if`/`then`/`else` on a scalar (exercising the `else` branch and an `exclusiveMinimum` constraint), `if`/`else` without `then`, and `$ref` branches.

`just all` green — 715 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.