### PR TITLE
feat(applicators): round-trip `not`/`contains`/`prefixItems`/`if`-`then`-`else` JSON Schema

### DIFF
--- a/pydantic_jsonschema/_applicators/_contains.py
+++ b/pydantic_jsonschema/_applicators/_contains.py
@@ -3,12 +3,18 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.3
 """
 
-from pydantic import GetCoreSchemaHandler, TypeAdapter
+from typing import Final
+
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
 from ._base import AnnotationType, Applicator
 
 __all__ = ["Contains"]
+
+# `minContains` defaults to 1, so it is only re-emitted when it differs.
+_DEFAULT_MIN_CONTAINS: Final[int] = 1
 
 
 class Contains(Applicator):
@@ -46,6 +52,20 @@ class Contains(Applicator):
     ) -> CoreSchema:
         """Wrap the array schema with the match-count check."""
         return core_schema.no_info_after_validator_function(self._validate, handler(source_type))
+
+    def __get_pydantic_json_schema__(
+        self,
+        schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Restore the `contains` / `minContains` / `maxContains` keywords on dump."""
+        json_schema = handler(schema)
+        json_schema["contains"] = self._get_adapter().json_schema()
+        if self._min_contains != _DEFAULT_MIN_CONTAINS:
+            json_schema["minContains"] = self._min_contains
+        if self._max_contains is not None:
+            json_schema["maxContains"] = self._max_contains
+        return json_schema
 
     def _get_adapter(self) -> TypeAdapter[AnnotationType]:
         """Build the `contains` adapter on first use (caches across calls).

--- a/pydantic_jsonschema/_applicators/_if_then_else.py
+++ b/pydantic_jsonschema/_applicators/_if_then_else.py
@@ -3,7 +3,8 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2
 """
 
-from pydantic import GetCoreSchemaHandler, TypeAdapter
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
 from ._base import AnnotationType, Applicator
@@ -50,6 +51,21 @@ class IfThenElse(Applicator):
     ) -> CoreSchema:
         """Wrap the value schema with the conditional check (on the raw input)."""
         return core_schema.no_info_wrap_validator_function(self._validate, handler(source_type))
+
+    def __get_pydantic_json_schema__(
+        self,
+        schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Restore the `if` / `then` / `else` keywords on dump."""
+        json_schema = handler(schema)
+        if_adapter = self._build_adapters()
+        json_schema["if"] = if_adapter.json_schema()
+        if self._then_adapter is not None:
+            json_schema["then"] = self._then_adapter.json_schema()
+        if self._else_adapter is not None:
+            json_schema["else"] = self._else_adapter.json_schema()
+        return json_schema
 
     def _build_adapters(self) -> TypeAdapter[AnnotationType]:
         """Build the `if` / `then` / `else` adapters on first use (caches across calls).

--- a/pydantic_jsonschema/_applicators/_not.py
+++ b/pydantic_jsonschema/_applicators/_not.py
@@ -3,7 +3,8 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.4
 """
 
-from pydantic import GetCoreSchemaHandler, TypeAdapter
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
 from ._base import AnnotationType, Applicator
@@ -45,6 +46,16 @@ class Not(Applicator):
     ) -> CoreSchema:
         """Wrap the value schema with the `not` check (on the raw input)."""
         return core_schema.no_info_wrap_validator_function(self._validate, handler(source_type))
+
+    def __get_pydantic_json_schema__(
+        self,
+        schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Restore the `not` keyword on dump (the wrap-validator drops it otherwise)."""
+        json_schema = handler(schema)
+        json_schema["not"] = self._get_adapter().json_schema()
+        return json_schema
 
     def matches(
         self,

--- a/pydantic_jsonschema/_applicators/_prefix_items.py
+++ b/pydantic_jsonschema/_applicators/_prefix_items.py
@@ -5,7 +5,8 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.1
 
 from collections.abc import Iterable
 
-from pydantic import GetCoreSchemaHandler, TypeAdapter, ValidationError
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter, ValidationError
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
 from ._base import AnnotationType, Applicator
@@ -47,6 +48,21 @@ class PrefixItems(Applicator):
     ) -> CoreSchema:
         """Wrap the array schema with positional validation."""
         return core_schema.no_info_after_validator_function(self._validate, handler(source_type))
+
+    def __get_pydantic_json_schema__(
+        self,
+        schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Restore the `prefixItems` (and tail `items`) keywords on dump."""
+        json_schema = handler(schema)
+        self._build_adapters()
+        json_schema["prefixItems"] = [
+            adapter.json_schema() for adapter in self._prefix_adapters or []
+        ]
+        if self._tail_adapter is not None:
+            json_schema["items"] = self._tail_adapter.json_schema()
+        return json_schema
 
     def _build_adapters(self) -> None:
         """Build the per-position and tail adapters on first use (caches across calls)."""

--- a/tests/applicators/test_contains.py
+++ b/tests/applicators/test_contains.py
@@ -125,3 +125,53 @@ class TestContains:
                 }
             ]
         )
+
+
+class TestContainsJsonSchema:
+    """`contains` / `minContains` / `maxContains` round-trip into the dumped JSON Schema."""
+
+    def test_contains_round_trips(self) -> None:
+        """A converted model re-emits its `contains` bounds on `model_json_schema()`."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "type": "array",
+                            "contains": {"type": "integer"},
+                            "minContains": 2,
+                            "maxContains": 4,
+                        },
+                    },
+                    "required": ["a"],
+                }
+            )
+        )
+
+        assert model.model_json_schema()["properties"]["a"] == snapshot(
+            {
+                "contains": {"type": "integer"},
+                "items": {},
+                "maxContains": 4,
+                "minContains": 2,
+                "title": "A",
+                "type": "array",
+            }
+        )
+
+    def test_contains_default_bounds_round_trips(self) -> None:
+        """Default `minContains` (1) and absent `maxContains` are not emitted on dump."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {"a": {"type": "array", "contains": {"type": "integer"}}},
+                    "required": ["a"],
+                }
+            )
+        )
+
+        assert model.model_json_schema()["properties"]["a"] == snapshot(
+            {"contains": {"type": "integer"}, "items": {}, "title": "A", "type": "array"}
+        )

--- a/tests/applicators/test_if_then_else.py
+++ b/tests/applicators/test_if_then_else.py
@@ -159,3 +159,82 @@ class TestIfThenElse:
                 }
             ]
         )
+
+
+class TestIfThenElseJsonSchema:
+    """`if` / `then` / `else` round-trip into the dumped JSON Schema."""
+
+    def test_if_then_else_round_trips(self) -> None:
+        """A converted model re-emits its `if` / `then` / `else` keywords on dump."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "type": "integer",
+                            "if": {"const": 1},
+                            "then": {"const": 1},
+                            "else": {"const": 2},
+                        },
+                    },
+                    "required": ["a"],
+                }
+            )
+        )
+
+        assert model.model_json_schema()["properties"]["a"] == snapshot(
+            {
+                "else": {"const": 2, "type": "integer"},
+                "if": {"const": 1, "type": "integer"},
+                "then": {"const": 1, "type": "integer"},
+                "title": "A",
+                "type": "integer",
+            }
+        )
+
+    def test_if_then_only_round_trips(self) -> None:
+        """`if` / `then` without `else` dumps without an `else` keyword."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "integer", "if": {"const": 1}, "then": {"const": 1}}
+                    },
+                    "required": ["a"],
+                }
+            )
+        )
+
+        assert model.model_json_schema()["properties"]["a"] == snapshot(
+            {
+                "if": {"const": 1, "type": "integer"},
+                "then": {"const": 1, "type": "integer"},
+                "title": "A",
+                "type": "integer",
+            }
+        )
+
+    def test_if_else_only_round_trips(self) -> None:
+        """`if` / `else` without `then` dumps without a `then` keyword."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "integer", "if": {"const": 1}, "else": {"const": 2}}
+                    },
+                    "required": ["a"],
+                }
+            )
+        )
+
+        assert model.model_json_schema()["properties"]["a"] == snapshot(
+            {
+                "else": {"const": 2, "type": "integer"},
+                "if": {"const": 1, "type": "integer"},
+                "title": "A",
+                "type": "integer",
+            }
+        )

--- a/tests/applicators/test_not.py
+++ b/tests/applicators/test_not.py
@@ -133,3 +133,23 @@ class TestNot:
                 }
             ]
         )
+
+
+class TestNotJsonSchema:
+    """`not` round-trips into the dumped JSON Schema."""
+
+    def test_not_round_trips(self) -> None:
+        """A converted model re-emits its `not` keyword on `model_json_schema()`."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer", "not": {"const": 5}}},
+                    "required": ["x"],
+                }
+            )
+        )
+
+        assert model.model_json_schema()["properties"]["x"] == snapshot(
+            {"not": {"const": 5, "type": "integer"}, "title": "X", "type": "integer"}
+        )

--- a/tests/applicators/test_prefix_items.py
+++ b/tests/applicators/test_prefix_items.py
@@ -112,3 +112,52 @@ class TestPrefixItems:
                 }
             ]
         )
+
+
+class TestPrefixItemsJsonSchema:
+    """`prefixItems` (and tail `items`) round-trip into the dumped JSON Schema."""
+
+    def test_prefix_items_round_trips(self) -> None:
+        """A converted model re-emits its `prefixItems` and tail `items` on dump."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "type": "array",
+                            "prefixItems": [{"type": "string"}, {"type": "integer"}],
+                            "items": {"type": "boolean"},
+                        },
+                    },
+                    "required": ["a"],
+                }
+            )
+        )
+
+        assert model.model_json_schema()["properties"]["a"] == snapshot(
+            {
+                "items": {"type": "boolean"},
+                "prefixItems": [{"type": "string"}, {"type": "integer"}],
+                "title": "A",
+                "type": "array",
+            }
+        )
+
+    def test_prefix_items_without_tail_round_trips(self) -> None:
+        """`prefixItems` with no `items` tail dumps without an `items` keyword."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "array", "prefixItems": [{"type": "string"}]},
+                    },
+                    "required": ["a"],
+                }
+            )
+        )
+
+        assert model.model_json_schema()["properties"]["a"] == snapshot(
+            {"items": {}, "prefixItems": [{"type": "string"}], "title": "A", "type": "array"}
+        )


### PR DESCRIPTION
Implements the first half of the TODO "Applicators: JSON Schema round-trip" item: a converted model now re-emits these keywords on `model_json_schema()` instead of silently dropping them. Written TDD.

## The gap

Only `OneOf` restored its keyword on dump; the other applicators are wrap/after validators, so `model_json_schema()` lost the keyword:

```python
to_model(Schema.model_validate({"type": "integer", "not": {"const": 5}})).model_json_schema()
# -> {"type": "integer"}   # `not` gone
```

## Fix

Each `Annotated`-metadata applicator gains a `__get_pydantic_json_schema__` hook (the same mechanism `OneOf` already uses) that re-emits its keyword from the branch `TypeAdapter`(s):

- `Not` -> `not`
- `Contains` -> `contains` (+ `minContains` when not the default 1, `maxContains` when set)
- `PrefixItems` -> `prefixItems` (+ tail `items`)
- `IfThenElse` -> `if` / `then` / `else` (each optional branch emitted only when present)

## Tests (TDD, shown failing first)

`Test*JsonSchema` round-trip classes in each applicator test file, covering present/absent optional bounds and branches.

## Verification

100% coverage, `ruff` / `mypy --strict` / `codespell` / `mkdocs build` green via pre-commit.

---

**Follow-up (separate PR):** the `before`-model-validator applicators — `PropertyNames` / `PatternProperties` / `DependentSchemas` — are not in the annotation chain, so they need a model-level JSON-schema mechanism rather than `__get_pydantic_json_schema__`. Tracked in TODO.