### PR TITLE
ci(github): cancel superseded runs via a `concurrency` group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs: a new push to the same ref aborts the in-flight run for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   pull-requests: read
 
+# Cancel superseded runs: a new push to the same ref aborts the in-flight run for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   title:
     name: Validate PR title


### PR DESCRIPTION
Add a `concurrency` group with `cancel-in-progress: true` to the push/PR workflows so a new push to a ref aborts the in-flight run for that ref.

## What

- `ci.yml` and `pr.yml` each gain:
  ```yaml
  concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true
  ```

## Why

Neither workflow declared `concurrency`, so each re-push to a branch/PR started a full duplicate run and never cancelled the superseded one. `ci.yml` fans out to 6 jobs per run (lint + docs + a 4-way `test` matrix `3.12`/`3.13`/`3.14`/`3.15`), so rapid pushes multiplied wasted runner minutes. Keyed on `github.ref`, each ref cancels only its own superseded run.

## Validation

- CI-only change; `check-yaml` pre-commit hook passes. Effective on the next push/PR.