### PR TITLE
refactor(types): extract shared `AnnotationType`/`PythonType` into `_types`

### DIFF
--- a/pydantic_jsonschema/_markers/_contains.py
+++ b/pydantic_jsonschema/_markers/_contains.py
@@ -3,7 +3,7 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.3
 """
 
-from typing import Any, ForwardRef
+from typing import ForwardRef
 
 from pydantic import (
     BaseModel,
@@ -13,12 +13,9 @@ from pydantic import (
 )
 from pydantic_core import CoreSchema, core_schema
 
-__all__ = ["Contains"]
+from pydantic_jsonschema._types import AnnotationType
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
+__all__ = ["Contains"]
 
 
 class Contains:

--- a/pydantic_jsonschema/_markers/_dependent_schemas.py
+++ b/pydantic_jsonschema/_markers/_dependent_schemas.py
@@ -3,7 +3,7 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4
 """
 
-from typing import Any, ForwardRef
+from typing import ForwardRef
 
 from pydantic import (
     BaseModel,
@@ -11,12 +11,9 @@ from pydantic import (
     ValidationError,
 )
 
-__all__ = ["DependentSchemas"]
+from pydantic_jsonschema._types import AnnotationType
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
+__all__ = ["DependentSchemas"]
 
 
 class DependentSchemas:

--- a/pydantic_jsonschema/_markers/_if_then_else.py
+++ b/pydantic_jsonschema/_markers/_if_then_else.py
@@ -3,7 +3,7 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2
 """
 
-from typing import Any, ForwardRef
+from typing import ForwardRef
 
 from pydantic import (
     BaseModel,
@@ -13,12 +13,9 @@ from pydantic import (
 )
 from pydantic_core import CoreSchema, core_schema
 
-__all__ = ["IfThenElse"]
+from pydantic_jsonschema._types import AnnotationType
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
+__all__ = ["IfThenElse"]
 
 
 class IfThenElse:

--- a/pydantic_jsonschema/_markers/_not.py
+++ b/pydantic_jsonschema/_markers/_not.py
@@ -3,7 +3,7 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.4
 """
 
-from typing import Any, ForwardRef
+from typing import ForwardRef
 
 from pydantic import (
     BaseModel,
@@ -13,12 +13,9 @@ from pydantic import (
 )
 from pydantic_core import CoreSchema, core_schema
 
-__all__ = ["Not"]
+from pydantic_jsonschema._types import AnnotationType
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
+__all__ = ["Not"]
 
 
 class Not:

--- a/pydantic_jsonschema/_markers/_one_of.py
+++ b/pydantic_jsonschema/_markers/_one_of.py
@@ -4,7 +4,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3
 """
 
 from collections.abc import Iterable
-from typing import Annotated, Any, ForwardRef, Union
+from typing import Annotated, ForwardRef, Union
 
 from pydantic import (
     BaseModel,
@@ -16,12 +16,9 @@ from pydantic import (
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
-__all__ = ["OneOf"]
+from pydantic_jsonschema._types import AnnotationType
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
+__all__ = ["OneOf"]
 
 
 class OneOf:

--- a/pydantic_jsonschema/_markers/_pattern_properties.py
+++ b/pydantic_jsonschema/_markers/_pattern_properties.py
@@ -4,7 +4,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2
 """
 
 import re
-from typing import Any, ForwardRef
+from typing import ForwardRef
 
 from pydantic import (
     BaseModel,
@@ -12,12 +12,9 @@ from pydantic import (
     ValidationError,
 )
 
-__all__ = ["PatternProperties"]
+from pydantic_jsonschema._types import AnnotationType
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
+__all__ = ["PatternProperties"]
 
 
 class PatternProperties:

--- a/pydantic_jsonschema/_markers/_prefix_items.py
+++ b/pydantic_jsonschema/_markers/_prefix_items.py
@@ -4,7 +4,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.1
 """
 
 from collections.abc import Iterable
-from typing import Any, ForwardRef
+from typing import ForwardRef
 
 from pydantic import (
     BaseModel,
@@ -14,12 +14,9 @@ from pydantic import (
 )
 from pydantic_core import CoreSchema, core_schema
 
-__all__ = ["PrefixItems"]
+from pydantic_jsonschema._types import AnnotationType
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
+__all__ = ["PrefixItems"]
 
 
 class PrefixItems:

--- a/pydantic_jsonschema/_markers/_property_names.py
+++ b/pydantic_jsonschema/_markers/_property_names.py
@@ -3,7 +3,7 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.4
 """
 
-from typing import Any, ForwardRef
+from typing import ForwardRef
 
 from pydantic import (
     BaseModel,
@@ -11,12 +11,9 @@ from pydantic import (
     ValidationError,
 )
 
-__all__ = ["PropertyNames"]
+from pydantic_jsonschema._types import AnnotationType
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
+__all__ = ["PropertyNames"]
 
 
 class PropertyNames:

--- a/pydantic_jsonschema/_types.py
+++ b/pydantic_jsonschema/_types.py
@@ -1,0 +1,13 @@
+"""Shared type aliases used across the converter and the marker validators."""
+
+from typing import Any
+
+__all__ = [
+    "AnnotationType",
+    "PythonType",
+]
+
+# Any annotation Pydantic supports (`type`, `Annotated`, `Union`, `Literal`, `ForwardRef`, ...).
+type AnnotationType = Any
+# Any value or type Pydantic can validate or produce.
+type PythonType = Any

--- a/pydantic_jsonschema/converters.py
+++ b/pydantic_jsonschema/converters.py
@@ -46,6 +46,7 @@ from ._markers import (
     PrefixItems,
     PropertyNames,
 )
+from ._types import AnnotationType, PythonType
 from ._utils import sanitize_identifier
 from .exceptions import SchemaConversionError, SchemaReferenceError
 from .types import DataType, Reference, Schema
@@ -87,8 +88,6 @@ _DATA_TYPE_ANNOTATION_MAPPING: Final[dict[DataType, type]] = {
 type Ref = str  # Reference path like "#/$defs/User"
 type SchemaHash = str  # Schema cache key (JSON hash)
 type FormatName = str  # Format name like "date-time", "uuid"
-type AnnotationType = Any  # `type`, `Annotated`, `Union`, `Literal`, `ForwardRef`, etc.
-type PythonType = Any  # Anything that Pydantic supports
 type FieldKindType = Literal["required", "optional", "root"]  # How a field is used in a model
 type FormatValidatorType = (
     FormatValidator | type | TypeAliasType


### PR DESCRIPTION
Foundational refactor (2/8): kill the duplicated `type AnnotationType = Any` alias copy-pasted across the converter and all eight marker modules.

## What

- Add `pydantic_jsonschema/_types.py` with the two genuinely shared aliases: `AnnotationType` and `PythonType`.
- Remove the per-module local `AnnotationType` definitions in `converters.py` and every `_markers/*` module; import from `_types` instead (absolute import, per the `..`-ban in ruff).
- Drop the now-unused `Any` import from the marker modules.

## Why

One canonical home for the aliases instead of nine copies. Sets up the next PR (shared marker base class), which will lean on these.

## Validation

- `just lint` clean (ruff/mypy/codespell/markdownlint).
- `just test`: 721 passed, 100% coverage.