### PR TITLE
ci(docs): deploy to a single-commit `gh-pages` to stop repo bloat

### DIFF
--- a/justfile
+++ b/justfile
@@ -212,8 +212,26 @@ ci-build:
 # Build documentation in CI
 ci-docs-build: docs-build
 
-# Deploy versioned documentation and update `latest` alias in CI
-ci-docs-deploy version: _ci-configure-git (docs-deploy-version version) (docs-alias version "latest") (docs-set-default "latest")
+# Deploy versioned docs to a single-commit `gh-pages` in CI (history never grows).
+#
+# `mike` keeps every version in the `gh-pages` *tree*, but each `mike deploy --push` adds a
+# commit carrying a full site snapshot, so the branch history balloons over time. Instead we
+# deploy locally (no `--push`), then collapse the whole branch into one orphan commit and
+# force-push it — each release replaces `gh-pages` rather than appending to it.
+# See: https://github.com/ag2ai/ag2/pull/2989
+ci-docs-deploy version: _ci-configure-git
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Bring the existing versions local so `mike` preserves them in the new tree.
+    git fetch origin gh-pages:gh-pages 2>/dev/null || true
+    uv run mike deploy --update-aliases "{{version}}" latest
+    uv run mike set-default latest
+    # Squash the entire branch to one orphan commit, then replace the remote branch.
+    git checkout gh-pages
+    git checkout --orphan _gh_pages_squashed
+    git add --all
+    git commit --quiet --message "docs: deploy {{version}}"
+    git push --force origin _gh_pages_squashed:gh-pages
 
 # Generate release notes for CI
 ci-release-notes output:


### PR DESCRIPTION
## Summary

Versioned docs are deployed with `mike`, which keeps every version in the `gh-pages` *tree* but adds a commit carrying a full site snapshot on every `mike deploy --push`. Over many releases the `gh-pages` history balloons (the AG2 repo hit 4.4 GiB this way), slowing every `git clone`.

This reworks `ci-docs-deploy` so each release **replaces** `gh-pages` with a single commit instead of appending a snapshot — the branch history never grows.

## What changed

`ci-docs-deploy` (run from `release.yml` on a `v*` tag) now:

1. `git fetch origin gh-pages` — bring existing versions local so `mike` preserves them;
2. `mike deploy --update-aliases <version> latest` + `mike set-default latest` — **without** `--push` (commit the new version into the local `gh-pages` tree);
3. `git checkout --orphan` + commit + `git push --force` — collapse the whole branch to one orphan commit and replace the remote branch.

All versions stay in the tree; `gh-pages` stays at one commit. The first run also discards the already-accumulated history. Approach mirrors [ag2ai/ag2#2989](https://github.com/ag2ai/ag2/pull/2989).

Why not the `upload-pages-artifact` / `deploy-pages` artifact flow: it is stateless (no persistent store between deploys), so it cannot keep `mike`s accumulated versions without rebuilding every tagged version from source on each release — slower and fragile (old tags may no longer build).

`release.yml` already grants `contents: write` and checks out with `fetch-depth: 0`, so no workflow change is needed.

## Validation

This is a CI-only change that exercises a force-push to the live `gh-pages` branch, so it cannot be run locally — it will be validated on the next release tag. The `justfile` recipe parses (`just --show ci-docs-deploy`). Manual `docs-deploy*` recipes are left as-is as an escape hatch.