### PR TITLE
fix(converters): support recursive and mutual `$ref` (no more `RecursionError`)

### DIFF
--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -144,6 +144,7 @@ class SchemaConverter:
         self._models_cache: dict[SchemaHash, type[BaseModel]] = {}
         self._resolution_path: list[str] = []  # Track path for error reporting
         self._applicators: list[Applicator] = []
+        self._building: set[Ref] = set()  # Defs whose model is mid-construction
 
     @staticmethod
     def _hash_schema(
@@ -491,9 +492,16 @@ class SchemaConverter:
         """
         defs = get_inline_defs(schema)
 
+        # Convert each def with its ref marked in-progress, so a body that references the def
+        # currently being built (a recursive / mutual `$ref`) defers to a `ForwardRef` instead
+        # of recursing forever. `_rebuild_def_models` binds those refs once every model exists.
         for ref, schema_def in defs.items():
             self._defs_cache[ref] = schema_def
-            self._convert_nested_schema(schema_def)
+            self._building.add(ref)
+            try:
+                self._convert_nested_schema(schema_def)
+            finally:
+                self._building.discard(ref)
 
         self._rebuild_def_models(defs)
 
@@ -615,7 +623,13 @@ class SchemaConverter:
                 schema_for_field: Schema
 
                 if isinstance(field_schema, Reference):
-                    annotation = self._get_model(field_schema.ref)
+                    # Defer a recursive / mutual ref (its target def is still building) to a
+                    # `ForwardRef`, bound later by `_rebuild_def_models`. Otherwise resolve
+                    # eagerly, so an unknown `$ref` still raises here instead of silently deferring.
+                    if field_schema.ref in self._building:
+                        annotation = ForwardRef(sanitize_identifier(field_schema.ref))
+                    else:
+                        annotation = self._get_model(field_schema.ref)
                     # A local `$ref` carries its own field metadata in `$defs`; an unknown
                     # ref (external / pre-built) contributes none, so fall back to an empty schema.
                     schema_for_field = self._defs_cache.get(field_schema.ref, Schema())
@@ -917,6 +931,12 @@ class SchemaConverter:
         :param reference: Reference to resolve.
         :returns: Resolved model or `ForwardRef` for later resolution.
         """
+        # A ref to a def whose model is still being built (a recursive or mutual `$ref`)
+        # must defer: returning its half-built model would recurse forever. The `ForwardRef`
+        # is bound once every def model exists (`_rebuild_def_models` / `_bind_forward_refs`).
+        if reference.ref in self._building:
+            return ForwardRef(sanitize_identifier(reference.ref))
+
         if reference.ref in self._refs or reference.ref in self._defs_cache:
             return self._get_model(reference.ref)
 

--- a/tests/converters/test_references.py
+++ b/tests/converters/test_references.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from inline_snapshot import snapshot
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from pydantic_jsonschema import (
     SchemaConverter,
@@ -601,3 +601,109 @@ class TestReferences:
                 ],
             }
         )
+
+
+class TestRecursiveReferences:
+    """A `$def` may reference itself or another def cyclically (tree / linked-list shapes)."""
+
+    def test_self_referential_ref(self) -> None:
+        """A def whose property points at itself converts and validates nested data."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {"head": {"$ref": "#/$defs/Node"}},
+            "required": ["head"],
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "integer"},
+                        "next": {"anyOf": [{"$ref": "#/$defs/Node"}, {"type": "null"}]},
+                    },
+                    "required": ["value"],
+                },
+            },
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        instance = model(head={"value": 1, "next": {"value": 2, "next": None}})
+        assert instance.model_dump() == snapshot(
+            {"head": {"value": 1, "next": {"value": 2, "next": None}}}
+        )
+
+    def test_self_referential_ref_rejects_invalid(self) -> None:
+        """The recursive type still enforces its constraints at every depth."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {"head": {"$ref": "#/$defs/Node"}},
+            "required": ["head"],
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "integer"},
+                        "next": {"anyOf": [{"$ref": "#/$defs/Node"}, {"type": "null"}]},
+                    },
+                    "required": ["value"],
+                },
+            },
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        with pytest.raises(ValidationError):
+            model(head={"value": 1, "next": {"value": "not-an-int", "next": None}})
+
+    def test_mutually_referential_refs(self) -> None:
+        """Two defs referencing each other convert regardless of `$defs` key order."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {"a": {"$ref": "#/$defs/A"}},
+            "required": ["a"],
+            "$defs": {
+                "B": {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string"},
+                        "a": {"anyOf": [{"$ref": "#/$defs/A"}, {"type": "null"}]},
+                    },
+                    "required": ["label"],
+                },
+                "A": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "b": {"anyOf": [{"$ref": "#/$defs/B"}, {"type": "null"}]},
+                    },
+                    "required": ["id"],
+                },
+            },
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        instance = model(a={"id": 1, "b": {"label": "x", "a": None}})
+        assert instance.model_dump() == snapshot({"a": {"id": 1, "b": {"label": "x", "a": None}}})
+
+    def test_direct_self_referential_ref(self) -> None:
+        """A direct (non-composition) optional `$ref` to the def being built defers correctly."""
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {"head": {"$ref": "#/$defs/Node"}},
+            "required": ["head"],
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "integer"},
+                        "child": {"$ref": "#/$defs/Node"},
+                    },
+                    "required": ["value"],
+                },
+            },
+        }
+        schema = Schema.model_validate(schema_raw)
+        model = to_model(schema)
+
+        instance = model(head={"value": 1, "child": {"value": 2}})
+        assert instance.model_dump() == snapshot({"head": {"value": 1, "child": {"value": 2}}})


### PR DESCRIPTION
Fixes a crash on recursive / cyclic `$ref` schemas — the canonical tree / linked-list shape. Found during a full-project audit; written TDD (failing regression tests first, then the fix).

## The bug

A `$def` that references itself (or another def cyclically) crashed:

```python
to_model(Schema.model_validate({
    "type": "object", "properties": {"head": {"$ref": "#/$defs/Node"}}, "required": ["head"],
    "$defs": {"Node": {"type": "object", "properties": {
        "value": {"type": "integer"},
        "next": {"anyOf": [{"$ref": "#/$defs/Node"}, {"type": "null"}]}}, "required": ["value"]}},
}))
# -> RecursionError
```

Mutual refs (`A` → `B` → `A`) additionally failed order-dependently with `SchemaReferenceError`. Despite 100% line coverage, no test exercised a self-cycle — exactly the gap line coverage hides.

## Root cause

`_build_defs_cache` caches each def before converting it, so a body referencing the def *currently under construction* saw it in `_defs_cache` and resolved it **eagerly** (`_get_model`) — re-entering its own conversion forever. The `ForwardRef` + `_rebuild_def_models` machinery already existed for forward refs but never fired for self-cycles.

## Fix

Track the def whose model is mid-construction (`self._building`). A `$ref` to an in-progress def now defers to a `ForwardRef` (bound afterwards by `_rebuild_def_models`), exactly as forward refs already do. Touches `_reference_annotation` and the direct-`$ref` path in `_build_fields`; unknown refs still raise `SchemaReferenceError` eagerly (no silent deferral).

## Tests (regression, written first and shown failing)

`tests/converters/test_references.py::TestRecursiveReferences` — self-referential (composition + direct), constraint enforcement at depth, and mutual (`$defs`-order-independent) refs.

## Verification

`722 → 726 passed`, 100% coverage, `ruff` / `mypy --strict` / `codespell` / `mkdocs build` green via pre-commit.

---

Part of an audit-driven series. Next: silent sibling-`type` drop under `anyOf`/`oneOf`, then `enum: []` clean error, then stale `.claude/overview.md` / metadata.