### PR TITLE
ci(github): retry transient source-build install on `3.15`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
     env:
       UV_PYTHON: ${{ matrix.python-version }}
       UV_NO_SYNC: "1"
+      # `pydantic-core` ships no `cp315` wheel yet, so on 3.15 `uv` builds it from source via
+      # `cargo`, whose crates.io downloads intermittently fail (transient TLS / unexpected EOF).
+      # Make `cargo` retry each download before the step-level retry kicks in.
+      CARGO_NET_RETRY: "10"
     strategy:
       fail-fast: false
       matrix:
@@ -69,8 +73,19 @@ jobs:
       - name: Install `just`
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
+      # Retry the whole install: on 3.15 it builds `pydantic-core` from source, so a flaky
+      # crates.io download (not a code fault) shouldn't fail the run. See `CARGO_NET_RETRY` above.
       - name: Install dependencies
-        run: just ci-install-test
+        run: |
+          for attempt in 1 2 3; do
+            if just ci-install-test; then
+              exit 0
+            fi
+            echo "::warning::Install attempt ${attempt} failed; retrying in 15s"
+            sleep 15
+          done
+          echo "::error::Install failed after 3 attempts"
+          exit 1
 
       - name: Run tests with coverage
         run: just ci-test


### PR DESCRIPTION
Adds retries so a flaky source build of `pydantic-core` on Python 3.15 stops failing CI.

## Why

`pydantic-core` publishes version-specific wheels only up to `cp314` (no `cp315`, no `abi3`). On the 3.15 matrix leg `uv` therefore builds it from source via `cargo`, whose crates.io downloads intermittently fail with transient TLS / unexpected-EOF errors — not a code fault. It already cost one red run on a green PR (a manual re-run fixed it).

## Changes (`test` job only — the only leg that builds from source)

- `CARGO_NET_RETRY: "10"` — `cargo` retries each crate download before giving up.
- Wrap the `Install dependencies` step in a 3-attempt retry loop (15s backoff) so a flaky install does not fail the whole run; it still fails loudly after 3 attempts.

No third-party action; plain bash. `lint` / `docs` jobs run on a stable interpreter (wheels exist, no source build), so they are left unchanged.

## Verification

- `check-yaml` passes; workflow parses.
- `just lint` / `just test` / `just docs-build` green via pre-commit.
- Real behavior will show on this PR's 3.15 run.