### PR TITLE
refactor(applicators): `AnnotationApplicator` / `ObjectApplicator` ABC roles

### DIFF
--- a/pydantic_jsonschema/_applicators/__init__.py
+++ b/pydantic_jsonschema/_applicators/__init__.py
@@ -30,7 +30,7 @@ The converter collects them and calls `bind_namespace` once conversion finishes.
 [spec]: https://json-schema.org/draft/2020-12/json-schema-core#section-10
 """
 
-from ._base import Applicator
+from ._base import AnnotationApplicator, Applicator, ObjectApplicator
 from ._contains import Contains
 from ._dependent_schemas import DependentSchemas
 from ._if_then_else import IfThenElse
@@ -41,11 +41,13 @@ from ._prefix_items import PrefixItems
 from ._property_names import PropertyNames
 
 __all__ = [
+    "AnnotationApplicator",
     "Applicator",
     "Contains",
     "DependentSchemas",
     "IfThenElse",
     "Not",
+    "ObjectApplicator",
     "OneOf",
     "PatternProperties",
     "PrefixItems",

--- a/pydantic_jsonschema/_applicators/_base.py
+++ b/pydantic_jsonschema/_applicators/_base.py
@@ -1,18 +1,39 @@
-"""Shared base for applicator validators.
+"""Shared base and roles for applicator validators.
 
 Every applicator validates values against one or more subschemas via a `TypeAdapter`. A subschema
 may be a `ForwardRef` (a keyword pointing at a `$ref`) that only becomes resolvable after the whole
 schema — including `$defs` — is converted. Applicators therefore build their adapters lazily, and
 the converter binds a forward-ref namespace via `bind_namespace` once conversion finishes.
+
+`Applicator` holds that shared plumbing; two abstract roles extend it and declare the hooks each
+kind must implement:
+
+- `AnnotationApplicator` — applied as `Annotated[type, self]` metadata, overriding Pydantic's
+  `__get_pydantic_core_schema__` / `__get_pydantic_json_schema__`;
+- `ObjectApplicator` — applied to an object model via the converter's model-wrapper, exposing
+  `validate` / `json_schema_keyword`.
+
+`Not` and `IfThenElse` fill both roles (used on a field annotation and on a root object).
 """
 
+from abc import ABC, abstractmethod
 from typing import Any, ForwardRef
 
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic import (
+    BaseModel,
+    GetCoreSchemaHandler,
+    GetJsonSchemaHandler,
+    TypeAdapter,
+    ValidationError,
+)
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
 
 __all__ = [
+    "AnnotationApplicator",
     "AnnotationType",
     "Applicator",
+    "ObjectApplicator",
 ]
 
 # Any annotation Pydantic supports (`type`, `Annotated`, `Union`, `Literal`, `ForwardRef`, ...).
@@ -20,12 +41,13 @@ type AnnotationType = Any
 
 
 class Applicator:
-    """Base for validators that check values against `TypeAdapter`-wrapped subschemas.
+    """Plumbing base for validators that check values against `TypeAdapter`-wrapped subschemas.
 
     Holds the forward-ref namespace and provides the shared plumbing: resolving a `ForwardRef`
     subschema and building its adapter, and testing whether a value validates against an adapter.
     Subclasses own their adapter caching (single / list / mapping), since the shape differs per
-    keyword.
+    keyword. Concrete applicators extend the abstract roles `AnnotationApplicator` and/or
+    `ObjectApplicator` (which carry the required hooks), never this class directly.
     """
 
     def __init__(self) -> None:
@@ -75,3 +97,44 @@ class Applicator:
         except ValidationError:
             return False
         return True
+
+
+class AnnotationApplicator(Applicator, ABC):
+    """An applicator applied as `Annotated[type, self]` metadata on a value annotation.
+
+    It overrides Pydantic's schema hooks: `__get_pydantic_core_schema__` enforces the keyword
+    during validation, and `__get_pydantic_json_schema__` re-emits it on `model_json_schema()`.
+    """
+
+    @abstractmethod
+    def __get_pydantic_core_schema__(
+        self,
+        source_type: AnnotationType,
+        handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        """Build the core schema wrapping the host type with this applicator's check."""
+
+    @abstractmethod
+    def __get_pydantic_json_schema__(
+        self,
+        schema: CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Re-emit this applicator's keyword into the dumped JSON Schema."""
+
+
+class ObjectApplicator(Applicator, ABC):
+    """An applicator applied to an object model via the converter's model-wrapper.
+
+    The wrapper delegates `validate` (raw-mapping check, run as a `before` validator) and
+    `json_schema_keyword` (keyword fragment) from the model subclass's Pydantic hooks, so object
+    keywords round-trip without riding on an `Annotated` annotation.
+    """
+
+    @abstractmethod
+    def validate(self, data: AnnotationType, /) -> AnnotationType:
+        """Validate the raw mapping, returning it unchanged or raising `ValueError`."""
+
+    @abstractmethod
+    def json_schema_keyword(self) -> JsonSchemaValue:
+        """Return this applicator's keyword fragment for the dumped JSON Schema."""

--- a/pydantic_jsonschema/_applicators/_contains.py
+++ b/pydantic_jsonschema/_applicators/_contains.py
@@ -9,7 +9,7 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
-from ._base import AnnotationType, Applicator
+from ._base import AnnotationApplicator, AnnotationType
 
 __all__ = ["Contains"]
 
@@ -17,7 +17,7 @@ __all__ = ["Contains"]
 _DEFAULT_MIN_CONTAINS: Final[int] = 1
 
 
-class Contains(Applicator):
+class Contains(AnnotationApplicator):
     """Enforce JSON Schema `contains` / `minContains` / `maxContains` on an array.
 
     Counts how many array elements validate against the `contains` subschema and requires that

--- a/pydantic_jsonschema/_applicators/_dependent_schemas.py
+++ b/pydantic_jsonschema/_applicators/_dependent_schemas.py
@@ -6,12 +6,12 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4
 from pydantic import TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 
-from ._base import AnnotationType, Applicator
+from ._base import AnnotationType, ObjectApplicator
 
 __all__ = ["DependentSchemas"]
 
 
-class DependentSchemas(Applicator):
+class DependentSchemas(ObjectApplicator):
     """Enforce JSON Schema `dependentSchemas`: a present property triggers a whole-object schema.
 
     For each `{property: subschema}` pair, when the property is present in the object the entire

--- a/pydantic_jsonschema/_applicators/_if_then_else.py
+++ b/pydantic_jsonschema/_applicators/_if_then_else.py
@@ -7,12 +7,12 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
-from ._base import AnnotationType, Applicator
+from ._base import AnnotationApplicator, AnnotationType, ObjectApplicator
 
 __all__ = ["IfThenElse"]
 
 
-class IfThenElse(Applicator):
+class IfThenElse(AnnotationApplicator, ObjectApplicator):
     """Enforce JSON Schema `if` / `then` / `else` conditional application.
 
     If the instance validates against `if`, it must also validate against `then`; otherwise it

--- a/pydantic_jsonschema/_applicators/_not.py
+++ b/pydantic_jsonschema/_applicators/_not.py
@@ -7,12 +7,12 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
-from ._base import AnnotationType, Applicator
+from ._base import AnnotationApplicator, AnnotationType, ObjectApplicator
 
 __all__ = ["Not"]
 
 
-class Not(Applicator):
+class Not(AnnotationApplicator, ObjectApplicator):
     """Enforce JSON Schema `not`: the instance must NOT validate against the subschema.
 
     Used two ways, both checking the *raw* input (before the host type coerces it):

--- a/pydantic_jsonschema/_applicators/_one_of.py
+++ b/pydantic_jsonschema/_applicators/_one_of.py
@@ -10,12 +10,12 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
-from ._base import AnnotationType, Applicator
+from ._base import AnnotationApplicator, AnnotationType
 
 __all__ = ["OneOf"]
 
 
-class OneOf(Applicator):
+class OneOf(AnnotationApplicator):
     """Enforce JSON Schema `oneOf` semantics: exactly one branch must match.
 
     Python `Union` accepts a value when *any* branch matches (`anyOf` semantics),

--- a/pydantic_jsonschema/_applicators/_pattern_properties.py
+++ b/pydantic_jsonschema/_applicators/_pattern_properties.py
@@ -8,12 +8,12 @@ import re
 from pydantic import TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 
-from ._base import AnnotationType, Applicator
+from ._base import AnnotationType, ObjectApplicator
 
 __all__ = ["PatternProperties"]
 
 
-class PatternProperties(Applicator):
+class PatternProperties(ObjectApplicator):
     """Enforce JSON Schema `patternProperties`: regex-keyed property-value subschemas.
 
     Every property whose name matches a regex must have a value validating against that regex's

--- a/pydantic_jsonschema/_applicators/_prefix_items.py
+++ b/pydantic_jsonschema/_applicators/_prefix_items.py
@@ -9,12 +9,12 @@ from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter, Va
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
-from ._base import AnnotationType, Applicator
+from ._base import AnnotationApplicator, AnnotationType
 
 __all__ = ["PrefixItems"]
 
 
-class PrefixItems(Applicator):
+class PrefixItems(AnnotationApplicator):
     """Enforce JSON Schema `prefixItems`: positional (tuple-style) array validation.
 
     Element `i` is validated against `prefixItems[i]`; elements past the prefix are validated

--- a/pydantic_jsonschema/_applicators/_property_names.py
+++ b/pydantic_jsonschema/_applicators/_property_names.py
@@ -6,12 +6,12 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.4
 from pydantic import TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 
-from ._base import AnnotationType, Applicator
+from ._base import AnnotationType, ObjectApplicator
 
 __all__ = ["PropertyNames"]
 
 
-class PropertyNames(Applicator):
+class PropertyNames(ObjectApplicator):
     """Enforce JSON Schema `propertyNames`: every property name must match the subschema.
 
     Property names are always strings, so the subschema typically constrains the string (a

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -42,6 +42,7 @@ from pydantic_jsonschema._applicators import (
     DependentSchemas,
     IfThenElse,
     Not,
+    ObjectApplicator,
     OneOf,
     PatternProperties,
     PrefixItems,
@@ -121,22 +122,6 @@ class FormatValidator(Protocol):
         value: PythonType,
     ) -> PythonType:
         """Process the raw value before Pydantic's standard validation."""
-        ...
-
-
-class ObjectApplicator(Protocol):
-    """An object-level applicator (`propertyNames` / `patternProperties` / `dependentSchemas`).
-
-    It validates the raw mapping and re-emits its JSON Schema keyword, letting the converter apply
-    it to an object model uniformly — both for validation and for `model_json_schema()` round-trip.
-    """
-
-    def validate(self, data: PythonType, /) -> PythonType:
-        """Validate the raw mapping, returning it unchanged or raising `ValueError`."""
-        ...
-
-    def json_schema_keyword(self) -> JsonSchemaValue:
-        """Return this applicator's keyword fragment for the dumped JSON Schema."""
         ...
 
 


### PR DESCRIPTION
Gives applicators an explicit type hierarchy with `abc.abstractmethod`, so each class declares — and the type checker enforces — exactly which hooks it must implement. Pure refactor, no behaviour change.

## Why

Pydantic offers no base class for `__get_pydantic_core_schema__` / `__get_pydantic_json_schema__` (they are a duck-typed protocol), and after the round-trip work applicators split into two roles with different interfaces. Nothing declared those interfaces — a missing hook only surfaced at runtime, and the converter carried a stand-in `ObjectApplicator` `Protocol`.

## What

`_base.py` now defines:
- `Applicator` — the plumbing base (namespace + adapter building), unchanged;
- `AnnotationApplicator(Applicator, ABC)` — abstract `__get_pydantic_core_schema__` + `__get_pydantic_json_schema__` (applied as `Annotated` metadata);
- `ObjectApplicator(Applicator, ABC)` — abstract `validate` + `json_schema_keyword` (applied via the converter model-wrapper).

Re-parenting:
- `OneOf` / `Contains` / `PrefixItems` -> `AnnotationApplicator`;
- `PropertyNames` / `PatternProperties` / `DependentSchemas` -> `ObjectApplicator`;
- `Not` / `IfThenElse` -> **both** (used on a field annotation and on a root object).

The converters stand-in `ObjectApplicator` `Protocol` is deleted and replaced by importing the real ABC — one definition instead of a duplicate.

`Applicator` itself stays a plain class (no shared abstract method across roles; making it an ABC would trip `B024`). The abstract methods live on the two roles.

## Verification

745 passed (unchanged), 100% coverage, `ruff` / `mypy --strict` / `codespell` / `mkdocs build` green via pre-commit.