### PR TITLE
refactor(markers): add shared `SubschemaMarker` base for marker validators

### DIFF
--- a/pydantic_jsonschema/_markers/_base.py
+++ b/pydantic_jsonschema/_markers/_base.py
@@ -1,0 +1,77 @@
+"""Shared base for marker validators.
+
+Every marker validates values against one or more subschemas via a `TypeAdapter`. A subschema may
+be a `ForwardRef` (a keyword pointing at a `$ref`) that only becomes resolvable after the whole
+schema — including `$defs` — is converted. Markers therefore build their adapters lazily, and the
+converter binds a forward-ref namespace via `bind_namespace` once conversion finishes.
+"""
+
+from typing import Any, ForwardRef
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+__all__ = [
+    "AnnotationType",
+    "SubschemaMarker",
+]
+
+# Any annotation Pydantic supports (`type`, `Annotated`, `Union`, `Literal`, `ForwardRef`, ...).
+type AnnotationType = Any
+
+
+class SubschemaMarker:
+    """Base for validators that check values against `TypeAdapter`-wrapped subschemas.
+
+    Holds the forward-ref namespace and provides the shared plumbing: resolving a `ForwardRef`
+    subschema and building its adapter, and testing whether a value validates against an adapter.
+    Subclasses own their adapter caching (single / list / mapping), since the shape differs per
+    keyword.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with an empty forward-ref namespace (bound later via `bind_namespace`)."""
+        self._namespace: dict[str, type[BaseModel]] = {}
+
+    def bind_namespace(
+        self,
+        namespace: dict[str, type[BaseModel]],
+        /,
+    ) -> None:
+        """Provide the namespace used to resolve `ForwardRef` subschemas.
+
+        :param namespace: Mapping of sanitized reference names to models.
+        """
+        self._namespace = namespace
+
+    def _build_adapter(
+        self,
+        branch: AnnotationType,
+        /,
+    ) -> TypeAdapter[AnnotationType]:
+        """Build a `TypeAdapter` for a subschema, resolving a `ForwardRef` against the namespace.
+
+        :param branch: A subschema annotation, possibly a `ForwardRef`.
+        :returns: A `TypeAdapter` for the resolved subschema.
+        """
+        resolved: AnnotationType = (
+            self._namespace[branch.__forward_arg__] if isinstance(branch, ForwardRef) else branch
+        )
+        return TypeAdapter(resolved)
+
+    @staticmethod
+    def _validates(
+        adapter: TypeAdapter[AnnotationType],
+        value: AnnotationType,
+        /,
+    ) -> bool:
+        """Return whether a value validates against a subschema adapter.
+
+        :param adapter: The subschema adapter.
+        :param value: The raw input value.
+        :returns: `True` when the value validates.
+        """
+        try:
+            adapter.validate_python(value)
+        except ValidationError:
+            return False
+        return True

--- a/pydantic_jsonschema/_markers/_contains.py
+++ b/pydantic_jsonschema/_markers/_contains.py
@@ -3,25 +3,15 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.3
 """
 
-from typing import Any, ForwardRef
-
-from pydantic import (
-    BaseModel,
-    GetCoreSchemaHandler,
-    TypeAdapter,
-    ValidationError,
-)
+from pydantic import GetCoreSchemaHandler, TypeAdapter
 from pydantic_core import CoreSchema, core_schema
+
+from ._base import AnnotationType, SubschemaMarker
 
 __all__ = ["Contains"]
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
 
-
-class Contains:
+class Contains(SubschemaMarker):
     """Enforce JSON Schema `contains` / `minContains` / `maxContains` on an array.
 
     Counts how many array elements validate against the `contains` subschema and requires that
@@ -43,22 +33,11 @@ class Contains:
         :param min_contains: Minimum number of matching elements (`minContains`, default 1).
         :param max_contains: Maximum number of matching elements (`maxContains`), or `None`.
         """
+        super().__init__()
         self._branch: AnnotationType = branch
         self._min_contains: int = min_contains
         self._max_contains: int | None = max_contains
-        self._namespace: dict[str, type[BaseModel]] = {}
         self._adapter: TypeAdapter[AnnotationType] | None = None
-
-    def bind_namespace(
-        self,
-        namespace: dict[str, type[BaseModel]],
-        /,
-    ) -> None:
-        """Provide the namespace used to resolve a `ForwardRef` subschema.
-
-        :param namespace: Mapping of sanitized reference names to models.
-        """
-        self._namespace = namespace
 
     def __get_pydantic_core_schema__(
         self,
@@ -69,20 +48,12 @@ class Contains:
         return core_schema.no_info_after_validator_function(self._validate, handler(source_type))
 
     def _get_adapter(self) -> TypeAdapter[AnnotationType]:
-        """Build the `contains` adapter, resolving a `ForwardRef` subschema on first use.
+        """Build the `contains` adapter on first use (caches across calls).
 
         :returns: A `TypeAdapter` for the `contains` subschema.
         """
-        # NOTE: Built lazily: at conversion time the subschema may be a `ForwardRef` that only
-        #       becomes resolvable after the whole schema (including `$defs`) is converted and
-        #       the namespace is bound via `bind_namespace`.
         if self._adapter is None:
-            branch = (
-                self._namespace[self._branch.__forward_arg__]
-                if isinstance(self._branch, ForwardRef)
-                else self._branch
-            )
-            self._adapter = TypeAdapter(branch)
+            self._adapter = self._build_adapter(self._branch)
         return self._adapter
 
     def _matches(
@@ -95,11 +66,7 @@ class Contains:
         :param item: An array element (already parsed by the array's item type).
         :returns: `True` when the element validates against `contains`.
         """
-        try:
-            self._get_adapter().validate_python(item)
-        except ValidationError:
-            return False
-        return True
+        return self._validates(self._get_adapter(), item)
 
     def _validate(
         self,

--- a/pydantic_jsonschema/_markers/_dependent_schemas.py
+++ b/pydantic_jsonschema/_markers/_dependent_schemas.py
@@ -3,23 +3,14 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4
 """
 
-from typing import Any, ForwardRef
+from pydantic import TypeAdapter
 
-from pydantic import (
-    BaseModel,
-    TypeAdapter,
-    ValidationError,
-)
+from ._base import AnnotationType, SubschemaMarker
 
 __all__ = ["DependentSchemas"]
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
 
-
-class DependentSchemas:
+class DependentSchemas(SubschemaMarker):
     """Enforce JSON Schema `dependentSchemas`: a present property triggers a whole-object schema.
 
     For each `{property: subschema}` pair, when the property is present in the object the entire
@@ -38,37 +29,18 @@ class DependentSchemas:
         :param branches: Mapping of trigger property name to its subschema annotation (each may
             be a `ForwardRef`).
         """
+        super().__init__()
         self._branches: dict[str, AnnotationType] = dict(branches)
-        self._namespace: dict[str, type[BaseModel]] = {}
         self._adapters: dict[str, TypeAdapter[AnnotationType]] | None = None
 
-    def bind_namespace(
-        self,
-        namespace: dict[str, type[BaseModel]],
-        /,
-    ) -> None:
-        """Provide the namespace used to resolve `ForwardRef` subschemas.
-
-        :param namespace: Mapping of sanitized reference names to models.
-        """
-        self._namespace = namespace
-
     def _get_adapters(self) -> dict[str, TypeAdapter[AnnotationType]]:
-        """Build the per-trigger adapters, resolving `ForwardRef` subschemas on first use.
+        """Build the per-trigger adapters on first use (caches across calls).
 
         :returns: Mapping of trigger property name to its subschema `TypeAdapter`.
         """
-        # NOTE: Built lazily: at conversion time subschemas may be `ForwardRef`s that only become
-        #       resolvable after the whole schema (including `$defs`) is converted and the
-        #       namespace is bound via `bind_namespace`.
         if self._adapters is None:
             self._adapters = {
-                trigger: TypeAdapter(
-                    self._namespace[branch.__forward_arg__]
-                    if isinstance(branch, ForwardRef)
-                    else branch
-                )
-                for trigger, branch in self._branches.items()
+                trigger: self._build_adapter(branch) for trigger, branch in self._branches.items()
             }
         return self._adapters
 
@@ -89,10 +61,8 @@ class DependentSchemas:
         for trigger, adapter in self._get_adapters().items():
             if trigger not in data:
                 continue
-            try:
-                adapter.validate_python(data)
-            except ValidationError:
+            if not self._validates(adapter, data):
                 msg = f"Property `{trigger}` does not satisfy its `dependentSchemas` schema"
-                raise ValueError(msg) from None
+                raise ValueError(msg)
 
         return data

--- a/pydantic_jsonschema/_markers/_if_then_else.py
+++ b/pydantic_jsonschema/_markers/_if_then_else.py
@@ -3,25 +3,15 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2
 """
 
-from typing import Any, ForwardRef
-
-from pydantic import (
-    BaseModel,
-    GetCoreSchemaHandler,
-    TypeAdapter,
-    ValidationError,
-)
+from pydantic import GetCoreSchemaHandler, TypeAdapter
 from pydantic_core import CoreSchema, core_schema
+
+from ._base import AnnotationType, SubschemaMarker
 
 __all__ = ["IfThenElse"]
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
 
-
-class IfThenElse:
+class IfThenElse(SubschemaMarker):
     """Enforce JSON Schema `if` / `then` / `else` conditional application.
 
     If the instance validates against `if`, it must also validate against `then`; otherwise it
@@ -45,24 +35,13 @@ class IfThenElse:
         :param then_branch: The `then` subschema applied on a match, or `None`.
         :param else_branch: The `else` subschema applied on no match, or `None`.
         """
+        super().__init__()
         self._if: AnnotationType = if_branch
         self._then: AnnotationType | None = then_branch
         self._else: AnnotationType | None = else_branch
-        self._namespace: dict[str, type[BaseModel]] = {}
         self._if_adapter: TypeAdapter[AnnotationType] | None = None
         self._then_adapter: TypeAdapter[AnnotationType] | None = None
         self._else_adapter: TypeAdapter[AnnotationType] | None = None
-
-    def bind_namespace(
-        self,
-        namespace: dict[str, type[BaseModel]],
-        /,
-    ) -> None:
-        """Provide the namespace used to resolve `ForwardRef` subschemas.
-
-        :param namespace: Mapping of sanitized reference names to models.
-        """
-        self._namespace = namespace
 
     def __get_pydantic_core_schema__(
         self,
@@ -72,54 +51,21 @@ class IfThenElse:
         """Wrap the value schema with the conditional check (on the raw input)."""
         return core_schema.no_info_wrap_validator_function(self._validate, handler(source_type))
 
-    def _resolve(
-        self,
-        branch: AnnotationType,
-        /,
-    ) -> AnnotationType:
-        """Resolve a `ForwardRef` subschema against the bound namespace.
-
-        :param branch: A subschema annotation, possibly a `ForwardRef`.
-        :returns: The resolved model, or the annotation unchanged.
-        """
-        return self._namespace[branch.__forward_arg__] if isinstance(branch, ForwardRef) else branch
-
     def _build_adapters(self) -> TypeAdapter[AnnotationType]:
-        """Build the `if` / `then` / `else` adapters, resolving `ForwardRef`s on first use.
+        """Build the `if` / `then` / `else` adapters on first use (caches across calls).
 
         :returns: The `if` adapter (always present).
         """
-        # NOTE: Built lazily: at conversion time subschemas may be `ForwardRef`s that only become
-        #       resolvable after the whole schema (including `$defs`) is converted and the
-        #       namespace is bound via `bind_namespace`.
         if self._if_adapter is not None:
             return self._if_adapter
 
-        if_adapter: TypeAdapter[AnnotationType] = TypeAdapter(self._resolve(self._if))
+        if_adapter: TypeAdapter[AnnotationType] = self._build_adapter(self._if)
         self._if_adapter = if_adapter
         if self._then is not None:
-            self._then_adapter = TypeAdapter(self._resolve(self._then))
+            self._then_adapter = self._build_adapter(self._then)
         if self._else is not None:
-            self._else_adapter = TypeAdapter(self._resolve(self._else))
+            self._else_adapter = self._build_adapter(self._else)
         return if_adapter
-
-    @staticmethod
-    def _matches(
-        adapter: TypeAdapter[AnnotationType],
-        value: AnnotationType,
-        /,
-    ) -> bool:
-        """Return whether a value validates against a subschema adapter.
-
-        :param adapter: The subschema adapter.
-        :param value: The raw input value.
-        :returns: `True` when the value validates.
-        """
-        try:
-            adapter.validate_python(value)
-        except ValidationError:
-            return False
-        return True
 
     def check(
         self,
@@ -134,11 +80,11 @@ class IfThenElse:
         """
         if_adapter = self._build_adapters()
 
-        if self._matches(if_adapter, value):
-            if self._then_adapter is not None and not self._matches(self._then_adapter, value):
+        if self._validates(if_adapter, value):
+            if self._then_adapter is not None and not self._validates(self._then_adapter, value):
                 msg = "Value matches `if` but not `then`"
                 raise ValueError(msg)
-        elif self._else_adapter is not None and not self._matches(self._else_adapter, value):
+        elif self._else_adapter is not None and not self._validates(self._else_adapter, value):
             msg = "Value does not match `if` and not `else`"
             raise ValueError(msg)
 

--- a/pydantic_jsonschema/_markers/_not.py
+++ b/pydantic_jsonschema/_markers/_not.py
@@ -3,25 +3,15 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.4
 """
 
-from typing import Any, ForwardRef
-
-from pydantic import (
-    BaseModel,
-    GetCoreSchemaHandler,
-    TypeAdapter,
-    ValidationError,
-)
+from pydantic import GetCoreSchemaHandler, TypeAdapter
 from pydantic_core import CoreSchema, core_schema
+
+from ._base import AnnotationType, SubschemaMarker
 
 __all__ = ["Not"]
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
 
-
-class Not:
+class Not(SubschemaMarker):
     """Enforce JSON Schema `not`: the instance must NOT validate against the subschema.
 
     Used two ways, both checking the *raw* input (before the host type coerces it):
@@ -44,20 +34,9 @@ class Not:
 
         :param branch: The `not` subschema annotation (may be a `ForwardRef`).
         """
+        super().__init__()
         self._branch: AnnotationType = branch
-        self._namespace: dict[str, type[BaseModel]] = {}
         self._adapter: TypeAdapter[AnnotationType] | None = None
-
-    def bind_namespace(
-        self,
-        namespace: dict[str, type[BaseModel]],
-        /,
-    ) -> None:
-        """Provide the namespace used to resolve a `ForwardRef` subschema.
-
-        :param namespace: Mapping of sanitized reference names to models.
-        """
-        self._namespace = namespace
 
     def __get_pydantic_core_schema__(
         self,
@@ -77,27 +56,15 @@ class Not:
         :param value: The raw input value.
         :returns: `True` when the value validates against `not` (and so must be rejected).
         """
-        try:
-            self._get_adapter().validate_python(value)
-        except ValidationError:
-            return False
-        return True
+        return self._validates(self._get_adapter(), value)
 
     def _get_adapter(self) -> TypeAdapter[AnnotationType]:
-        """Build the `not` adapter, resolving a `ForwardRef` subschema on first use.
+        """Build the `not` adapter on first use (caches across calls).
 
         :returns: A `TypeAdapter` for the `not` subschema.
         """
-        # NOTE: Built lazily: at conversion time the subschema may be a `ForwardRef` that only
-        #       becomes resolvable after the whole schema (including `$defs`) is converted and
-        #       the namespace is bound via `bind_namespace`.
         if self._adapter is None:
-            branch = (
-                self._namespace[self._branch.__forward_arg__]
-                if isinstance(self._branch, ForwardRef)
-                else self._branch
-            )
-            self._adapter = TypeAdapter(branch)
+            self._adapter = self._build_adapter(self._branch)
         return self._adapter
 
     def _validate(

--- a/pydantic_jsonschema/_markers/_one_of.py
+++ b/pydantic_jsonschema/_markers/_one_of.py
@@ -4,27 +4,18 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3
 """
 
 from collections.abc import Iterable
-from typing import Annotated, Any, ForwardRef, Union
+from typing import Annotated, Union
 
-from pydantic import (
-    BaseModel,
-    GetCoreSchemaHandler,
-    GetJsonSchemaHandler,
-    TypeAdapter,
-    ValidationError,
-)
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
+from ._base import AnnotationType, SubschemaMarker
+
 __all__ = ["OneOf"]
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
 
-
-class OneOf:
+class OneOf(SubschemaMarker):
     """Enforce JSON Schema `oneOf` semantics: exactly one branch must match.
 
     Python `Union` accepts a value when *any* branch matches (`anyOf` semantics),
@@ -41,8 +32,8 @@ class OneOf:
 
         :param branches: Union branch annotations (may contain `ForwardRef`).
         """
+        super().__init__()
         self._branches: tuple[AnnotationType, ...] = tuple(branches)
-        self._namespace: dict[str, type[BaseModel]] = {}
         self._adapters: list[TypeAdapter[AnnotationType]] | None = None
 
     def as_annotation(self) -> AnnotationType:
@@ -56,17 +47,6 @@ class OneOf:
         """
         union_annotation = Union[self._branches]  # type: ignore[name-defined]  # noqa: UP007
         return Annotated[union_annotation, self]
-
-    def bind_namespace(
-        self,
-        namespace: dict[str, type[BaseModel]],
-        /,
-    ) -> None:
-        """Provide the namespace used to resolve `ForwardRef` branches.
-
-        :param namespace: Mapping of sanitized reference names to models.
-        """
-        self._namespace = namespace
 
     def __get_pydantic_core_schema__(
         self,
@@ -88,22 +68,12 @@ class OneOf:
         return json_schema
 
     def _get_adapters(self) -> list[TypeAdapter[AnnotationType]]:
-        """Build branch adapters, resolving `ForwardRef` branches on first use.
+        """Build branch adapters on first use (caches across calls).
 
         :returns: One `TypeAdapter` per `oneOf` branch.
         """
-        # NOTE: Adapters are built lazily: at conversion time branches may contain
-        #       `ForwardRef` entries that only become resolvable after the whole
-        #       schema (including `$defs`) has been converted and the namespace
-        #       has been bound via `bind_namespace`.
         if self._adapters is None:
-            resolved_branches = [
-                self._namespace[branch.__forward_arg__]
-                if isinstance(branch, ForwardRef)
-                else branch
-                for branch in self._branches
-            ]
-            self._adapters = [TypeAdapter(branch) for branch in resolved_branches]
+            self._adapters = [self._build_adapter(branch) for branch in self._branches]
         return self._adapters
 
     def _validate(
@@ -118,14 +88,9 @@ class OneOf:
         :returns: Validated value.
         :raises ValueError: If the value does not match exactly one branch.
         """
-        matched_count: int = 0
-        for adapter in self._get_adapters():
-            try:
-                adapter.validate_python(value)
-            except ValidationError:
-                continue
-            else:
-                matched_count += 1
+        matched_count: int = sum(
+            1 for adapter in self._get_adapters() if self._validates(adapter, value)
+        )
 
         if matched_count != 1:
             msg = f"Input matches {matched_count} `oneOf` branches, expected exactly 1"

--- a/pydantic_jsonschema/_markers/_pattern_properties.py
+++ b/pydantic_jsonschema/_markers/_pattern_properties.py
@@ -4,23 +4,15 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2
 """
 
 import re
-from typing import Any, ForwardRef
 
-from pydantic import (
-    BaseModel,
-    TypeAdapter,
-    ValidationError,
-)
+from pydantic import TypeAdapter
+
+from ._base import AnnotationType, SubschemaMarker
 
 __all__ = ["PatternProperties"]
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
 
-
-class PatternProperties:
+class PatternProperties(SubschemaMarker):
     """Enforce JSON Schema `patternProperties`: regex-keyed property-value subschemas.
 
     Every property whose name matches a regex must have a value validating against that regex's
@@ -39,39 +31,18 @@ class PatternProperties:
         :param branches: Mapping of regex (`patternProperties` key) to its value subschema
             annotation (each may be a `ForwardRef`).
         """
+        super().__init__()
         self._branches: dict[str, AnnotationType] = dict(branches)
-        self._namespace: dict[str, type[BaseModel]] = {}
         self._compiled: list[tuple[re.Pattern[str], TypeAdapter[AnnotationType]]] | None = None
 
-    def bind_namespace(
-        self,
-        namespace: dict[str, type[BaseModel]],
-        /,
-    ) -> None:
-        """Provide the namespace used to resolve `ForwardRef` subschemas.
-
-        :param namespace: Mapping of sanitized reference names to models.
-        """
-        self._namespace = namespace
-
     def _get_compiled(self) -> list[tuple[re.Pattern[str], TypeAdapter[AnnotationType]]]:
-        """Compile the patterns and build the value adapters, resolving `ForwardRef`s on first use.
+        """Compile the patterns and build the value adapters on first use (caches across calls).
 
         :returns: A list of `(compiled regex, value adapter)` pairs.
         """
-        # NOTE: Built lazily: at conversion time subschemas may be `ForwardRef`s that only become
-        #       resolvable after the whole schema (including `$defs`) is converted and the
-        #       namespace is bound via `bind_namespace`.
         if self._compiled is None:
             self._compiled = [
-                (
-                    re.compile(pattern),
-                    TypeAdapter(
-                        self._namespace[branch.__forward_arg__]
-                        if isinstance(branch, ForwardRef)
-                        else branch
-                    ),
-                )
+                (re.compile(pattern), self._build_adapter(branch))
                 for pattern, branch in self._branches.items()
             ]
         return self._compiled
@@ -95,10 +66,8 @@ class PatternProperties:
                 # ECMA-262 `patternProperties` is unanchored; `re.search` matches anywhere.
                 if not pattern.search(str(name)):
                     continue
-                try:
-                    adapter.validate_python(value)
-                except ValidationError:
+                if not self._validates(adapter, value):
                     msg = f"Property `{name}` does not satisfy its `patternProperties` schema"
-                    raise ValueError(msg) from None
+                    raise ValueError(msg)
 
         return data

--- a/pydantic_jsonschema/_markers/_prefix_items.py
+++ b/pydantic_jsonschema/_markers/_prefix_items.py
@@ -4,25 +4,16 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.1
 """
 
 from collections.abc import Iterable
-from typing import Any, ForwardRef
 
-from pydantic import (
-    BaseModel,
-    GetCoreSchemaHandler,
-    TypeAdapter,
-    ValidationError,
-)
+from pydantic import GetCoreSchemaHandler, TypeAdapter, ValidationError
 from pydantic_core import CoreSchema, core_schema
+
+from ._base import AnnotationType, SubschemaMarker
 
 __all__ = ["PrefixItems"]
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
 
-
-class PrefixItems:
+class PrefixItems(SubschemaMarker):
     """Enforce JSON Schema `prefixItems`: positional (tuple-style) array validation.
 
     Element `i` is validated against `prefixItems[i]`; elements past the prefix are validated
@@ -43,22 +34,11 @@ class PrefixItems:
         :param tail: The `items` annotation for elements past the prefix, or `None` when `items`
             is absent (extra elements are then unconstrained).
         """
+        super().__init__()
         self._prefixes: tuple[AnnotationType, ...] = tuple(prefixes)
         self._tail: AnnotationType | None = tail
-        self._namespace: dict[str, type[BaseModel]] = {}
         self._prefix_adapters: list[TypeAdapter[AnnotationType]] | None = None
         self._tail_adapter: TypeAdapter[AnnotationType] | None = None
-
-    def bind_namespace(
-        self,
-        namespace: dict[str, type[BaseModel]],
-        /,
-    ) -> None:
-        """Provide the namespace used to resolve `ForwardRef` subschemas.
-
-        :param namespace: Mapping of sanitized reference names to models.
-        """
-        self._namespace = namespace
 
     def __get_pydantic_core_schema__(
         self,
@@ -68,29 +48,12 @@ class PrefixItems:
         """Wrap the array schema with positional validation."""
         return core_schema.no_info_after_validator_function(self._validate, handler(source_type))
 
-    def _resolve(
-        self,
-        branch: AnnotationType,
-        /,
-    ) -> AnnotationType:
-        """Resolve a `ForwardRef` subschema against the bound namespace.
-
-        :param branch: A subschema annotation, possibly a `ForwardRef`.
-        :returns: The resolved model, or the annotation unchanged.
-        """
-        return self._namespace[branch.__forward_arg__] if isinstance(branch, ForwardRef) else branch
-
     def _build_adapters(self) -> None:
-        """Build the per-position and tail adapters, resolving `ForwardRef`s on first use."""
-        # NOTE: Built lazily: at conversion time subschemas may be `ForwardRef`s that only
-        #       become resolvable after the whole schema (including `$defs`) is converted and
-        #       the namespace is bound via `bind_namespace`.
+        """Build the per-position and tail adapters on first use (caches across calls)."""
         if self._prefix_adapters is None:
-            self._prefix_adapters = [
-                TypeAdapter(self._resolve(branch)) for branch in self._prefixes
-            ]
+            self._prefix_adapters = [self._build_adapter(branch) for branch in self._prefixes]
             if self._tail is not None:
-                self._tail_adapter = TypeAdapter(self._resolve(self._tail))
+                self._tail_adapter = self._build_adapter(self._tail)
 
     def _validate(
         self,

--- a/pydantic_jsonschema/_markers/_property_names.py
+++ b/pydantic_jsonschema/_markers/_property_names.py
@@ -3,23 +3,14 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.4
 """
 
-from typing import Any, ForwardRef
+from pydantic import TypeAdapter
 
-from pydantic import (
-    BaseModel,
-    TypeAdapter,
-    ValidationError,
-)
+from ._base import AnnotationType, SubschemaMarker
 
 __all__ = ["PropertyNames"]
 
-# Type aliases
-type AnnotationType = (
-    Any  # Any annotation Pydantic supports (`type`, `Annotated`, `ForwardRef`, ...)
-)
 
-
-class PropertyNames:
+class PropertyNames(SubschemaMarker):
     """Enforce JSON Schema `propertyNames`: every property name must match the subschema.
 
     Property names are always strings, so the subschema typically constrains the string (a
@@ -38,36 +29,17 @@ class PropertyNames:
         :param branch: The subschema every property name must validate against (may be a
             `ForwardRef`).
         """
+        super().__init__()
         self._branch: AnnotationType = branch
-        self._namespace: dict[str, type[BaseModel]] = {}
         self._adapter: TypeAdapter[AnnotationType] | None = None
 
-    def bind_namespace(
-        self,
-        namespace: dict[str, type[BaseModel]],
-        /,
-    ) -> None:
-        """Provide the namespace used to resolve a `ForwardRef` subschema.
-
-        :param namespace: Mapping of sanitized reference names to models.
-        """
-        self._namespace = namespace
-
     def _get_adapter(self) -> TypeAdapter[AnnotationType]:
-        """Build the subschema adapter, resolving a `ForwardRef` on first use.
+        """Build the subschema adapter on first use (caches across calls).
 
         :returns: A `TypeAdapter` for the `propertyNames` subschema.
         """
-        # NOTE: Built lazily: at conversion time the subschema may be a `ForwardRef` that only
-        #       becomes resolvable after the whole schema (including `$defs`) is converted and
-        #       the namespace is bound via `bind_namespace`.
         if self._adapter is None:
-            branch = (
-                self._namespace[self._branch.__forward_arg__]
-                if isinstance(self._branch, ForwardRef)
-                else self._branch
-            )
-            self._adapter = TypeAdapter(branch)
+            self._adapter = self._build_adapter(self._branch)
         return self._adapter
 
     def validate(
@@ -86,10 +58,8 @@ class PropertyNames:
 
         adapter = self._get_adapter()
         for name in data:
-            try:
-                adapter.validate_python(name)
-            except ValidationError:
+            if not self._validates(adapter, name):
                 msg = f"Property name `{name}` does not satisfy the `propertyNames` schema"
-                raise ValueError(msg) from None
+                raise ValueError(msg)
 
         return data


### PR DESCRIPTION
Refactor (3/8): factor the duplicated marker plumbing into one base class. Replaces the abandoned `_types.py` idea (#24) — the shared `AnnotationType` now lives in the base-class module, and `PythonType` stays local to `converters.py`.

## What

- Add `pydantic_jsonschema/_markers/_base.py` with `SubschemaMarker`:
  - holds the forward-ref `namespace` + `bind_namespace`;
  - `_build_adapter(branch)` — resolves a `ForwardRef` against the namespace and builds its `TypeAdapter`;
  - `_validates(adapter, value)` — the shared `try/validate/except ValidationError -> bool`.
  - also exports the shared `AnnotationType` alias.
- Refactor all eight markers to inherit from it, removing the per-class copies of: the `AnnotationType` alias, `_namespace` field, `bind_namespace`, the `ForwardRef`-resolution snippet, and the `try/except ValidationError` bool check. Each marker keeps only its own adapter caching (single / list / mapping) and keyword logic.

## Why

The lazy-adapter + `ForwardRef` resolution + `matches` boilerplate was copy-pasted across every marker. One canonical home now; net ~40 fewer statements. No behavior change.

## Validation

- `just lint` clean (ruff/mypy/codespell/markdownlint).
- `just test`: 721 passed, 100% coverage.