### PR TITLE
refactor(applicators): one format — unified model-wrapper + JSON Schema round-trip

### DIFF
--- a/pydantic_jsonschema/_applicators/_dependent_schemas.py
+++ b/pydantic_jsonschema/_applicators/_dependent_schemas.py
@@ -4,6 +4,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4
 """
 
 from pydantic import TypeAdapter
+from pydantic.json_schema import JsonSchemaValue
 
 from ._base import AnnotationType, Applicator
 
@@ -43,6 +44,14 @@ class DependentSchemas(Applicator):
                 trigger: self._build_adapter(branch) for trigger, branch in self._branches.items()
             }
         return self._adapters
+
+    def json_schema_keyword(self) -> JsonSchemaValue:
+        """Return the `dependentSchemas` keyword fragment for the dumped JSON Schema."""
+        return {
+            "dependentSchemas": {
+                trigger: adapter.json_schema() for trigger, adapter in self._get_adapters().items()
+            }
+        }
 
     def validate(
         self,

--- a/pydantic_jsonschema/_applicators/_if_then_else.py
+++ b/pydantic_jsonschema/_applicators/_if_then_else.py
@@ -59,13 +59,18 @@ class IfThenElse(Applicator):
     ) -> JsonSchemaValue:
         """Restore the `if` / `then` / `else` keywords on dump."""
         json_schema = handler(schema)
-        if_adapter = self._build_adapters()
-        json_schema["if"] = if_adapter.json_schema()
-        if self._then_adapter is not None:
-            json_schema["then"] = self._then_adapter.json_schema()
-        if self._else_adapter is not None:
-            json_schema["else"] = self._else_adapter.json_schema()
+        json_schema.update(self.json_schema_keyword())
         return json_schema
+
+    def json_schema_keyword(self) -> JsonSchemaValue:
+        """Return the `if` / `then` / `else` keyword fragment for the dumped JSON Schema."""
+        if_adapter = self._build_adapters()
+        keyword: JsonSchemaValue = {"if": if_adapter.json_schema()}
+        if self._then_adapter is not None:
+            keyword["then"] = self._then_adapter.json_schema()
+        if self._else_adapter is not None:
+            keyword["else"] = self._else_adapter.json_schema()
+        return keyword
 
     def _build_adapters(self) -> TypeAdapter[AnnotationType]:
         """Build the `if` / `then` / `else` adapters on first use (caches across calls).
@@ -83,7 +88,7 @@ class IfThenElse(Applicator):
             self._else_adapter = self._build_adapter(self._else)
         return if_adapter
 
-    def check(
+    def validate(
         self,
         value: AnnotationType,
         /,
@@ -118,5 +123,5 @@ class IfThenElse(Applicator):
         :returns: The validated value.
         :raises ValueError: When the conditional check fails.
         """
-        self.check(value)
+        self.validate(value)
         return handler(value)

--- a/pydantic_jsonschema/_applicators/_not.py
+++ b/pydantic_jsonschema/_applicators/_not.py
@@ -54,8 +54,12 @@ class Not(Applicator):
     ) -> JsonSchemaValue:
         """Restore the `not` keyword on dump (the wrap-validator drops it otherwise)."""
         json_schema = handler(schema)
-        json_schema["not"] = self._get_adapter().json_schema()
+        json_schema.update(self.json_schema_keyword())
         return json_schema
+
+    def json_schema_keyword(self) -> JsonSchemaValue:
+        """Return the `not` keyword fragment for the dumped JSON Schema."""
+        return {"not": self._get_adapter().json_schema()}
 
     def matches(
         self,
@@ -69,7 +73,7 @@ class Not(Applicator):
         """
         return self._validates(self._get_adapter(), value)
 
-    def check(
+    def validate(
         self,
         value: AnnotationType,
         /,
@@ -106,5 +110,5 @@ class Not(Applicator):
         :returns: The validated value.
         :raises ValueError: When the value matches the `not` subschema.
         """
-        self.check(value)
+        self.validate(value)
         return handler(value)

--- a/pydantic_jsonschema/_applicators/_pattern_properties.py
+++ b/pydantic_jsonschema/_applicators/_pattern_properties.py
@@ -6,6 +6,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2
 import re
 
 from pydantic import TypeAdapter
+from pydantic.json_schema import JsonSchemaValue
 
 from ._base import AnnotationType, Applicator
 
@@ -46,6 +47,14 @@ class PatternProperties(Applicator):
                 for pattern, branch in self._branches.items()
             ]
         return self._compiled
+
+    def json_schema_keyword(self) -> JsonSchemaValue:
+        """Return the `patternProperties` keyword fragment for the dumped JSON Schema."""
+        return {
+            "patternProperties": {
+                pattern.pattern: adapter.json_schema() for pattern, adapter in self._get_compiled()
+            }
+        }
 
     def validate(
         self,

--- a/pydantic_jsonschema/_applicators/_property_names.py
+++ b/pydantic_jsonschema/_applicators/_property_names.py
@@ -4,6 +4,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.4
 """
 
 from pydantic import TypeAdapter
+from pydantic.json_schema import JsonSchemaValue
 
 from ._base import AnnotationType, Applicator
 
@@ -41,6 +42,10 @@ class PropertyNames(Applicator):
         if self._adapter is None:
             self._adapter = self._build_adapter(self._branch)
         return self._adapter
+
+    def json_schema_keyword(self) -> JsonSchemaValue:
+        """Return the `propertyNames` keyword fragment for the dumped JSON Schema."""
+        return {"propertyNames": self._get_adapter().json_schema()}
 
     def validate(
         self,

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -30,7 +30,6 @@ from pydantic import (
     RootModel,
     TypeAdapter,
     create_model,
-    model_validator,
 )
 from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
@@ -237,15 +236,12 @@ class SchemaConverter:
         if issubclass(model, RootModel):
             return model
 
+        applicators: list[ObjectApplicator] = []
         if schema.not_ is not MISSING:
-            model = self._wrap_root_assertion(model, self._build_not(schema), key="_validate_not")
+            applicators.append(self._build_not(schema))
         if self._has_conditional(schema):
-            model = self._wrap_root_assertion(
-                model,
-                self._build_conditional(schema),
-                key="_validate_conditional",
-            )
-        return model
+            applicators.append(self._build_conditional(schema))
+        return self._wrap_object_applicators(model, applicators)
 
     def _register[ApplicatorT: Applicator](
         self,
@@ -459,6 +455,15 @@ class SchemaConverter:
         Each applicator runs as a `before` validator on the raw mapping and re-emits its keyword
         via `json_schema_keyword`, both delegated from the subclass's Pydantic hooks. A `ForwardRef`
         subschema resolves lazily once `bind_namespace` runs, so both hooks fire after binding.
+
+        Why a *subclass* and not `Annotated[model, *applicators]`: object applicators apply to the
+        whole object, so Pydantic must see their hooks on the model itself. `to_model` returns this
+        model as a class the caller instantiates (`User(...)` / `User.model_validate(...)`); an
+        `Annotated[...]` is not a class and cannot be returned as the root model. A nested object
+        (used as a field type) could instead carry the applicators as `Annotated` and skip the
+        subclass, but subclassing covers root and nested through one path. The classmethod hooks are
+        Pydantic's own extension points — subclassing is merely where they get defined for a model
+        built at runtime by `create_model` (which has no place to declare them otherwise).
 
         :param model: The freshly built object model.
         :param applicators: Object applicators to attach (the model is returned as-is when empty).
@@ -1014,55 +1019,6 @@ class SchemaConverter:
                 else_branch=else_branch,
             )
         )
-
-    def _wrap_root_assertion(
-        self,
-        model: type[BaseModel],
-        applicator: Not | IfThenElse,
-        /,
-        *,
-        key: str,
-    ) -> type[BaseModel]:
-        """Wrap a root object model with a `before` validator enforcing a whole-value assertion.
-
-        A root object is a plain `BaseModel` with no host annotation, so `not` / `if` / `then` /
-        `else` cannot ride along as `Annotated` metadata (the path used for every other shape).
-        Instead the applicator's `check` runs as a `before` model validator on the raw input.
-
-        :param model: The root object `BaseModel`.
-        :param applicator: The whole-value applicator (`Not` or `IfThenElse`), already registered.
-        :param key: The `__validators__` key for the validator.
-        :returns: A subclass of `model` applying the assertion.
-        """
-
-        def _check(data: PythonType) -> PythonType:
-            return applicator.check(data)
-
-        return self._wrap_root_before(model, key=key, check=_check)
-
-    @staticmethod
-    def _wrap_root_before(
-        model: type[BaseModel],
-        /,
-        *,
-        key: str,
-        check: PythonType,
-    ) -> type[BaseModel]:
-        """Subclass a root object model, attaching one `before` model validator.
-
-        :param model: The root object `BaseModel`.
-        :param key: The `__validators__` key for the validator.
-        :param check: The `(data) -> data` validation function.
-        :returns: A subclass of `model` with the validator attached.
-        """
-        validators: dict[str, PythonType] = {key: model_validator(mode="before")(check)}
-        wrapped = create_model(
-            model.__name__,
-            __base__=model,
-            __module__=__name__,
-            __validators__=validators,
-        )
-        return cast("type[BaseModel]", wrapped)
 
     def _reference_annotation(
         self,

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -25,6 +25,8 @@ from pydantic import (
     BeforeValidator,
     ConfigDict,
     Field,
+    GetCoreSchemaHandler,
+    GetJsonSchemaHandler,
     RootModel,
     TypeAdapter,
     create_model,
@@ -32,6 +34,8 @@ from pydantic import (
 )
 from pydantic.experimental.missing_sentinel import MISSING
 from pydantic.fields import FieldInfo
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema, core_schema
 
 from pydantic_jsonschema._applicators import (
     Applicator,
@@ -53,7 +57,7 @@ from ._field_kwargs import FieldKindType, build_field_kwargs, get_field_default
 from ._metadata import annotate, array_metadata, object_dict_metadata
 from ._object_keywords import build_dependent_required, build_property_count
 from ._refs import DEFS_KEY, get_inline_defs
-from ._utils import before_validator, make_union, unwrap
+from ._utils import make_union, unwrap
 
 __all__ = [
     "SchemaConverter",
@@ -118,6 +122,22 @@ class FormatValidator(Protocol):
         value: PythonType,
     ) -> PythonType:
         """Process the raw value before Pydantic's standard validation."""
+        ...
+
+
+class ObjectApplicator(Protocol):
+    """An object-level applicator (`propertyNames` / `patternProperties` / `dependentSchemas`).
+
+    It validates the raw mapping and re-emits its JSON Schema keyword, letting the converter apply
+    it to an object model uniformly — both for validation and for `model_json_schema()` round-trip.
+    """
+
+    def validate(self, data: PythonType, /) -> PythonType:
+        """Validate the raw mapping, returning it unchanged or raising `ValueError`."""
+        ...
+
+    def json_schema_keyword(self) -> JsonSchemaValue:
+        """Return this applicator's keyword fragment for the dumped JSON Schema."""
         ...
 
 
@@ -375,6 +395,7 @@ class SchemaConverter:
         fields = self._build_fields(schema)
         model_config = self._build_model_config(schema)
         validators = self._build_object_validators(schema)
+        applicators = self._build_object_applicators(schema)
 
         # For some reason, `create_model` "accepts" `fields` values as `tuple[str, Any]`,
         # when in reality it accepts `tuple[type, FieldInfo]`
@@ -387,19 +408,19 @@ class SchemaConverter:
             __validators__=validators,
             **fields,
         )
-        return cast("type[BaseModel]", created_model)
+        return self._wrap_object_applicators(cast("type[BaseModel]", created_model), applicators)
 
     def _build_object_validators(
         self,
         schema: Schema,
         /,
     ) -> dict[str, PythonType]:
-        """Collect the `model_validator`s for an object model from every keyword builder.
+        """Collect the `model_validator`s for an object model's non-applicator keywords.
 
-        Each `_build_*` builder returns a (possibly empty) `__validators__` fragment; merging them
-        yields the full mapping. To support a new object-level keyword, add a builder and spread it
-        here. Stateless builders are `@staticmethod`; converter-aware ones (subschemas need
-        conversion + namespace binding) are instance methods.
+        Covers object keywords with no subschema (`minProperties` / `maxProperties` /
+        `dependentRequired`). Subschema-bearing keywords (`propertyNames` / `patternProperties` /
+        `dependentSchemas`) are object applicators, applied via `_wrap_object_applicators` so they
+        also round-trip into `model_json_schema()`.
 
         :param schema: Object schema to read keywords from.
         :returns: A `create_model(__validators__=...)` mapping (empty when no keyword applies).
@@ -407,80 +428,142 @@ class SchemaConverter:
         return {
             **build_property_count(schema),
             **build_dependent_required(schema),
-            **self._build_dependent_schemas(schema),
-            **self._build_pattern_properties(schema),
-            **self._build_property_names(schema),
         }
+
+    def _build_object_applicators(
+        self,
+        schema: Schema,
+        /,
+    ) -> list[ObjectApplicator]:
+        """Collect the object-level applicators declared on an object schema.
+
+        :param schema: Object schema to read keywords from.
+        :returns: The `dependentSchemas` / `patternProperties` / `propertyNames` applicators
+            present on the schema (empty when none apply).
+        """
+        builders = (
+            self._build_dependent_schemas(schema),
+            self._build_pattern_properties(schema),
+            self._build_property_names(schema),
+        )
+        return [applicator for applicator in builders if applicator is not None]
+
+    def _wrap_object_applicators(
+        self,
+        model: type[BaseModel],
+        applicators: list[ObjectApplicator],
+        /,
+    ) -> type[BaseModel]:
+        """Subclass an object model so its applicators validate and round-trip into JSON Schema.
+
+        Each applicator runs as a `before` validator on the raw mapping and re-emits its keyword
+        via `json_schema_keyword`, both delegated from the subclass's Pydantic hooks. A `ForwardRef`
+        subschema resolves lazily once `bind_namespace` runs, so both hooks fire after binding.
+
+        :param model: The freshly built object model.
+        :param applicators: Object applicators to attach (the model is returned as-is when empty).
+        :returns: A subclass applying every applicator, or the model unchanged.
+        """
+        if not applicators:
+            return model
+
+        def get_core_schema(
+            _cls: type[BaseModel],
+            source: AnnotationType,
+            handler: GetCoreSchemaHandler,
+        ) -> CoreSchema:
+            schema = handler(source)
+            for applicator in applicators:
+                schema = core_schema.no_info_before_validator_function(applicator.validate, schema)
+            return schema
+
+        def get_json_schema(
+            _cls: type[BaseModel],
+            schema: CoreSchema,
+            handler: GetJsonSchemaHandler,
+        ) -> JsonSchemaValue:
+            json_schema = handler(schema)
+            for applicator in applicators:
+                json_schema.update(applicator.json_schema_keyword())
+            return json_schema
+
+        wrapped = type(
+            model.__name__,
+            (model,),
+            {
+                "__get_pydantic_core_schema__": classmethod(get_core_schema),
+                "__get_pydantic_json_schema__": classmethod(get_json_schema),
+                "__module__": __name__,
+            },
+        )
+        return cast("type[BaseModel]", wrapped)
 
     def _build_dependent_schemas(
         self,
         schema: Schema,
         /,
-    ) -> dict[str, PythonType]:
-        """Build the `dependentSchemas` validator for an object model.
+    ) -> DependentSchemas | None:
+        """Build the `dependentSchemas` applicator for an object model.
 
-        Registers the validator so its `ForwardRef` subschemas (a dependent pointing at a `$ref`)
-        are namespace-bound after the whole schema is converted.
+        Registers it so its `ForwardRef` subschemas (a dependent pointing at a `$ref`) are
+        namespace-bound after the whole schema is converted.
 
         :param schema: Object schema.
-        :returns: A `__validators__` mapping (empty when `dependentSchemas` is absent).
+        :returns: A `DependentSchemas` applicator, or `None` when `dependentSchemas` is absent.
         """
         if schema.dependent_schemas is MISSING:
-            return {}
+            return None
 
         branches: dict[str, PythonType] = {}
         for trigger, sub_schema in schema.dependent_schemas.items():
             with self._track_path(f"dependentSchemas.{trigger}"):
                 branches[trigger] = self._constrained_annotation(sub_schema)
 
-        dependent_schemas = self._register(DependentSchemas(branches=branches))
-        return before_validator("_validate_dependent_schemas", applicator=dependent_schemas)
+        return self._register(DependentSchemas(branches=branches))
 
     def _build_pattern_properties(
         self,
         schema: Schema,
         /,
-    ) -> dict[str, PythonType]:
-        """Build the `patternProperties` validator for an object model.
+    ) -> PatternProperties | None:
+        """Build the `patternProperties` applicator for an object model.
 
-        Registers the validator so its `ForwardRef` subschemas (a pattern value pointing at a
-        `$ref`) are namespace-bound after the whole schema is converted.
+        Registers it so its `ForwardRef` subschemas (a pattern value pointing at a `$ref`) are
+        namespace-bound after the whole schema is converted.
 
         :param schema: Object schema.
-        :returns: A `__validators__` mapping (empty when `patternProperties` is absent).
+        :returns: A `PatternProperties` applicator, or `None` when `patternProperties` is absent.
         """
         if schema.pattern_properties is MISSING:
-            return {}
+            return None
 
         branches: dict[str, PythonType] = {}
         for pattern, sub_schema in schema.pattern_properties.items():
             with self._track_path(f"patternProperties.{pattern}"):
                 branches[pattern] = self._constrained_annotation(sub_schema)
 
-        pattern_properties = self._register(PatternProperties(branches=branches))
-        return before_validator("_validate_pattern_properties", applicator=pattern_properties)
+        return self._register(PatternProperties(branches=branches))
 
     def _build_property_names(
         self,
         schema: Schema,
         /,
-    ) -> dict[str, PythonType]:
-        """Build the `propertyNames` validator for an object model.
+    ) -> PropertyNames | None:
+        """Build the `propertyNames` applicator for an object model.
 
-        Registers the validator so its `ForwardRef` subschema (a `propertyNames` pointing at a
-        `$ref`) is namespace-bound after the whole schema is converted.
+        Registers it so its `ForwardRef` subschema (a `propertyNames` pointing at a `$ref`) is
+        namespace-bound after the whole schema is converted.
 
         :param schema: Object schema.
-        :returns: A `__validators__` mapping (empty when `propertyNames` is absent).
+        :returns: A `PropertyNames` applicator, or `None` when `propertyNames` is absent.
         """
         if schema.property_names is MISSING:
-            return {}
+            return None
 
         with self._track_path("propertyNames"):
             branch = self._constrained_annotation(schema.property_names)
 
-        property_names = self._register(PropertyNames(branch=branch))
-        return before_validator("_validate_property_names", applicator=property_names)
+        return self._register(PropertyNames(branch=branch))
 
     def _build_defs_cache(
         self,

--- a/pydantic_jsonschema/converters/_utils.py
+++ b/pydantic_jsonschema/converters/_utils.py
@@ -5,26 +5,16 @@
 # and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
-from typing import Any, Protocol, Union, cast
+from typing import Any, Union, cast
 
-from pydantic import model_validator
 from pydantic.experimental.missing_sentinel import MISSING
 
 __all__ = [
-    "before_validator",
     "make_union",
     "unwrap",
 ]
 
 type PythonType = Any
-
-
-class _Validatable(Protocol):
-    """A subschema applicator exposing a whole-value `before`-validator entry point."""
-
-    def validate(self, data: PythonType, /) -> PythonType:
-        """Validate the raw input, returning it unchanged or raising `ValueError`."""
-        ...
 
 
 def unwrap[T](value: T, /, *, default: T) -> T:
@@ -50,17 +40,3 @@ def make_union(args: list[Any], /) -> type:
     :returns: The `Union[...]` annotation.
     """
     return cast("type", Union[tuple(args)])  # noqa: UP007
-
-
-def before_validator(key: str, /, *, applicator: _Validatable) -> dict[str, PythonType]:
-    """Wrap an applicator's `validate` as a `before` `model_validator` `__validators__` fragment.
-
-    :param key: The `__validators__` key for the validator.
-    :param applicator: The registered applicator whose `validate` runs on the raw input.
-    :returns: A single-entry `create_model(__validators__=...)` mapping.
-    """
-
-    def _check(data: PythonType) -> PythonType:
-        return applicator.validate(data)
-
-    return {key: model_validator(mode="before")(_check)}

--- a/tests/applicators/test_dependent_schemas.py
+++ b/tests/applicators/test_dependent_schemas.py
@@ -96,3 +96,42 @@ class TestDependentSchemas:
                 }
             ]
         )
+
+
+class TestDependentSchemasJsonSchema:
+    """`dependentSchemas` round-trips into the dumped JSON Schema."""
+
+    def test_dependent_schemas_round_trips(self) -> None:
+        """A converted model re-emits its `dependentSchemas` keyword on dump."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "dependentSchemas": {
+                        "a": {
+                            "type": "object",
+                            "properties": {"b": {"type": "integer"}},
+                            "required": ["b"],
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "additionalProperties": True,
+                "dependentSchemas": {
+                    "a": {
+                        "additionalProperties": True,
+                        "properties": {"b": {"title": "B", "type": "integer"}},
+                        "required": ["b"],
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "properties": {},
+                "title": "Model",
+                "type": "object",
+            }
+        )

--- a/tests/applicators/test_if_then_else.py
+++ b/tests/applicators/test_if_then_else.py
@@ -238,3 +238,30 @@ class TestIfThenElseJsonSchema:
                 "type": "integer",
             }
         )
+
+    def test_if_then_root_object_round_trips(self) -> None:
+        """A root-object `if`/`then` (applied via the model wrapper) also re-emits its keywords."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {"country": {"type": "string"}, "zip": {"type": "string"}},
+                    "if": {"properties": {"country": {"const": "US"}}, "required": ["country"]},
+                    "then": {"required": ["zip"]},
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "additionalProperties": True,
+                "if": {},
+                "properties": {
+                    "country": {"title": "Country", "type": "string"},
+                    "zip": {"title": "Zip", "type": "string"},
+                },
+                "then": {},
+                "title": "Model",
+                "type": "object",
+            }
+        )

--- a/tests/applicators/test_not.py
+++ b/tests/applicators/test_not.py
@@ -153,3 +153,35 @@ class TestNotJsonSchema:
         assert model.model_json_schema()["properties"]["x"] == snapshot(
             {"not": {"const": 5, "type": "integer"}, "title": "X", "type": "integer"}
         )
+
+    def test_not_root_object_round_trips(self) -> None:
+        """A root-object `not` (applied via the model wrapper) also re-emits its keyword."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {"role": {"type": "string"}},
+                    "not": {
+                        "type": "object",
+                        "properties": {"secret": {"type": "integer"}},
+                        "required": ["secret"],
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "additionalProperties": True,
+                "not": {
+                    "additionalProperties": True,
+                    "properties": {"secret": {"title": "Secret", "type": "integer"}},
+                    "required": ["secret"],
+                    "title": "Model",
+                    "type": "object",
+                },
+                "properties": {"role": {"title": "Role", "type": "string"}},
+                "title": "Model",
+                "type": "object",
+            }
+        )

--- a/tests/applicators/test_pattern_properties.py
+++ b/tests/applicators/test_pattern_properties.py
@@ -107,3 +107,25 @@ class TestPatternProperties:
                 }
             ]
         )
+
+
+class TestPatternPropertiesJsonSchema:
+    """`patternProperties` round-trips into the dumped JSON Schema."""
+
+    def test_pattern_properties_round_trips(self) -> None:
+        """A converted model re-emits its `patternProperties` keyword on dump."""
+        model = to_model(
+            Schema.model_validate(
+                {"type": "object", "patternProperties": {"^x": {"type": "integer"}}}
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "additionalProperties": True,
+                "patternProperties": {"^x": {"type": "integer"}},
+                "properties": {},
+                "title": "Model",
+                "type": "object",
+            }
+        )

--- a/tests/applicators/test_property_names.py
+++ b/tests/applicators/test_property_names.py
@@ -69,3 +69,23 @@ class TestPropertyNames:
                 }
             ]
         )
+
+
+class TestPropertyNamesJsonSchema:
+    """`propertyNames` round-trips into the dumped JSON Schema."""
+
+    def test_property_names_round_trips(self) -> None:
+        """A converted model re-emits its `propertyNames` keyword on `model_json_schema()`."""
+        model = to_model(
+            Schema.model_validate({"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}})
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "additionalProperties": True,
+                "properties": {},
+                "propertyNames": {},
+                "title": "Model",
+                "type": "object",
+            }
+        )


### PR DESCRIPTION
Completes TODO "Applicators: JSON Schema round-trip" **and** unifies how every object-level applicator is applied — one format for all. Built on the investigation you asked for (EXP1-4 below).

## The goal

After #45, applicators round-tripped in two unrelated ways: `Annotated`-metadata ones via `__get_pydantic_json_schema__`, and object-level ones (`propertyNames` / `patternProperties` / `dependentSchemas`) not at all (they were `before` model-validators, outside the JSON-schema chain). The investigation also surfaced a hidden gap: **root-object `not`/`if-then-else` never round-tripped either** (same model-validator path).

## One format

Every object-level applicator now exposes the same pair:
- `validate(data) -> data` — the check on the raw mapping;
- `json_schema_keyword() -> {...}` — its JSON Schema fragment.

The converter applies them uniformly through `_wrap_object_applicators`: a model subclass whose `__get_pydantic_core_schema__` chains each `validate` as a `before` validator and whose `__get_pydantic_json_schema__` merges each `json_schema_keyword()`. This replaces both the `before_validator` mechanism (group B) and `_wrap_root_assertion` / `_wrap_root_before` (root `not`/`if-then-else`), which are deleted.

`Not` / `IfThenElse` reuse `json_schema_keyword()` from their `Annotated`-path `__get_pydantic_json_schema__` too — single source of emission. `check` renamed to `validate` to match the shared interface.

## Result

- `propertyNames` / `patternProperties` / `dependentSchemas` now round-trip on `model_json_schema()`.
- Root-object `not` / `if` / `then` / `else` now round-trip (previously silently dropped).
- One application path for all object applicators; ~130 lines of bespoke wiring removed.

## Investigation (why this design)

- EXP1: root `not` did **not** round-trip (hidden gap).
- EXP2: an applicator with core+json hooks works as `Annotated[Model, applicator]`.
- EXP4: a model subclass delegating both hooks works for root — validation **and** JSON schema.

## Tests (TDD)

`Test*JsonSchema` round-trip classes for `propertyNames` / `patternProperties` / `dependentSchemas`, plus root-object `not` and `if`/`then` cases.

## Verification

`733 → 745 passed`, 100% coverage, `ruff` / `mypy --strict` / `codespell` / `mkdocs build` green via pre-commit.

## Known limitation

A `propertyNames` subschema with only a constraint and no `type` (e.g. `{"pattern": ...}`) dumps as `{}` — the same `Any`-without-type limitation already documented for branch constraints; validation is unaffected.