### PR TITLE
feat(exceptions): re-export exception classes from the package root

### DIFF
--- a/pydantic_jsonschema/__init__.py
+++ b/pydantic_jsonschema/__init__.py
@@ -3,13 +3,23 @@
 from importlib.metadata import version as _metadata_version
 
 from pydantic_jsonschema.converters import SchemaConverter, to_model
+from pydantic_jsonschema.exceptions import (
+    BasePydanticJsonSchemaError,
+    FormatValidationError,
+    SchemaConversionError,
+    SchemaReferenceError,
+)
 from pydantic_jsonschema.schema import DataType, Reference, Schema
 
 __all__ = [
+    "BasePydanticJsonSchemaError",
     "DataType",
+    "FormatValidationError",
     "Reference",
     "Schema",
+    "SchemaConversionError",
     "SchemaConverter",
+    "SchemaReferenceError",
     "__version__",
     "to_model",
 ]

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,7 +3,8 @@
 import pytest
 from inline_snapshot import snapshot
 
-from pydantic_jsonschema.exceptions import (
+# Imported from the package root to also assert the top-level re-export.
+from pydantic_jsonschema import (
     FormatValidationError,
     SchemaConversionError,
     SchemaReferenceError,


### PR DESCRIPTION
Completes the curated top-level API surface by exposing the exception classes at the package root.

## Why

`Schema` / `Reference` / `DataType` / `to_model` / `SchemaConverter` are importable from `pydantic_jsonschema`, but the exceptions a caller catches were reachable only via `pydantic_jsonschema.exceptions`. That boundary was arbitrary. Now anything you need to call `to_model` and handle its result is at the top level.

(The earlier plan also listed exposing `FormatValidator` here — that became moot once it was deleted in #53, so this PR is exceptions only.)

## Changes

- `pydantic_jsonschema/__init__.py` re-exports `BasePydanticJsonSchemaError`, `SchemaConversionError`, `SchemaReferenceError`, `FormatValidationError`.
- `tests/test_exceptions.py` now imports them from the package root, so the test also asserts the re-export.

`pydantic_jsonschema.exceptions` remains the canonical home (unchanged); the root names are a re-export.

## Verification

- `just lint` — clean.
- `just test` — 100.00% coverage.