### PR TITLE
fix(converters): clean error on empty `enum`

### DIFF
--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -933,6 +933,13 @@ class SchemaConverter:
         :returns: `Literal` annotation.
         """
         values = schema.enum if schema.enum is not MISSING else (schema.const,)
+
+        # An empty `enum` has no valid value; `Literal[()]` makes Pydantic raise a bare
+        # `AssertionError` deep in schema generation, so reject it with a library error instead.
+        if not values:
+            msg = "`enum` must contain at least one value"
+            raise SchemaConversionError(msg)
+
         literal_type = Literal[tuple(values)]  # type: ignore[valid-type]
         return cast("type", literal_type)
 

--- a/tests/converters/test_converter.py
+++ b/tests/converters/test_converter.py
@@ -10,6 +10,7 @@ from pydantic_jsonschema import (
     SchemaConverter,
     to_model,
 )
+from pydantic_jsonschema.exceptions import SchemaConversionError
 from pydantic_jsonschema.types import Schema
 
 if TYPE_CHECKING:
@@ -382,6 +383,14 @@ class TestLiteralTypes:
 
         with pytest.raises(ValidationError):
             model(field=invalid_value)
+
+    def test_empty_enum_raises_conversion_error(self) -> None:
+        """An empty `enum` raises a clean `SchemaConversionError`, not a bare `AssertionError`."""
+        with pytest.raises(SchemaConversionError) as exc_info:
+            to_model(Schema.model_validate({"enum": []}))
+        assert str(exc_info.value) == snapshot(
+            "SchemaConversionError(message='`enum` must contain at least one value')"
+        )
 
 
 class TestAdditionalProperties:


### PR DESCRIPTION
An empty `enum` leaked a bare `AssertionError` from deep inside Pydantic instead of the library's own `SchemaConversionError`. Found during the audit; written TDD.

## The bug

```python
to_model(Schema.model_validate({"enum": []}))
# -> AssertionError: literal "expected" cannot be empty, obj=typing.Literal[()]
```

`_literal_annotation` built `Literal[()]`, which Pydantic rejects with an internal `AssertionError` — an opaque, non-library exception callers cannot reasonably catch.

## Fix

`_literal_annotation` now guards against an empty `enum` and raises `SchemaConversionError` (a malformed schema — the spec requires `enum` to be non-empty). `const` is unaffected (always a single value).

## Tests (TDD, shown failing first)

`tests/converters/test_converter.py::TestLiteralTypes::test_empty_enum_raises_conversion_error`.

## Verification

100% coverage, `ruff` / `mypy --strict` / `codespell` / `mkdocs build` green via pre-commit.