### PR TITLE
docs(readme): remove completed section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,15 +109,6 @@ Per-object control over how each type is loaded, inspired by
 
 [https://danipulok.github.io/pydantic-jsonschema/](https://danipulok.github.io/pydantic-jsonschema/)
 
-## Roadmap
-
-- [x] Custom JSON Schema implementation (remove `openapi-pydantic` dependency)
-- [x] Remove `fqdn` and `rfc3986` dependencies
-- [x] Remove `email-validator` dependency
-- [x] Logic fixes in schema conversion
-- [x] Add `inline_snapshot` for tests
-- [ ] Configurable loading by type (inspired by [adaptix](https://github.com/reagento/adaptix))
-
 ## Acknowledgments
 
 - [vgavro](https://github.com/vgavro) — initial library idea and early guidance


### PR DESCRIPTION
Removes the `Roadmap` section from the README. Every item in it is done — `openapi-pydantic` / `fqdn` / `rfc3986` / `email-validator` dependencies dropped, conversion logic fixes landed, `inline_snapshot` adopted — so the list was stale and misleading.

The one remaining forward-looking item (configurable loading by type) is already covered by the **Planned: configurable loading by type** section above, so nothing is lost.