### PR TITLE
feat(converters): enforce `propertyNames` on object conversion

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -117,17 +117,15 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `dependentRequired`                          | conditionally required properties           | `before` validator                  |
 | `dependentSchemas`                           | conditionally applied object subschema      | `DependentSchemas` validator        |
 | `patternProperties`                          | regex-keyed property-value subschemas       | `PatternProperties` validator       |
+| `propertyNames`                              | schema every property name must match       | `PropertyNames` validator           |
 | `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
 
 ## Unsupported Keywords
 
-These keywords are parsed and preserved on the `Schema` model (declared fields, or `extra="allow"`
-for custom keywords) but do not yet affect the generated model's validation:
-
-| Keyword group | Ignored keywords                                                                                                 |
-|---------------|------------------------------------------------------------------------------------------------------------------|
-| objects       | `propertyNames`                                                                                                  |
+All JSON Schema 2020-12 validation and applicator keywords are now enforced on conversion.
+Unknown or custom keywords are still parsed and preserved on the `Schema` model (`extra="allow"`)
+but do not affect the generated model.
 
 ## Known Limitations
 

--- a/pydantic_jsonschema/_property_names.py
+++ b/pydantic_jsonschema/_property_names.py
@@ -1,0 +1,95 @@
+"""JSON Schema `propertyNames` validator.
+
+See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.4
+"""
+
+from typing import Any, ForwardRef
+
+from pydantic import (
+    BaseModel,
+    TypeAdapter,
+    ValidationError,
+)
+
+__all__ = ["PropertyNames"]
+
+# Type aliases
+type AnnotationType = (
+    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
+)
+
+
+class PropertyNames:
+    """Enforce JSON Schema `propertyNames`: every property name must match the subschema.
+
+    Property names are always strings, so the subschema typically constrains the string (a
+    `pattern`, `maxLength`, `enum`, ...). Used from a `before` model validator on object models;
+    the subschema may be a `ForwardRef` (pointing at a `$ref`), resolved lazily via
+    `bind_namespace`.
+    """
+
+    def __init__(
+        self,
+        *,
+        branch: AnnotationType,
+    ) -> None:
+        """Initialize with the `propertyNames` subschema annotation.
+
+        :param branch: The subschema every property name must validate against (may be a
+            `ForwardRef`).
+        """
+        self._branch: AnnotationType = branch
+        self._namespace: dict[str, type[BaseModel]] = {}
+        self._adapter: TypeAdapter[AnnotationType] | None = None
+
+    def bind_namespace(
+        self,
+        namespace: dict[str, type[BaseModel]],
+        /,
+    ) -> None:
+        """Provide the namespace used to resolve a `ForwardRef` subschema.
+
+        :param namespace: Mapping of sanitized reference names to models.
+        """
+        self._namespace = namespace
+
+    def _get_adapter(self) -> TypeAdapter[AnnotationType]:
+        """Build the subschema adapter, resolving a `ForwardRef` on first use.
+
+        :returns: A `TypeAdapter` for the `propertyNames` subschema.
+        """
+        # NOTE: Built lazily: at conversion time the subschema may be a `ForwardRef` that only
+        #       becomes resolvable after the whole schema (including `$defs`) is converted and
+        #       the namespace is bound via `bind_namespace`.
+        if self._adapter is None:
+            branch = (
+                self._namespace[self._branch.__forward_arg__]
+                if isinstance(self._branch, ForwardRef)
+                else self._branch
+            )
+            self._adapter = TypeAdapter(branch)
+        return self._adapter
+
+    def validate(
+        self,
+        data: AnnotationType,
+        /,
+    ) -> AnnotationType:
+        """Validate every property name against the subschema.
+
+        :param data: The raw input mapping (other input is left for type validation to reject).
+        :returns: The input unchanged when every name validates.
+        :raises ValueError: When a property name does not validate against the subschema.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        adapter = self._get_adapter()
+        for name in data:
+            try:
+                adapter.validate_python(name)
+            except ValidationError:
+                msg = f"Property name `{name}` does not satisfy the `propertyNames` schema"
+                raise ValueError(msg) from None
+
+        return data

--- a/pydantic_jsonschema/_schema.py
+++ b/pydantic_jsonschema/_schema.py
@@ -108,6 +108,8 @@ class Schema(BaseModel):
     """The `additionalProperties` keyword: schema/toggle for extra properties. [Core §10.3.2.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.3)."""
     pattern_properties: dict[str, SchemaOrRefType] | MISSING = MISSING
     """The `patternProperties` keyword: schemas for properties matching a regex. [Core §10.3.2.2](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2)."""
+    property_names: SchemaOrRefType | MISSING = MISSING
+    """The `propertyNames` keyword: schema every property name must match. [Core §10.3.2.4](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.4)."""
 
     required: list[str] | MISSING = MISSING
     """The `required` keyword: names of required properties. [Validation §6.5.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.3)."""

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -43,6 +43,7 @@ from ._not import Not
 from ._one_of import OneOf
 from ._pattern_properties import PatternProperties
 from ._prefix_items import PrefixItems
+from ._property_names import PropertyNames
 from ._utils import sanitize_identifier
 from .exceptions import SchemaConversionError, SchemaReferenceError
 from .types import DataType, Reference, Schema
@@ -345,6 +346,7 @@ class SchemaConverter:
         self._dependent_schemas_validators: list[DependentSchemas] = []
         self._if_then_else_validators: list[IfThenElse] = []
         self._pattern_properties_validators: list[PatternProperties] = []
+        self._property_names_validators: list[PropertyNames] = []
 
     @staticmethod
     def _hash_schema(
@@ -440,6 +442,7 @@ class SchemaConverter:
             *self._dependent_schemas_validators,
             *self._if_then_else_validators,
             *self._pattern_properties_validators,
+            *self._property_names_validators,
         )
         for marker in markers:
             marker.bind_namespace(namespace)
@@ -576,6 +579,7 @@ class SchemaConverter:
         validators = _build_object_validators(schema)
         validators.update(self._build_dependent_schemas_validators(schema))
         validators.update(self._build_pattern_properties_validators(schema))
+        validators.update(self._build_property_names_validators(schema))
 
         # For some reason, `create_model` "accepts" `fields` values as `tuple[str, Any]`,
         # when in reality it accepts `tuple[type, FieldInfo]`
@@ -647,6 +651,33 @@ class SchemaConverter:
             return pattern_properties.validate(data)
 
         return {"_validate_pattern_properties": model_validator(mode="before")(_check)}
+
+    def _build_property_names_validators(
+        self,
+        schema: Schema,
+        /,
+    ) -> dict[str, PythonType]:
+        """Build the `propertyNames` validator for an object model.
+
+        Registers the validator so its `ForwardRef` subschema (a `propertyNames` pointing at a
+        `$ref`) is namespace-bound after the whole schema is converted.
+
+        :param schema: Object schema.
+        :returns: A `__validators__` mapping (empty when `propertyNames` is absent).
+        """
+        if schema.property_names is MISSING:
+            return {}
+
+        with self._track_path("propertyNames"):
+            branch = self._constrained_annotation(schema.property_names)
+
+        property_names = PropertyNames(branch=branch)
+        self._property_names_validators.append(property_names)
+
+        def _check(data: PythonType) -> PythonType:
+            return property_names.validate(data)
+
+        return {"_validate_property_names": model_validator(mode="before")(_check)}
 
     def _check_alias_target(
         self,

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -2469,6 +2469,64 @@ class TestPatternProperties:
         )
 
 
+class TestPropertyNames:
+    """Tests for `propertyNames` enforcement."""
+
+    def test_property_names_pattern(self) -> None:
+        """Test every property name must match the `propertyNames` subschema."""
+        schema = Schema.model_validate({"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}})
+        model = to_model(schema)
+
+        assert model.model_validate({"foo": 1, "bar": 2}).model_dump() == snapshot(
+            {"foo": 1, "bar": 2}
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"Foo": 1})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Property name `Foo` does not satisfy the `propertyNames` schema",
+                    "input": {"Foo": 1},
+                }
+            ]
+        )
+
+        # Non-mapping input passes through and is rejected by type validation.
+        with pytest.raises(ValidationError):
+            model.model_validate("not a mapping")
+
+    def test_property_names_ref(self) -> None:
+        """Test a `propertyNames` subschema pointing at a `$ref`."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "propertyNames": {"$ref": "#/$defs/Name"},
+                "$defs": {"Name": {"type": "string", "enum": ["a", "b"]}},
+            }
+        )
+        model = to_model(schema)
+
+        assert model.model_validate({"a": 1, "b": 2}).model_dump() == snapshot({"a": 1, "b": 2})
+
+        with pytest.raises(ValidationError) as exc_info:
+            model.model_validate({"z": 1})
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": (),
+                    "msg": "Value error, Property name `z` does not satisfy the `propertyNames` schema",
+                    "input": {"z": 1},
+                }
+            ]
+        )
+
+
 class TestPrefixItems:
     """Tests for `prefixItems` positional validation."""
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -421,6 +421,17 @@ class TestSchemaObjectKeywords:
             }
         )
 
+    def test_property_names(self) -> None:
+        """Test `propertyNames` parsed as a nested `Schema`."""
+        schema = Schema.model_validate({"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}})
+        assert isinstance(schema.property_names, Schema)
+        assert schema.model_dump() == snapshot(
+            {
+                "type": DataType.OBJECT,
+                "propertyNames": {"pattern": "^[a-z]+$"},
+            }
+        )
+
     def test_min_max_properties(self) -> None:
         """Test `minProperties` / `maxProperties` parsed from camelCase."""
         schema = Schema.model_validate(


### PR DESCRIPTION
## Summary

Make `to_model` enforce `propertyNames`: every property name must validate against the subschema. This keyword was not even declared on `Schema` before. With it, every JSON Schema 2020-12 validation/applicator keyword is now enforced on conversion.

## What changed

- `Schema`: new `property_names` field (`propertyNames`, core §10.3.2.4).
- `_property_names.py`: new `PropertyNames` validator. A `before` model validator that validates every property name (always a string, so the subschema is typically a `pattern` / `maxLength` / `enum`) against the subschema. The subschema may be a `ForwardRef` (a `propertyNames` pointing at a `$ref`), resolved lazily via `bind_namespace`.
- `converters.py`: `_build_property_names_validators` merges the validator into the object model.

## How tested

- Round-trip test in `test_schema.py`.
- New `TestPropertyNames`: a `pattern` subschema (matching / rejected names), non-mapping passthrough, and a `$ref` subschema.

`just all` green — 721 tests, 100% coverage, `mypy` / `ruff` / `markdownlint` clean.