### PR TITLE
feat(converters): enforce `patternProperties` on object conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -116,6 +116,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `minProperties`, `maxProperties`             | object property-count constraints           | `before` validator / `dict` length  |
 | `dependentRequired`                          | conditionally required properties           | `before` validator                  |
 | `dependentSchemas`                           | conditionally applied object subschema      | `DependentSchemas` validator        |
+| `patternProperties`                          | regex-keyed property-value subschemas       | `PatternProperties` validator       |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
 
@@ -126,7 +127,7 @@ for custom keywords) but do not yet affect the generated model's validation:
 
 | Keyword group | Ignored keywords                                                                                                 |
 |---------------|------------------------------------------------------------------------------------------------------------------|
-| objects       | `patternProperties`, `propertyNames`                                                                             |
+| objects       | `propertyNames`                                                                                                  |
 
 ## Known Limitations
 
@@ -145,6 +146,9 @@ for custom keywords) but do not yet affect the generated model's validation:
 - `not` is only as precise as the converter's coverage of its subschema. A subschema that maps to
   `Any` (an empty schema, or `required` without `type` / `properties`) matches every value, so
   `not` then rejects everything.
+- `patternProperties` validates the values of matching property names, but combined with
+  `additionalProperties: false` a pattern-matched extra key is still rejected by `extra="forbid"`
+  (the generated model cannot express "allow keys matching this regex").
 
 ## Common Conversions
 

--- a/pydantic_jsonschema/_pattern_properties.py
+++ b/pydantic_jsonschema/_pattern_properties.py
@@ -1,0 +1,104 @@
+"""JSON Schema `patternProperties` validator.
+
+See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2
+"""
+
+import re
+from typing import Any, ForwardRef
+
+from pydantic import (
+    BaseModel,
+    TypeAdapter,
+    ValidationError,
+)
+
+__all__ = ["PatternProperties"]
+
+# Type aliases
+type AnnotationType = (
+    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
+)
+
+
+class PatternProperties:
+    """Enforce JSON Schema `patternProperties`: regex-keyed property-value subschemas.
+
+    Every property whose name matches a regex must have a value validating against that regex's
+    subschema (a name may match several patterns, and must then satisfy all of them). Used from a
+    `before` model validator on object models; subschemas may be `ForwardRef` (pointing at a
+    `$ref`), resolved lazily via `bind_namespace`.
+    """
+
+    def __init__(
+        self,
+        *,
+        branches: dict[str, AnnotationType],
+    ) -> None:
+        """Initialize with the pattern-to-subschema mapping.
+
+        :param branches: Mapping of regex (`patternProperties` key) to its value subschema
+            annotation (each may be a `ForwardRef`).
+        """
+        self._branches: dict[str, AnnotationType] = dict(branches)
+        self._namespace: dict[str, type[BaseModel]] = {}
+        self._compiled: list[tuple[re.Pattern[str], TypeAdapter[AnnotationType]]] | None = None
+
+    def bind_namespace(
+        self,
+        namespace: dict[str, type[BaseModel]],
+        /,
+    ) -> None:
+        """Provide the namespace used to resolve `ForwardRef` subschemas.
+
+        :param namespace: Mapping of sanitized reference names to models.
+        """
+        self._namespace = namespace
+
+    def _get_compiled(self) -> list[tuple[re.Pattern[str], TypeAdapter[AnnotationType]]]:
+        """Compile the patterns and build the value adapters, resolving `ForwardRef`s on first use.
+
+        :returns: A list of `(compiled regex, value adapter)` pairs.
+        """
+        # NOTE: Built lazily: at conversion time subschemas may be `ForwardRef`s that only become
+        #       resolvable after the whole schema (including `$defs`) is converted and the
+        #       namespace is bound via `bind_namespace`.
+        if self._compiled is None:
+            self._compiled = [
+                (
+                    re.compile(pattern),
+                    TypeAdapter(
+                        self._namespace[branch.__forward_arg__]
+                        if isinstance(branch, ForwardRef)
+                        else branch
+                    ),
+                )
+                for pattern, branch in self._branches.items()
+            ]
+        return self._compiled
+
+    def validate(
+        self,
+        data: AnnotationType,
+        /,
+    ) -> AnnotationType:
+        """Validate every matching property's value against its pattern's subschema.
+
+        :param data: The raw input mapping (other input is left for type validation to reject).
+        :returns: The input unchanged when every matched value validates.
+        :raises ValueError: When a matching property's value does not validate.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        for name, value in data.items():
+            for pattern, adapter in self._get_compiled():
+                # ECMA-262 `patternProperties` is unanchored; `re.search` matches anywhere.
+                if not pattern.search(str(name)):
+                    continue
+                try:
+                    adapter.validate_python(value)
+                except ValidationError:
+                    msg = f"Property `{name}` does not satisfy its `patternProperties` schema"
+                    raise ValueError(msg) from None
+
+        return data

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -41,6 +41,7 @@ from ._dependent_schemas import DependentSchemas
 from ._if_then_else import IfThenElse
 from ._not import Not
 from ._one_of import OneOf
+from ._pattern_properties import PatternProperties
 from ._prefix_items import PrefixItems
 from ._utils import sanitize_identifier
 from .exceptions import SchemaConversionError, SchemaReferenceError
@@ -273,6 +274,14 @@ def _dependent_required_validator(schema: Schema, /) -> PythonType | None:
     return model_validator(mode="before")(_check)
 
 
+class _ForwardRefMarker(Protocol):
+    """A marker validator whose `ForwardRef` subschemas resolve via a bound namespace."""
+
+    def bind_namespace(self, namespace: dict[str, type[BaseModel]], /) -> None:
+        """Bind the namespace used to resolve `ForwardRef` subschemas."""
+        ...
+
+
 class _ObjectValidatorBuilder(Protocol):
     """Builds a `model_validator` for one object keyword, or `None` when the schema omits it."""
 
@@ -335,6 +344,7 @@ class SchemaConverter:
         self._not_validators: list[Not] = []
         self._dependent_schemas_validators: list[DependentSchemas] = []
         self._if_then_else_validators: list[IfThenElse] = []
+        self._pattern_properties_validators: list[PatternProperties] = []
 
     @staticmethod
     def _hash_schema(
@@ -384,34 +394,55 @@ class SchemaConverter:
 
         # Build model using common logic
         model = self._build_model(schema, model_name=model_name)
-
-        # A root object becomes a plain `BaseModel` (not a `RootModel`), so it bypasses the
-        # annotation path where whole-value assertions are otherwise attached — wrap it
-        # explicitly here. Every other shape (root non-object / dict-root, and all nested
-        # values) carries these via its annotation already.
-        if not issubclass(model, RootModel):
-            if schema.not_ is not MISSING:
-                model = self._wrap_root_not(model, schema)
-            if self._has_conditional(schema):
-                model = self._wrap_root_conditional(model, schema)
-
-        # Bind the forward-refs namespace so `OneOf` / `Contains` validators can resolve
-        # `ForwardRef` branches lazily at validation time.
-        namespace = self._get_forward_refs_namespace()
-        for one_of_validator in self._one_of_validators:
-            one_of_validator.bind_namespace(namespace)
-        for contains_validator in self._contains_validators:
-            contains_validator.bind_namespace(namespace)
-        for prefix_items_validator in self._prefix_items_validators:
-            prefix_items_validator.bind_namespace(namespace)
-        for not_validator in self._not_validators:
-            not_validator.bind_namespace(namespace)
-        for dependent_schemas_validator in self._dependent_schemas_validators:
-            dependent_schemas_validator.bind_namespace(namespace)
-        for if_then_else_validator in self._if_then_else_validators:
-            if_then_else_validator.bind_namespace(namespace)
+        model = self._wrap_root_value_assertions(model, schema)
+        self._bind_forward_refs()
 
         return model
+
+    def _wrap_root_value_assertions(
+        self,
+        model: type[BaseModel],
+        schema: Schema,
+        /,
+    ) -> type[BaseModel]:
+        """Attach `not` / `if` / `then` / `else` to a root object model.
+
+        A root object becomes a plain `BaseModel` (not a `RootModel`), so it bypasses the
+        annotation path where these whole-value assertions are otherwise attached. Every other
+        shape (root non-object / dict-root, and all nested values) carries them via its
+        annotation already.
+
+        :param model: The freshly built root model.
+        :param schema: The root schema.
+        :returns: The model, wrapped when it is a root object carrying whole-value assertions.
+        """
+        if issubclass(model, RootModel):
+            return model
+
+        if schema.not_ is not MISSING:
+            model = self._wrap_root_not(model, schema)
+        if self._has_conditional(schema):
+            model = self._wrap_root_conditional(model, schema)
+        return model
+
+    def _bind_forward_refs(self) -> None:
+        """Bind the forward-refs namespace into every marker validator.
+
+        Lets `OneOf` / `Contains` / `Not` / ... resolve `ForwardRef` branches lazily at
+        validation time, once the whole schema (including `$defs`) has been converted.
+        """
+        namespace = self._get_forward_refs_namespace()
+        markers: tuple[_ForwardRefMarker, ...] = (
+            *self._one_of_validators,
+            *self._contains_validators,
+            *self._prefix_items_validators,
+            *self._not_validators,
+            *self._dependent_schemas_validators,
+            *self._if_then_else_validators,
+            *self._pattern_properties_validators,
+        )
+        for marker in markers:
+            marker.bind_namespace(namespace)
 
     def _convert_nested_schema(
         self,
@@ -544,6 +575,7 @@ class SchemaConverter:
         # (subschemas need conversion + namespace binding) that the registry cannot build.
         validators = _build_object_validators(schema)
         validators.update(self._build_dependent_schemas_validators(schema))
+        validators.update(self._build_pattern_properties_validators(schema))
 
         # For some reason, `create_model` "accepts" `fields` values as `tuple[str, Any]`,
         # when in reality it accepts `tuple[type, FieldInfo]`
@@ -586,6 +618,35 @@ class SchemaConverter:
             return dependent_schemas.validate(data)
 
         return {"_validate_dependent_schemas": model_validator(mode="before")(_check)}
+
+    def _build_pattern_properties_validators(
+        self,
+        schema: Schema,
+        /,
+    ) -> dict[str, PythonType]:
+        """Build the `patternProperties` validator for an object model.
+
+        Registers the validator so its `ForwardRef` subschemas (a pattern value pointing at a
+        `$ref`) are namespace-bound after the whole schema is converted.
+
+        :param schema: Object schema.
+        :returns: A `__validators__` mapping (empty when `patternProperties` is absent).
+        """
+        if schema.pattern_properties is MISSING:
+            return {}
+
+        branches: dict[str, PythonType] = {}
+        for pattern, sub_schema in schema.pattern_properties.items():
+            with self._track_path(f"patternProperties.{pattern}"):
+                branches[pattern] = self._constrained_annotation(sub_schema)
+
+        pattern_properties = PatternProperties(branches=branches)
+        self._pattern_properties_validators.append(pattern_properties)
+
+        def _check(data: PythonType) -> PythonType:
+            return pattern_properties.validate(data)
+
+        return {"_validate_pattern_properties": model_validator(mode="before")(_check)}
 
     def _check_alias_target(
         self,

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2373,6 +2373,102 @@ class TestDependentSchemas:
         )
 
 
+class TestPatternProperties:
+    """Tests for `patternProperties` enforcement."""
+
+    def test_pattern_properties(self) -> None:
+        """Test values of matching property names are validated; non-matching are ignored."""
+        schema = Schema.model_validate(
+            {"type": "object", "patternProperties": {"^x-": {"type": "integer"}}}
+        )
+        model = to_model(schema)
+
+        # `x-count` matches and validates; `name` does not match -> ignored.
+        assert model.model_validate({"x-count": 5, "name": "a"}).model_dump() == snapshot(
+            {"x-count": 5, "name": "a"}
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"x-count": "nope"})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Property `x-count` does not satisfy its `patternProperties` schema",
+                    "input": {"x-count": "nope"},
+                }
+            ]
+        )
+
+        # Non-mapping input passes through and is rejected by type validation.
+        with pytest.raises(ValidationError):
+            model.model_validate("not a mapping")
+
+    def test_pattern_properties_with_declared(self) -> None:
+        """Test `patternProperties` alongside declared properties, with a constraint subschema."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"id": {"type": "integer"}},
+                "patternProperties": {"^meta_": {"type": "string", "minLength": 2}},
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"id": 1, "meta_x": "ab"}).model_dump() == snapshot(
+            {"id": 1, "meta_x": "ab"}
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"id": 1, "meta_x": "a"})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Property `meta_x` does not satisfy its `patternProperties` schema",
+                    "input": {"id": 1, "meta_x": "a"},
+                }
+            ]
+        )
+
+    def test_pattern_properties_ref(self) -> None:
+        """Test a `patternProperties` value pointing at a `$ref`."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "patternProperties": {"^p": {"$ref": "#/$defs/Point"}},
+                "$defs": {
+                    "Point": {
+                        "type": "object",
+                        "properties": {"k": {"type": "integer"}},
+                        "required": ["k"],
+                    },
+                },
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"p1": {"k": 1}}).model_dump() == snapshot({"p1": {"k": 1}})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"p1": {"no": 1}})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Property `p1` does not satisfy its `patternProperties` schema",
+                    "input": {"p1": {"no": 1}},
+                }
+            ]
+        )
+
+
 class TestPrefixItems:
     """Tests for `prefixItems` positional validation."""
 


### PR DESCRIPTION
## Summary

Make `to_model` enforce `patternProperties`: every property whose name matches a regex must have a value validating against that patterns subschema. Previously parsed onto `Schema` but ignored. Completes Tier 3 — all declared validation keywords are now enforced.

## What changed

- `_pattern_properties.py`: new `PatternProperties` validator. A `before` model validator that, for each instance key, validates the value against every pattern (`re.search`, unanchored per ECMA-262) whose subschema it matches. Subschemas may be `ForwardRef` (a pattern value pointing at a `$ref`), resolved lazily via `bind_namespace`.
- `converters.py`: `_build_pattern_properties_validators` merges the validator into the object model. Also refactored `convert_schema` (extracted `_wrap_root_value_assertions` and `_bind_forward_refs`, with a shared `_ForwardRefMarker` protocol) to keep it under the complexity limit.

LIMITATION: combined with `additionalProperties: false`, a pattern-matched extra key is still rejected by `extra="forbid"` — the generated model cannot express "allow keys matching this regex". Documented in Known Limitations.

## How tested

New `TestPatternProperties`: matching value validated / rejected, non-matching key ignored, alongside declared properties with a constraint subschema, non-mapping passthrough, and a `$ref` value subschema.

`just all` green — 718 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.