### PR TITLE
fix(converters): enforce field constraints on `anyOf`/`oneOf` branches

### DIFF
--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -741,7 +741,11 @@ class SchemaConverter:
         *,
         kind: Literal["anyOf", "oneOf"],
     ) -> list[type | ForwardRef]:
-        """Convert union sub-schemas to annotations.
+        """Convert union sub-schemas to annotations, baking in each branch's constraints.
+
+        Branches go through `_constrained_annotation` (not plain `_schema_to_annotation`), so a
+        branch's own field-level constraints (`minimum`, `maxLength`, `pattern`, ...) are enforced
+        instead of being dropped — otherwise a constraint-only branch collapses to `Any`.
 
         :param union_schemas: Sub-schemas of an `anyOf` / `oneOf` composition.
         :param kind: Composition keyword for path tracking (`anyOf` or `oneOf`).
@@ -750,7 +754,7 @@ class SchemaConverter:
         union_args: list[type | ForwardRef] = []
         for index, sub_schema in enumerate(union_schemas):
             with self._track_path(f"{kind}[{index}]"):
-                union_args.append(self._schema_to_annotation(sub_schema))
+                union_args.append(self._constrained_annotation(sub_schema, union_branch=True))
         return union_args
 
     def _schema_to_annotation(
@@ -840,6 +844,8 @@ class SchemaConverter:
         self,
         schema: Schema | Reference,
         /,
+        *,
+        union_branch: bool = False,
     ) -> AnnotationType:
         """Build a subschema annotation with field-level constraints baked in.
 
@@ -849,6 +855,10 @@ class SchemaConverter:
         `pattern`, `multipleOf`, ...), so they are re-applied here as `Annotated` `Field` metadata.
 
         :param schema: The subschema (or reference) to convert.
+        :param union_branch: `True` for `anyOf` / `oneOf` branches — drop non-validating metadata
+            (`title` / `description` / `examples`, which would leak into the dumped union) and skip
+            constraints on an untyped (`Any`) branch (a bound on `Any` makes Pydantic raise
+            `TypeError` on non-comparable input).
         :returns: The annotation, wrapped with `Field(...)` when it carries field-level constraints.
         """
         annotation = self._schema_to_annotation(schema)
@@ -856,8 +866,9 @@ class SchemaConverter:
             return annotation
 
         annotation = self._apply_validators(annotation, schema)
-        kwargs = build_field_kwargs(schema)
-        if kwargs:
+        kwargs = build_field_kwargs(schema, include_metadata=not union_branch)
+
+        if kwargs and not (union_branch and annotation is Any):
             annotation = cast("type", Annotated[annotation, Field(**kwargs)])
         return annotation
 

--- a/pydantic_jsonschema/converters/_field_kwargs.py
+++ b/pydantic_jsonschema/converters/_field_kwargs.py
@@ -48,19 +48,25 @@ class _FieldKwargs(TypedDict, total=False):
     pattern: str | None
 
 
-def build_field_kwargs(schema: Schema, /) -> _FieldKwargs:  # noqa: C901
+def build_field_kwargs(schema: Schema, /, *, include_metadata: bool = True) -> _FieldKwargs:  # noqa: C901
     """Build `FieldInfo` kwargs, only including constraints that are explicitly set.
 
     :param schema: Schema to extract constraints and metadata from.
+    :param include_metadata: When `False`, omit non-validating metadata (`title` / `description` /
+        `examples`). Used for union branches, where these are not field metadata and would otherwise
+        leak into the dumped `anyOf` / `oneOf` (e.g. a `title` on a discriminated `$ref` branch).
     :returns: Keyword arguments for `FieldInfo`.
     """
     kwargs: _FieldKwargs = {}
-    if schema.examples is not MISSING:
-        kwargs["examples"] = schema.examples
-    if schema.title is not MISSING:
-        kwargs["title"] = schema.title
-    if schema.description is not MISSING:
-        kwargs["description"] = schema.description
+
+    if include_metadata:
+        if schema.examples is not MISSING:
+            kwargs["examples"] = schema.examples
+        if schema.title is not MISSING:
+            kwargs["title"] = schema.title
+        if schema.description is not MISSING:
+            kwargs["description"] = schema.description
+
     if schema.minimum is not MISSING:
         kwargs["ge"] = schema.minimum
     if schema.exclusive_minimum is not MISSING:

--- a/tests/converters/test_composition.py
+++ b/tests/converters/test_composition.py
@@ -482,3 +482,38 @@ class TestCompositionWithSiblingType:
 
         with pytest.raises(ValidationError):
             model({"k": 1})  # type: ignore[call-arg]
+
+
+class TestCompositionBranchConstraints:
+    """`anyOf` / `oneOf` branches keep their own field-level constraints."""
+
+    def test_anyof_branch_constraints_enforced(self) -> None:
+        """An `anyOf` of constrained branches rejects a value outside every branch's range."""
+        schema_raw: SchemaRaw = {
+            "anyOf": [
+                {"type": "integer", "minimum": 0, "maximum": 10},
+                {"type": "integer", "minimum": 100, "maximum": 200},
+            ],
+        }
+        model = to_model(Schema.model_validate(schema_raw))
+
+        assert model(5).model_dump() == snapshot(5)  # type: ignore[call-arg]
+        assert model(150).model_dump() == snapshot(150)  # type: ignore[call-arg]
+
+        with pytest.raises(ValidationError):
+            model(50)  # type: ignore[call-arg]  # in neither range
+
+    def test_oneof_branch_constraints_enforced(self) -> None:
+        """`oneOf` branch constraints make exactly-one-branch dispatch meaningful."""
+        schema_raw: SchemaRaw = {
+            "oneOf": [
+                {"type": "integer", "minimum": 0, "maximum": 10},
+                {"type": "integer", "minimum": 100, "maximum": 200},
+            ],
+        }
+        model = to_model(Schema.model_validate(schema_raw))
+
+        assert model(5).model_dump() == snapshot(5)  # type: ignore[call-arg]
+
+        with pytest.raises(ValidationError):
+            model(50)  # type: ignore[call-arg]  # matches no branch


### PR DESCRIPTION
Fixes a silent validation gap (TODO #5, found while fixing the sibling-`type` drop in #41): `anyOf` / `oneOf` branches lost their own field-level constraints, so a constrained branch matched any value of the right type. Written TDD.

## The bug

```python
M = to_model(Schema.model_validate({"anyOf": [
    {"type": "integer", "minimum": 0, "maximum": 10},
    {"type": "integer", "minimum": 100, "maximum": 200},
]}))
M.model_validate(50)   # -> ACCEPTED (in neither range; both branches collapsed to bare `int`)
```

`_union_args` built each branch via `_schema_to_annotation`, which omits `FieldInfo` constraints — unlike `_constrained_annotation` (already used by the applicators).

## Fix

`_union_args` now routes branches through `_constrained_annotation(union_branch=True)`. The new `union_branch` flag captures what is special about a branch context:
- **drop non-validating metadata** (`title` / `description` / `examples`) — otherwise they leak into the dumped `anyOf`/`oneOf` (e.g. a `title` on a discriminated `$ref` branch);
- **skip constraints on an untyped (`Any`) branch** — a bound like `Field(ge=0)` on `Any` makes Pydantic raise `TypeError` on non-comparable input. A constraint-only branch (no `type`) keeps its prior behavior (constraint not expressible without a type).

Applicators are unaffected (`union_branch=False`).

## Tests (TDD, shown failing first)

`tests/converters/test_composition.py::TestCompositionBranchConstraints` — `anyOf` rejects a value outside every branch range; `oneOf` exactly-one dispatch becomes meaningful.

## Verification

`726 → 733 passed`, 100% coverage, `ruff` / `mypy --strict` / `codespell` / `mkdocs build` green via pre-commit. Closes the TODO #5 item.