### PR TITLE
refactor(applicators)!: drop root `OneOf` re-export

### DIFF
--- a/docs/api/one_of.md
+++ b/docs/api/one_of.md
@@ -2,4 +2,4 @@
 
 The validator behind the converter's `oneOf` support — also usable on your own unions.
 
-::: pydantic_jsonschema.OneOf
+::: pydantic_jsonschema._applicators.OneOf

--- a/pydantic_jsonschema/__init__.py
+++ b/pydantic_jsonschema/__init__.py
@@ -2,13 +2,11 @@
 
 from importlib.metadata import version as _metadata_version
 
-from pydantic_jsonschema._applicators import OneOf
 from pydantic_jsonschema.converters import SchemaConverter, to_model
 from pydantic_jsonschema.types import DataType, Reference, Schema
 
 __all__ = [
     "DataType",
-    "OneOf",
     "Reference",
     "Schema",
     "SchemaConverter",

--- a/tests/test_one_of.py
+++ b/tests/test_one_of.py
@@ -6,7 +6,8 @@ import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
-from pydantic_jsonschema import OneOf, Schema, to_model
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema._applicators import OneOf
 from tests.conftest import dump_errors
 
 __all__: list[str] = []


### PR DESCRIPTION
Re-does the change from #35, which was merged into its stacked base branch instead of `main` and never reached `main`. Targets `main` directly this time.

Removes the historical root-level `OneOf` re-export so the applicator classes are public **only** via `pydantic_jsonschema._applicators`.

## ⚠️ Breaking change

```python
# before
from pydantic_jsonschema import OneOf
# after
from pydantic_jsonschema._applicators import OneOf
```

## Changes

- `pydantic_jsonschema/__init__.py`: drop the `OneOf` import and `__all__` entry.
- `tests/test_one_of.py`: import `OneOf` from `pydantic_jsonschema._applicators`.
- `docs/api/one_of.md`: point mkdocstrings at the new path.

## Verification

`ruff`, `mypy --strict`, `codespell`, `mkdocs build`, and `721 passed` at 100% coverage (all via the pre-commit hook).

> Note: overlaps with the docs PR #36 (which removes `docs/api/one_of.md`). Whichever merges second will have a trivial modify/delete conflict on that one file — resolve by taking the deletion.