### PR TITLE
refactor(formats)!: accept only types/`Annotated` in `formats`, drop `FormatValidator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ validation.
 
 ### 3. Formats
 
-Built-in validators for every `format` in the JSON Schema spec (`email`, `uri`, `uuid`,
+Built-in types for every `format` in the JSON Schema spec (`email`, `uri`, `uuid`,
 `date-time`, `hostname`, `json-pointer`, `regex`, and more) — with zero extra
-dependencies. Pass your own callable for custom formats.
+dependencies. Map your own Pydantic type for custom formats.
 
 ```python
 from pydantic_jsonschema import Schema, to_model

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -9,7 +9,7 @@ applies.
 
 ## Third-Party Validator Libraries
 
-All built-in format validators work with zero extra dependencies.
+All built-in formats work with zero extra dependencies.
 For domain-specific types, install [`pydantic-extra-types`](https://github.com/pydantic/pydantic-extra-types) or other packages directly.
 
 See [Installation](install.md#third-party-validator-libraries) for the install commands.
@@ -132,7 +132,7 @@ print(type(user.created_at).__name__)
 
 ## Third-Party Pydantic Types
 
-If you want to use third-party or custom format validators, you can pass them via `formats`.
+If you want to use third-party or custom format types, you can pass them via `formats`.
 Here's an example involving `pydantic-extra-types` package.
 
 ```python title="extra_types.py"
@@ -169,15 +169,17 @@ MAC addresses, and phone numbers. See the
 [pydantic-extra-types documentation](https://github.com/pydantic/pydantic-extra-types) for the full
 list.
 
-## Custom Validators
+## Custom Formats
 
-Use a callable when you want to validate or normalize a project-specific format.
+A custom format is a Pydantic type you map to a `format` value — exactly how the built-in
+aliases are defined (`Email = Annotated[str, AfterValidator(...)]`). Wrap your own validation or
+normalization in an `Annotated` type; the wrapper you choose (`AfterValidator`, `BeforeValidator`,
+`Field(...)`) controls how and when it runs, so you keep full control.
 
-Callable validators receive the raw input before Pydantic type coercion. They should return the
-validated value and raise `ValueError` when validation fails.
+```python title="custom_sku_format.py"
+from typing import Annotated
 
-```python title="custom_sku_validator.py"
-from pydantic import ValidationError
+from pydantic import AfterValidator, ValidationError
 
 from pydantic_jsonschema import Schema, to_model
 
@@ -204,6 +206,8 @@ def validate_sku(value: str) -> str:
     return value.upper()
 
 
+Sku = Annotated[str, AfterValidator(validate_sku)]
+
 schema = Schema.model_validate(
     {
         "type": "object",
@@ -213,7 +217,7 @@ schema = Schema.model_validate(
     }
 )
 
-Product = to_model(schema, formats={"sku": validate_sku})
+Product = to_model(schema, formats={"sku": Sku})
 
 product = Product(sku="abc-1234-xyz")
 print(product.sku)
@@ -226,38 +230,22 @@ except ValidationError as er:
     #> ValidationError
 ```
 
-## Validator Types
+## Accepted Forms
 
-`formats` accepts these validator forms:
+`formats` maps each format name to a Pydantic type. Two forms are accepted:
 
-| Validator form   | Example                    | Behavior                                                       |
-|------------------|----------------------------|----------------------------------------------------------------|
-| Callable         | `{"sku": validate_sku}`    | Called before Pydantic type validation                         |
-| Pydantic type    | `{"url": HttpUrl}`         | Replaces the generated annotation                              |
-| `Annotated` type | `{"price": PositivePrice}` | Replaces the generated annotation and preserves its validators |
+| Form             | Example                    | Behavior                                            |
+|------------------|----------------------------|-----------------------------------------------------|
+| Type class       | `{"url": HttpUrl}`         | Replaces the generated annotation                   |
+| `Annotated` type | `{"price": PositivePrice}` | Replaces the annotation, preserving its validators  |
 
-### Callable Validators
+A bare callable is **not** accepted — wrap it in `Annotated[...]` so the timing is explicit
+(`Annotated[str, BeforeValidator(fn)]` for raw input, `Annotated[str, AfterValidator(fn)]` for the
+coerced value).
 
-```python title="callable_validator.py"
-from pydantic import JsonValue
+### Type classes
 
-
-def normalize_phone(value: JsonValue) -> str:
-    digits = "".join(character for character in str(value) if character.isdigit())
-
-    if len(digits) != 10:
-        msg = "Phone number must contain 10 digits"
-        raise ValueError(msg)
-
-    return f"({digits[:3]}) {digits[3:6]}-{digits[6:]}"
-
-
-formats = {"phone": normalize_phone}
-```
-
-### Pydantic Types
-
-```python title="pydantic_type_validator.py"
+```python title="type_class_format.py"
 from pydantic import HttpUrl
 from pydantic_extra_types.color import Color
 
@@ -267,40 +255,41 @@ formats = {
 }
 ```
 
-### Annotated Types
+### Annotated types
 
-```python title="annotated_validator.py"
+```python title="annotated_format.py"
 from typing import Annotated
 
-from pydantic import AfterValidator, Field
+from pydantic import AfterValidator, BeforeValidator, Field
 
 
 def round_price(value: float) -> float:
     return round(value, 2)
 
 
-PositivePrice = Annotated[
-    float,
-    Field(gt=0),
-    AfterValidator(round_price),
-]
+def normalize_phone(value: str) -> str:
+    digits = "".join(character for character in value if character.isdigit())
 
-formats = {"price": PositivePrice}
+    if len(digits) != 10:
+        msg = "Phone number must contain 10 digits"
+        raise ValueError(msg)
+
+    return f"({digits[:3]}) {digits[3:6]}-{digits[6:]}"
+
+
+# `AfterValidator` runs on the coerced value; `BeforeValidator` runs on the raw input.
+PositivePrice = Annotated[float, Field(gt=0), AfterValidator(round_price)]
+Phone = Annotated[str, BeforeValidator(normalize_phone)]
+
+formats = {"price": PositivePrice, "phone": Phone}
 ```
 
 ## Execution Order
 
-Execution order depends on the validator form:
-
-| Validator form   | Order                                           |
-|------------------|-------------------------------------------------|
-| Callable         | format callable, then generated type validation |
-| Pydantic type    | Pydantic type validation                        |
-| `Annotated` type | validators defined inside the `Annotated` type  |
-
-For callable validators, the value passed to the function is the raw input value. For Pydantic
-types and `Annotated` types, the validator replaces the generated annotation, so Pydantic runs that
-type's own validation pipeline.
+Each format type replaces the generated annotation and runs its own validation pipeline. With an
+`Annotated` type you set the order explicitly through the wrappers you include: `BeforeValidator`
+runs on the raw input, then Pydantic coerces to the base type, then `AfterValidator` and
+`Field(...)` constraints run on the coerced value.
 
 ## Error Handling
 

--- a/examples/custom_formats.py
+++ b/examples/custom_formats.py
@@ -1,6 +1,9 @@
-"""Add domain-specific validation with custom format validators."""
+"""Map a JSON Schema `format` to a custom Pydantic type."""
 
 import re
+from typing import Annotated
+
+from pydantic import AfterValidator
 
 from pydantic_jsonschema import Schema, to_model
 
@@ -30,6 +33,13 @@ def validate_price(value: float) -> float:
     return value
 
 
+# A custom format is a Pydantic type, the same shape as the built-in formats
+# (e.g. `Email = Annotated[str, AfterValidator(...)]`). The wrapper you pick
+# (`AfterValidator`, `BeforeValidator`, ...) controls when validation runs.
+Sku = Annotated[str, AfterValidator(validate_sku)]
+Price = Annotated[float, AfterValidator(validate_price)]
+
+
 product_schema = Schema.model_validate(
     {
         "type": "object",
@@ -45,8 +55,8 @@ product_schema = Schema.model_validate(
 Product = to_model(
     product_schema,
     formats={
-        "sku": validate_sku,
-        "price": validate_price,
+        "sku": Sku,
+        "price": Price,
     },
 )
 

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -729,7 +729,8 @@ class SchemaConverter:
             return format_type
 
         msg = (
-            f"`formats[{schema.format!r}]` must be a type or `Annotated` type, got {format_type!r}"
+            f"`formats[{schema.format!r}]` must be a type or `Annotated` type, "
+            f"got `{format_type!r}`"
         )
         raise SchemaConversionError(msg)
 

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -14,7 +14,6 @@ from typing import (
     Final,
     ForwardRef,
     Literal,
-    Protocol,
     TypeAliasType,
     cast,
     get_origin,
@@ -91,38 +90,7 @@ type SchemaHash = str  # Schema cache key (JSON hash)
 type FormatName = str  # Format name like "date-time", "uuid"
 type AnnotationType = Any  # `type`, `Annotated`, `Union`, `Literal`, `ForwardRef`, etc.
 type PythonType = Any  # Anything that Pydantic supports
-type FormatValidatorType = (
-    FormatValidator | type | TypeAliasType
-)  # `FormatValidator`, type, or `type` alias
-
-
-class FormatValidator(Protocol):
-    """Callable that validates a raw value for a JSON Schema `format`.
-
-    This describes the *callable* form of a `formats` entry (a value may also be a
-    Pydantic type or an `Annotated` type). The callable receives the raw input before
-    Pydantic's standard validation and returns the validated value, or raises `ValueError`.
-
-    See [validation §7.1](https://json-schema.org/draft/2020-12/json-schema-validation#section-7.1).
-
-    For Pydantic validators, see
-    [annotated validators](https://docs.pydantic.dev/latest/concepts/validators/#annotated-validators)
-    and [after validators](https://docs.pydantic.dev/latest/concepts/validators/#after-validators).
-    """
-
-    # NOTE: `value` must stay `Any`-typed: protocol parameters are contravariant,
-    # so narrowing it (e.g. to `JsonValue`) stops narrow user validators like
-    # `def validate_sku(value: str) -> str` from matching the protocol.
-    #
-    # Reproduce with `value: JsonValue`:
-    #   uv run mypy examples/custom_formats.py
-    #   # -> error: Dict entry 0 has incompatible type "str": "Callable[[str], str]"
-    def __call__(
-        self,
-        value: PythonType,
-    ) -> PythonType:
-        """Process the raw value before Pydantic's standard validation."""
-        ...
+type FormatType = type | TypeAliasType  # A type, `Annotated` type, or PEP 695 `type` alias
 
 
 class SchemaConverter:
@@ -133,17 +101,18 @@ class SchemaConverter:
         *,
         default_model_name: str = _DEFAULT_MODEL_NAME,
         refs: dict[Ref, type[BaseModel]] | None = None,
-        formats: dict[FormatName, FormatValidatorType] | None = None,
+        formats: dict[FormatName, FormatType] | None = None,
     ) -> None:
-        """Initialize converter with optional pre-built refs and format validators.
+        """Initialize converter with optional pre-built refs and format types.
 
         :param default_model_name: Fallback name for models without `title` (default: `Model`).
         :param refs: Pre-built Pydantic models for `$ref` resolution.
-        :param formats: Validators keyed by JSON Schema `format` value.
+        :param formats: Format types (a `type` or `Annotated` type) keyed by JSON Schema
+            `format` value.
         """
         self._default_model_name: str = default_model_name
         self._refs: dict[Ref, type[BaseModel]] = refs or {}
-        self._formats: dict[FormatName, FormatValidatorType] = formats or {}
+        self._formats: dict[FormatName, FormatType] = formats or {}
 
         self._defs_cache: dict[Ref, Schema] = {}
         self._models_cache: dict[SchemaHash, type[BaseModel]] = {}
@@ -720,43 +689,49 @@ class SchemaConverter:
 
         return fields
 
-    def _apply_validators(
+    def _apply_format(
         self,
         annotation: AnnotationType,
         schema: Schema,
         /,
     ) -> AnnotationType:
-        """Apply validator to annotation.
+        """Apply the registered format type for the schema's `format`, if any.
 
-        Handles these validator kinds:
-        - `type` aliases (the built-in format types): unwrapped to their underlying
-          `Annotated` / type, then handled like the cases below.
-        - Annotated types: used directly as annotation (replaces original).
-        - Type classes: used directly as annotation (replaces original).
-        - Callables: wrapped with `BeforeValidator`.
+        A `formats` entry is a Pydantic type that defines how the format is validated; the
+        caller keeps full control over *when* validation runs by choosing the wrapper inside
+        the type (e.g. `AfterValidator` vs `BeforeValidator`):
+        - PEP 695 `type` aliases (the built-in format types): unwrapped to the underlying
+          `Annotated` / type they alias, then handled like the cases below.
+        - `Annotated` types: used directly as the field annotation (replaces the original).
+        - Type classes: used directly as the field annotation (replaces the original).
 
         :param annotation: Original annotation.
-        :param schema: Schema to check for format.
-        :returns: Annotation with validator applied if applicable.
+        :param schema: Schema to check for `format`.
+        :returns: The format type's annotation when a matching entry exists, else `annotation`.
+        :raises SchemaConversionError: If the matching `formats` entry is not a type or
+            `Annotated` type.
         """
         if schema.format is MISSING or schema.format not in self._formats:
             return annotation
 
-        validator = self._formats[schema.format]
+        format_type = self._formats[schema.format]
 
         # Built-in format types (`Email`, `UUID`, ...) are PEP 695 `type` aliases, i.e.
         # `TypeAliasType`. Unwrap to the actual `Annotated` / class they alias so the field
         # annotation stays clean (`str`, `uuid.UUID`) instead of the alias wrapper.
-        if isinstance(validator, TypeAliasType):
-            validator = validator.__value__
+        if isinstance(format_type, TypeAliasType):
+            format_type = format_type.__value__
 
-        if get_origin(validator) is Annotated:
-            return validator
+        if get_origin(format_type) is Annotated:
+            return format_type
 
-        if isinstance(validator, type):
-            return validator
+        if isinstance(format_type, type):
+            return format_type
 
-        return Annotated[annotation, BeforeValidator(validator)]
+        msg = (
+            f"`formats[{schema.format!r}]` must be a type or `Annotated` type, got {format_type!r}"
+        )
+        raise SchemaConversionError(msg)
 
     @staticmethod
     def _build_model_config(
@@ -793,7 +768,7 @@ class SchemaConverter:
         else:
             valid_annotation = annotation
 
-        valid_annotation = self._apply_validators(valid_annotation, schema)
+        valid_annotation = self._apply_format(valid_annotation, schema)
 
         default = get_field_default(schema, field_kind=field_kind)
 
@@ -938,7 +913,7 @@ class SchemaConverter:
         if isinstance(schema, Reference):
             return annotation
 
-        annotation = self._apply_validators(annotation, schema)
+        annotation = self._apply_format(annotation, schema)
         kwargs = build_field_kwargs(schema, include_metadata=not union_branch)
 
         if kwargs and not (union_branch and annotation is Any):
@@ -1250,13 +1225,14 @@ def to_model(
     *,
     model_name: str | None = None,
     refs: dict[Ref, type[BaseModel]] | None = None,
-    formats: dict[FormatName, FormatValidatorType] | None = None,
+    formats: dict[FormatName, FormatType] | None = None,
 ) -> type[BaseModel]:
     """Convert schema to Pydantic model.
 
     :param schema: Schema to convert.
     :param refs: Pre-built reference models.
-    :param formats: Custom format validators (callables, types, or Annotated).
+    :param formats: Format types (a `type` or `Annotated` type) keyed by JSON Schema
+        `format` value.
     :param model_name: Name for the generated model.
     :returns: Pydantic model class.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,3 @@ fail_under = 100
 skip_covered = true # Omit fully covered files from report output
 show_missing = true # Show line numbers of missing coverage in report
 precision = 2       # Number of decimal places in coverage percentages
-exclude_lines = [
-    "^class .*\\(Protocol\\):$",     # It's impossible to test `Protocol`
-]

--- a/tests/converters/test_formats.py
+++ b/tests/converters/test_formats.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 from ipaddress import IPv4Address
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, TypeAliasType
 from uuid import UUID
 
 import pytest
@@ -128,23 +128,6 @@ class TestFormats:
                 }
             ]
         )
-
-    def test_bare_callable_rejected(self) -> None:
-        """A bare callable (not a type / `Annotated`) is rejected with a clear error."""
-
-        def normalize(value: str) -> str:
-            return value.strip()
-
-        schema = Schema.model_validate(
-            {
-                "type": "object",
-                "properties": {"code": {"type": "string", "format": "code"}},
-                "required": ["code"],
-            }
-        )
-
-        with pytest.raises(SchemaConversionError, match=r"must be a type or `Annotated` type"):
-            to_model(schema, formats={"code": normalize})  # type: ignore[dict-item]
 
     def test_mixed_validators(self) -> None:
         """Test multiple format types in one schema."""
@@ -461,3 +444,55 @@ class TestFormats:
                 "ip": IPv4Address("192.168.1.1"),
             }
         )
+
+
+class TestFormatAcceptedForms:
+    """A `formats` entry must be a type or `Annotated` type; any other form is rejected."""
+
+    @pytest.mark.parametrize(
+        ("format_type", "value", "expected"),
+        [
+            pytest.param(
+                Annotated[str, AfterValidator(str.upper)],
+                "abc",
+                "ABC",
+                id="raw-annotated",
+            ),
+            pytest.param(IPv4Address, "1.2.3.4", IPv4Address("1.2.3.4"), id="plain-class"),
+            pytest.param(Email, "alice@example.com", "alice@example.com", id="type-alias"),
+        ],
+    )
+    def test_accepted_forms(
+        self,
+        format_type: type | TypeAliasType,
+        value: str,
+        expected: object,
+    ) -> None:
+        """Each accepted form (raw `Annotated`, plain class, PEP 695 alias) is applied."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"field": {"type": "string", "format": "custom"}},
+                "required": ["field"],
+            }
+        )
+        model = to_model(schema, formats={"custom": format_type})
+
+        assert model(field=value).model_dump() == {"field": expected}
+
+    def test_bare_callable_rejected(self) -> None:
+        """A bare callable (not a type / `Annotated`) is rejected with a clear error."""
+
+        def normalize(value: str) -> str:
+            return value.strip()
+
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"code": {"type": "string", "format": "code"}},
+                "required": ["code"],
+            }
+        )
+
+        with pytest.raises(SchemaConversionError, match=r"must be a type or `Annotated` type"):
+            to_model(schema, formats={"code": normalize})  # type: ignore[dict-item]

--- a/tests/converters/test_formats.py
+++ b/tests/converters/test_formats.py
@@ -14,6 +14,7 @@ from pydantic_core import CoreSchema, core_schema
 from pydantic_jsonschema import (
     to_model,
 )
+from pydantic_jsonschema.exceptions import SchemaConversionError
 from pydantic_jsonschema.formats import UUID as UUID_FORMAT
 from pydantic_jsonschema.formats import DateTime, Email, IPv4, Uri
 from pydantic_jsonschema.schema import Schema
@@ -26,7 +27,7 @@ __all__: list[str] = []
 
 
 class TestFormats:
-    """Tests for `formats` support: custom validators and built-in aliases."""
+    """Tests for `formats` support: custom format types and built-in aliases."""
 
     def test_annotated_validator_basic(self) -> None:
         """Test basic Annotated type as validator."""
@@ -92,8 +93,8 @@ class TestFormats:
         instance = model(count=4)
         assert instance.model_dump() == snapshot({"count": 8})
 
-    def test_callable_validator(self) -> None:
-        """Test callable function as validator."""
+    def test_annotated_str_validator(self) -> None:
+        """Test an `Annotated` string type as a format."""
 
         def validate_email_simple(v: str) -> str:
             if "@" not in v:
@@ -101,13 +102,15 @@ class TestFormats:
                 raise ValueError(msg)
             return v
 
+        EmailSimple = Annotated[str, AfterValidator(validate_email_simple)]  # noqa: N806
+
         schema_raw: SchemaRaw = {
             "type": "object",
             "properties": {"email": {"type": "string", "format": "email-simple"}},
             "required": ["email"],
         }
         schema = Schema.model_validate(schema_raw)
-        model = to_model(schema, formats={"email-simple": validate_email_simple})  # type: ignore[dict-item]
+        model = to_model(schema, formats={"email-simple": EmailSimple})
 
         instance = model(email="test@example.com")
         assert instance.model_dump() == snapshot({"email": "test@example.com"})
@@ -126,8 +129,25 @@ class TestFormats:
             ]
         )
 
+    def test_bare_callable_rejected(self) -> None:
+        """A bare callable (not a type / `Annotated`) is rejected with a clear error."""
+
+        def normalize(value: str) -> str:
+            return value.strip()
+
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"code": {"type": "string", "format": "code"}},
+                "required": ["code"],
+            }
+        )
+
+        with pytest.raises(SchemaConversionError, match=r"must be a type or `Annotated` type"):
+            to_model(schema, formats={"code": normalize})  # type: ignore[dict-item]
+
     def test_mixed_validators(self) -> None:
-        """Test multiple validator types in one schema."""
+        """Test multiple format types in one schema."""
 
         def validate_positive(v: int) -> int:
             if v <= 0:
@@ -142,6 +162,7 @@ class TestFormats:
             return v
 
         PositiveInt = Annotated[int, AfterValidator(validate_positive)]  # noqa: N806
+        Uppercase = Annotated[str, AfterValidator(validate_uppercase)]  # noqa: N806
 
         schema_raw: SchemaRaw = {
             "type": "object",
@@ -154,7 +175,7 @@ class TestFormats:
         schema = Schema.model_validate(schema_raw)
         model = to_model(
             schema,
-            formats={"positive": PositiveInt, "uppercase": validate_uppercase},  # type: ignore[dict-item]
+            formats={"positive": PositiveInt, "uppercase": Uppercase},
         )
 
         instance = model(count=5, code="ABC")


### PR DESCRIPTION
Makes `formats` accept only Pydantic types, giving the user full, explicit control over how each format is validated — and removes the bare-callable shorthand along with its `FormatValidator` Protocol.

## Why

`formats` previously accepted a bare callable, which the converter silently wrapped in a `BeforeValidator` — while the built-in format types (`Email`, ...) are `Annotated[str, AfterValidator(...)]` (an `AfterValidator`). That was inconsistent (raw input vs coerced value, before vs after) and hid the timing decision from the user.

Since `formats` already accepts `type` / `Annotated`, the user can express the exact behavior themselves (`Annotated[str, AfterValidator(fn)]` or `BeforeValidator`). So a custom format is now defined the same way as a built-in one — one concept, one obvious way, zero magic.

## Changes

- `_apply_format` (renamed from `_apply_validators`): accepts a `type` / `Annotated` / PEP 695 alias; raises `SchemaConversionError` on any other form (e.g. a bare callable).
- Deleted the `FormatValidator` Protocol and its `value: Any` contravariance NOTE; `FormatValidatorType` -> `FormatType = type | TypeAliasType`.
- Removed the now-dead `Protocol` coverage exclude from `pyproject.toml`.
- `examples/custom_formats.py`: custom formats are `Annotated` types.
- `docs/formats.md`: "Custom Validators" / "Validator Types" rewritten as "Custom Formats" / "Accepted Forms"; before/after control documented; bare-callable form removed.
- Tests: callable cases converted to `Annotated`; added a test that a bare callable is rejected with `SchemaConversionError`.

This absorbs planned items #3 (expose `FormatValidator` — now moot, deleted) and #5 (`_apply_validators` -> `_apply_format`).

## Verification

- `just lint` — clean.
- `just test` — 740 passed, 100.00% coverage.

## BREAKING CHANGE

`formats` no longer accepts a bare callable. Wrap it in an `Annotated` type, e.g. `formats={"sku": Annotated[str, AfterValidator(validate_sku)]}`. The `FormatValidator` Protocol (previously private) is removed.