### PR TITLE
docs(contributing): add Python 3.15 to `test-all-python` row

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,7 @@ Run `just` to list all available commands.
 | Format code                       | `just format`          | `ruff format` and autofix-only `ruff check`          |
 | Lint everything                   | `just lint`            | `ruff`, `mypy`, `codespell`, and `markdownlint-cli2` |
 | Run tests                         | `just test`            | `pytest` with coverage reporting                     |
-| Run all supported Python versions | `just test-all-python` | Python 3.12, 3.13, and 3.14 test runs                |
+| Run all supported Python versions | `just test-all-python` | Python 3.12, 3.13, 3.14, and 3.15 test runs          |
 | Generate HTML coverage            | `just testcov`         | `just test` plus `coverage html`                     |
 | Run pre-commit hooks              | `just precommit`       | `pre-commit run --all-files`                         |
 | Run the full local gate           | `just all`             | format, lint, tests, and docs build                  |


### PR DESCRIPTION
The contributing table listed `just test-all-python` as running "Python 3.12, 3.13, and 3.14" but the `justfile` recipe (and `pyproject.toml` classifiers / CI) also run **3.15**. Adds 3.15 to match. Found during the audit.