### PR TITLE
fix(converters): enforce sibling `type` with `anyOf`/`oneOf`/`allOf`

### DIFF
--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -26,6 +26,7 @@ from pydantic import (
     ConfigDict,
     Field,
     RootModel,
+    TypeAdapter,
     create_model,
     model_validator,
 )
@@ -758,7 +759,7 @@ class SchemaConverter:
             # `anyOf` / `oneOf` / `allOf` -> union or nested model; else `type` (or `Any`).
             composition_annotation = self._composition_annotation(schema)
             annotation = (
-                composition_annotation
+                self._apply_sibling_type(composition_annotation, schema)
                 if composition_annotation is not None
                 else self._type_annotation(schema)
             )
@@ -772,6 +773,54 @@ class SchemaConverter:
             annotation = cast("type", Annotated[annotation, self._build_conditional(schema)])
 
         return annotation
+
+    def _apply_sibling_type(
+        self,
+        annotation: type | ForwardRef,
+        schema: Schema,
+        /,
+    ) -> type | ForwardRef:
+        """Enforce a `type` declared alongside `anyOf` / `oneOf` / `allOf`.
+
+        JSON Schema applies all keywords conjunctively, so a value must satisfy both the
+        composition and the sibling `type`. Pydantic has no intersection type, so the sibling
+        `type` runs as a `before`-validator over the composition union; without this the `type`
+        is silently dropped and the union accepts values of any type.
+
+        :param annotation: The composition annotation (union / nested model).
+        :param schema: The schema carrying both a composition keyword and a possible `type`.
+        :returns: The annotation, wrapped to also enforce the sibling `type` when one is present.
+        """
+        if schema.type is MISSING:
+            return annotation
+
+        adapter: TypeAdapter[PythonType] = TypeAdapter(self._host_type_guard(schema))
+
+        def _check(value: PythonType) -> PythonType:
+            adapter.validate_python(value)
+            return value
+
+        return cast("type", Annotated[annotation, BeforeValidator(_check)])
+
+    @staticmethod
+    def _host_type_guard(
+        schema: Schema,
+        /,
+    ) -> type:
+        """Map the sibling `type` to a plain JSON-type guard.
+
+        Unlike `_type_annotation`, this only checks the value's JSON type — it does not build a
+        nested model or attach array applicators, since it guards a value already shaped by the
+        composition.
+
+        :param schema: Schema whose `type` is set (single `DataType` or a list).
+        :returns: A type (or union of types) to validate the value's JSON type against.
+        """
+        if isinstance(schema.type, DataType):
+            return _DATA_TYPE_ANNOTATION_MAPPING[schema.type]
+
+        union_args = [_DATA_TYPE_ANNOTATION_MAPPING[data_type] for data_type in schema.type]
+        return make_union(union_args)
 
     def _constrained_annotation(
         self,

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -773,7 +773,7 @@ class SchemaConverter:
             # `anyOf` / `oneOf` / `allOf` -> union or nested model; else `type` (or `Any`).
             composition_annotation = self._composition_annotation(schema)
             annotation = (
-                self._apply_sibling_type(composition_annotation, schema)
+                composition_annotation
                 if composition_annotation is not None
                 else self._type_annotation(schema)
             )
@@ -790,10 +790,10 @@ class SchemaConverter:
 
     def _apply_sibling_type(
         self,
-        annotation: type | ForwardRef,
+        annotation: type,
         schema: Schema,
         /,
-    ) -> type | ForwardRef:
+    ) -> type:
         """Enforce a `type` declared alongside `anyOf` / `oneOf` / `allOf`.
 
         JSON Schema applies all keywords conjunctively, so a value must satisfy both the
@@ -1019,23 +1019,25 @@ class SchemaConverter:
     ) -> type | None:
         """Convert `anyOf` / `oneOf` / `allOf` composition to an annotation.
 
+        A `type` declared alongside the composition is enforced too — JSON Schema applies all
+        keywords conjunctively (see `_apply_sibling_type`).
+
         :param schema: Schema to convert.
         :returns: Annotation, or `None` if the schema has no composition keyword.
         """
         # `anyOf` -> `Union`:
         if schema.any_of is not MISSING:
-            union_args = self._union_args(schema.any_of, kind="anyOf")
-            return make_union(union_args)
-
+            annotation: type = make_union(self._union_args(schema.any_of, kind="anyOf"))
         # `oneOf` -> discriminated union or exactly-one-branch validation:
-        if schema.one_of is not MISSING:
-            return self._one_of_annotation(schema)
-
+        elif schema.one_of is not MISSING:
+            annotation = self._one_of_annotation(schema)
         # `allOf` -> nested model:
-        if schema.all_of is not MISSING:
-            return self._convert_nested_schema(schema)
+        elif schema.all_of is not MISSING:
+            annotation = self._convert_nested_schema(schema)
+        else:
+            return None
 
-        return None
+        return self._apply_sibling_type(annotation, schema)
 
     def _one_of_annotation(
         self,

--- a/tests/converters/test_composition.py
+++ b/tests/converters/test_composition.py
@@ -431,9 +431,54 @@ class TestComposition:
             }
         )
 
-        instance = model(item={"other": None})
-        assert instance.model_dump() == snapshot(
-            {
-                "item": {"other": None},
-            }
+
+class TestCompositionWithSiblingType:
+    """A `type` sibling to `anyOf` / `oneOf` constrains the union (keywords are conjunctive)."""
+
+    def test_anyof_with_sibling_type_rejects_wrong_type(self) -> None:
+        """`type` + `anyOf`: a value of the wrong type is rejected, not silently accepted."""
+        schema_raw: SchemaRaw = {
+            "type": "number",
+            "anyOf": [{"minimum": 0, "maximum": 10}, {"minimum": 100}],
+        }
+        model = to_model(Schema.model_validate(schema_raw))
+
+        assert model(5).model_dump() == snapshot(5)  # type: ignore[call-arg]
+
+        with pytest.raises(ValidationError) as exc_info:
+            model("hello")  # type: ignore[call-arg]
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "float_parsing",
+                    "loc": (),
+                    "msg": "Input should be a valid number, unable to parse string as a number",
+                    "input": "hello",
+                }
+            ]
         )
+
+    def test_anyof_with_sibling_type_rejects_object(self) -> None:
+        """`type` + `anyOf`: a non-scalar value is rejected by the sibling `type`."""
+        schema_raw: SchemaRaw = {
+            "type": "number",
+            "anyOf": [{"minimum": 0, "maximum": 10}, {"minimum": 100}],
+        }
+        model = to_model(Schema.model_validate(schema_raw))
+
+        with pytest.raises(ValidationError):
+            model({"k": 1})  # type: ignore[call-arg]
+
+    def test_multi_type_sibling_with_anyof(self) -> None:
+        """A list-valued sibling `type` (`["integer", "string"]`) still guards the union."""
+        schema_raw: SchemaRaw = {
+            "type": ["integer", "string"],
+            "anyOf": [{"minimum": 0}, {"minLength": 1}],
+        }
+        model = to_model(Schema.model_validate(schema_raw))
+
+        assert model(5).model_dump() == snapshot(5)  # type: ignore[call-arg]
+        assert model("hi").model_dump() == snapshot("hi")  # type: ignore[call-arg]
+
+        with pytest.raises(ValidationError):
+            model({"k": 1})  # type: ignore[call-arg]


### PR DESCRIPTION
Fixes silent under-validation: a `type` declared alongside a composition keyword was dropped, so the union accepted values of any JSON type. JSON Schema applies all keywords conjunctively. Found during the audit; written TDD.

## The bug

```python
M = to_model(Schema.model_validate({
    "type": "number",
    "anyOf": [{"minimum": 0, "maximum": 10}, {"minimum": 100}],
}))
M.model_validate("hello")   # -> ACCEPTED (should reject: not a number)
M.model_validate({"k": 1})  # -> ACCEPTED
```

`_schema_to_annotation` returned the composition annotation and never applied the sibling `type`.

## Fix

When a composition keyword and a `type` coexist, the `type` is enforced as a `before`-validator over the union (Pydantic has no intersection type) — the same `Annotated`-wrap mechanism already used for `not` / `if-then-else`. `_host_type_guard` maps the sibling `type` to a plain JSON-type check (no nested-model / array-applicator side effects). Schemas with composition but **no** `type` are unchanged.

## Tests (TDD, shown failing first)

`tests/converters/test_composition.py::TestCompositionWithSiblingType` — `anyOf` rejects wrong scalar type and non-scalar; list-valued `type` (`["integer","string"]`) guard.

## Verification

`722 → 725 passed`, 100% coverage, `ruff` / `mypy --strict` / `codespell` / `mkdocs build` green via pre-commit.

---

**Adjacent finding (separate, not fixed here):** `anyOf`/`oneOf` branches lose their own field constraints — a constraint-only branch like `{"minimum": 0}` collapses to `Any` because `_union_args` uses `_schema_to_annotation` (no `FieldInfo` constraints) rather than `_constrained_annotation`. I scoped it out of this PR to keep it focused; worth a follow-up.