### PR TITLE
docs(formats): rename "Format Validators" section to "Formats"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Turns a `Schema` into a Pydantic model (see [Quick start](#quick-start)). It res
 Python types, and applies string, number, array, and object constraints as Pydantic
 validation.
 
-### 3. Format validators
+### 3. Formats
 
 Built-in validators for every `format` in the JSON Schema spec (`email`, `uri`, `uuid`,
 `date-time`, `hostname`, `json-pointer`, `regex`, and more) — with zero extra

--- a/docs/api/formats.md
+++ b/docs/api/formats.md
@@ -1,5 +1,5 @@
-# Format validators
+# Formats
 
-For usage and examples, see the [Format Validators guide](../formats.md).
+For usage and examples, see the [Formats guide](../formats.md).
 
 ::: pydantic_jsonschema.formats

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -166,7 +166,7 @@ When adding or changing behavior:
 | Change                      | Where to document it                   |
 |-----------------------------|----------------------------------------|
 | Converter behavior          | `docs/converters.md`                   |
-| Format validators           | `docs/formats.md`                      |
+| Formats                     | `docs/formats.md`                      |
 | Complete runnable scenarios | `examples/*.py` and `docs/examples.md` |
 | Public API changes          | API docs and public docstrings         |
 | Breaking changes            | Relevant guide and migration notes     |

--- a/docs/converters.md
+++ b/docs/converters.md
@@ -118,7 +118,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `dependentSchemas`                           | conditionally applied object subschema      | `DependentSchemas` validator        |
 | `patternProperties`                          | regex-keyed property-value subschemas       | `PatternProperties` validator       |
 | `propertyNames`                              | schema every property name must match       | `PropertyNames` validator           |
-| `format` with validators                     | configured format validation                | see [Format Validators](formats.md) |
+| `format` with validators                     | configured format validation                | see [Formats](formats.md)           |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
 
 ## Unsupported Keywords
@@ -138,9 +138,9 @@ but do not affect the generated model.
   branch is validated as a plain `dict[str, Any]` — sibling `properties` are not applied.
 - On objects that declare both `properties` and a schema-valued `additionalProperties`,
   extra fields are accepted (`extra="allow"`) but their values are not validated against the `additionalProperties` schema.
-- `format` is metadata unless a matching entry is passed in `format_validators` — see [Format Validators](formats.md).
+- `format` is metadata unless a matching entry is passed in `format_validators` — see [Formats](formats.md).
   Built-in aliases cover all 19 spec-defined formats;
-  `idn-*` formats use the stdlib IDNA 2003 codec and `regex` uses the Python `re` dialect (see the differences from the specification in [Format Validators](formats.md)).
+  `idn-*` formats use the stdlib IDNA 2003 codec and `regex` uses the Python `re` dialect (see the differences from the specification in [Formats](formats.md)).
 - `not` is only as precise as the converter's coverage of its subschema. A subschema that maps to
   `Any` (an empty schema, or `required` without `type` / `properties`) matches every value, so
   `not` then rejects everything.
@@ -658,5 +658,5 @@ print(Model.__name__)
 
 ## Next Steps
 
-- [Format Validators](formats.md) - Add custom validation for special formats
+- [Formats](formats.md) - Add custom validation for special formats
 - [Examples](examples.md) - See real-world applications

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -42,7 +42,7 @@ Great article!
 --8<-- "examples/nested_schemas.py"
 ```
 
-## Custom Format Validators
+## Custom Formats
 
 Use this example when JSON Schema `format` values need project-specific validation.
 
@@ -73,5 +73,5 @@ WDG-1234-PRO
 ## Next Steps
 
 - [Converters](converters.md) - Learn about creating models
-- [Format Validators](formats.md) - Add custom validation
+- [Formats](formats.md) - Add custom validation
 - [Contributing](contributing.md) - Help improve the library

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,4 +1,4 @@
-# Format Validators
+# Formats
 
 JSON Schema `format` values describe semantic constraints such as email addresses, UUIDs, URIs, or
 domain-specific identifiers. Pydantic JSON Schema only enforces those constraints when you pass a

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,6 @@ print(post.author.name)
 - [Installation](install.md) - Install the package and third-party validator libraries
 - [Schema](schema.md) - Schema models, fields, and serialization
 - [Converters](converters.md) - Learn how schema conversion works
-- [Format Validators](formats.md) - Add validation for JSON Schema `format` values
+- [Formats](formats.md) - Add validation for JSON Schema `format` values
 - [Examples](examples.md) - Run complete examples
 - [Contributing](contributing.md) - Help improve the library

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,7 @@ For domain-specific formats such as payment cards, phone numbers, colors, countr
     pip install 'pydantic-extra-types[all]'
     ```
 
-See [Format Validators](formats.md) for supported formats and usage examples.
+See [Formats](formats.md) for supported formats and usage examples.
 
 ## Install from repository
 
@@ -63,5 +63,5 @@ truth for development dependencies, `just` recipes, documentation checks, and PR
 
 - [Schema](schema.md) - Schema models, fields, and serialization
 - [Converters](converters.md) - Create Pydantic models from JSON Schema
-- [Format Validators](formats.md) - Add validation for JSON Schema `format` values
+- [Formats](formats.md) - Add validation for JSON Schema `format` values
 - [Examples](examples.md) - Run complete examples

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -299,5 +299,5 @@ print(dumped["x-order"])
 ## Next Steps
 
 - [Converters](converters.md) - Convert schemas to Pydantic models
-- [Format Validators](formats.md) - Add validation for `format` values
+- [Formats](formats.md) - Add validation for `format` values
 - [API Reference](api/types.md) - Full API docs for schema types

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,13 +77,13 @@ nav:
   - Schema: schema.md
   - Converters: converters.md
   - Applicators: applicators.md
-  - Format Validators: formats.md
+  - Formats: formats.md
   - Examples: examples.md
   - API Reference:
     - Schema model: api/types.md
     - Converters: api/converters.md
     - Applicators: api/applicators.md
-    - Format validators: api/formats.md
+    - Formats: api/formats.md
     - Exceptions: api/exceptions.md
   - Development:
     - Contributing: contributing.md


### PR DESCRIPTION
Renames the documentation section from **Format Validators** to **Formats** — shorter, and consistent with the new *Applicators* section.

## What changed

- **Nav** (`mkdocs.yml`): *Format Validators* → *Formats* in both the main nav and the API Reference.
- **Page titles**: `docs/formats.md` and `docs/api/formats.md` H1 → `# Formats`.
- **Link text**: every `[Format Validators](formats.md)` → `[Formats](formats.md)` (index, schema, install, converters, examples, api/formats).
- **Section headings**: `README.md` *3. Format validators* → *3. Formats*; `docs/examples.md` *Custom Format Validators* → *Custom Formats*; `docs/contributing.md` table row.

## What was left alone

The technical concept and the API stay as-is: the `format_validators` parameter, prose that refers to the *validators* themselves (e.g. "all built-in format validators work with zero extra dependencies"), the changelog, and the example commit message. Only user-facing section/link names changed.

## Verification

`mkdocs build`, `markdownlint`, `codespell`, and `test_docs.py` (39 passed) green via the pre-commit hook. Table alignment and heading anchors checked — no broken in-page links.