### PR TITLE
docs(applicators): add applicators guide and API page

### DIFF
--- a/docs/api/applicators.md
+++ b/docs/api/applicators.md
@@ -1,0 +1,6 @@
+# Applicators
+
+For the concepts behind these classes — what an applicator is and why it is named that — see the
+[Applicators guide](../applicators.md).
+
+::: pydantic_jsonschema._applicators

--- a/docs/api/one_of.md
+++ b/docs/api/one_of.md
@@ -1,5 +1,0 @@
-# OneOf
-
-The validator behind the converter's `oneOf` support — also usable on your own unions.
-
-::: pydantic_jsonschema.OneOf

--- a/docs/applicators.md
+++ b/docs/applicators.md
@@ -1,0 +1,89 @@
+# Applicators
+
+In JSON Schema, a keyword whose value is *itself a schema* (or schemas) is called an
+**applicator**: it applies those subschemas to the instance — or to its array items, object
+property values, or property names — and the instance is valid only if those subschemas are
+satisfied. The term and the grouping are the spec's own, from
+[core §10, "A Vocabulary for Applying Subschemas"][applicator-vocab].
+
+`pydantic-jsonschema` represents the applicators that have **no native Pydantic equivalent** as a
+small set of validator classes in `pydantic_jsonschema._applicators`. The
+[converter](converters.md) builds them while turning a `Schema` into a model, and you can also use
+them directly on your own Pydantic models.
+
+## Why "applicators", not "validators" or "markers"
+
+- **`validators`** is too broad. The package already has *format validators* and *field
+  constraints*; "validator" says nothing about the trait that sets these apart — *applying a
+  subschema*.
+- **`markers`** described only the implementation: an `Annotated[T, ...]` metadata object. But
+  several of these run as `before` model validators rather than `Annotated` markers — so the name
+  was both narrower and less accurate than the behaviour.
+- **`applicators`** is the exact word the JSON Schema spec uses for this category. The library
+  speaks JSON Schema everywhere else, so it speaks it here too.
+
+## Supported applicators
+
+| Keyword | Class | Applies a subschema to… |
+| --- | --- | --- |
+| `not` | `Not` | the whole instance (it must *not* match) |
+| `oneOf` | `OneOf` | the whole instance (exactly one branch matches) |
+| `if` / `then` / `else` | `IfThenElse` | the whole instance, conditionally |
+| `dependentSchemas` | `DependentSchemas` | the whole instance, when a property is present |
+| `contains` | `Contains` | array items (at least / at most N match) |
+| `prefixItems` | `PrefixItems` | array items by position |
+| `patternProperties` | `PatternProperties` | property values whose name matches a regex |
+| `propertyNames` | `PropertyNames` | every property name |
+
+The first four are *in-place* applicators (they apply to the whole instance); the last four are
+*child* applicators (they apply to items, property values, or names).
+
+## What is not here
+
+`allOf`, `anyOf`, `properties`, `items`, and `additionalProperties` are applicators too, but each
+has a native Pydantic equivalent — inheritance, `Union`, and model fields — so the converter
+expresses them directly instead of through a class here. See the
+[conversion map](converters.md#conversion-map).
+
+## How they work
+
+Each applicator holds one or more subschema annotations and validates a value against them with a
+Pydantic `TypeAdapter`. A subschema may be a `ForwardRef` pointing at a `$ref` that only becomes
+resolvable once the whole schema — including `$defs` — is converted, so applicators build their
+adapters lazily and receive a forward-reference namespace via `bind_namespace` after conversion
+finishes.
+
+Depending on the keyword, the converter attaches an applicator either as `Annotated` metadata on
+the field type or as a `before` model validator on the model.
+
+## Using an applicator directly
+
+The applicator classes are not converter-internal — you can build a validated annotation from one
+directly. `OneOf`, for example, enforces JSON Schema `oneOf` semantics (*exactly one* branch must
+match), unlike a plain `Union`:
+
+```python title="applicator_one_of.py"
+from pydantic import TypeAdapter, ValidationError
+
+from pydantic_jsonschema._applicators import OneOf
+
+one_of = OneOf(branches=[int, float])
+adapter = TypeAdapter(one_of.as_annotation())
+
+print(adapter.validate_python(1.5))
+#> 1.5
+
+try:
+    # `1` validates as both `int` and `float` -> two branches, not exactly one
+    adapter.validate_python(1)
+except ValidationError as er:
+    print(er.errors()[0]["msg"])
+    #> Value error, Input matches 2 `oneOf` branches, expected exactly 1
+```
+
+## Reference
+
+See the [Applicators API](api/applicators.md) for every class, and
+[core §10, "A Vocabulary for Applying Subschemas"][applicator-vocab] for the spec.
+
+[applicator-vocab]: https://json-schema.org/draft/2020-12/json-schema-core#section-10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,12 +76,13 @@ nav:
   - Installation: install.md
   - Schema: schema.md
   - Converters: converters.md
+  - Applicators: applicators.md
   - Format Validators: formats.md
   - Examples: examples.md
   - API Reference:
     - Schema model: api/types.md
     - Converters: api/converters.md
-    - OneOf: api/one_of.md
+    - Applicators: api/applicators.md
     - Format validators: api/formats.md
     - Exceptions: api/exceptions.md
   - Development:


### PR DESCRIPTION
Adds a dedicated documentation section for applicators — what they are, how they work, and **why** they are named that.

## What

- **`docs/applicators.md`** (guide): defines *applicator* using the spec's own term, explains why the name beats `validators`/`markers`, tables the supported keywords → classes (in-place vs child), notes which applicators are handled natively by Pydantic instead, describes the lazy-`TypeAdapter` / `ForwardRef` / `bind_namespace` mechanics, and shows a runnable `OneOf` example. Links [core §10][spec].
- **`docs/api/applicators.md`** (API): renders the whole `pydantic_jsonschema._applicators` module (all classes + the `Applicator` base) via mkdocstrings; replaces the old single-class `api/one_of.md`.
- **`mkdocs.yml`**: adds *Applicators* to the main nav and the API Reference; drops the *OneOf* entry.

## Verification

`mkdocs build`, `markdownlint`, `codespell`, and the doc example runs green via `test_docs.py` (`721 passed`, 100% coverage), all through the pre-commit hook.

[spec]: https://json-schema.org/draft/2020-12/json-schema-core#section-10