### PR TITLE
docs(schema): drop stale "not yet consumed" caveat

### DIFF
--- a/docs/converters.md
+++ b/docs/converters.md
@@ -121,7 +121,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 | `format` with validators                     | configured format validation                | see [Formats](formats.md)           |
 | `title`, `model_name`, `default_model_name`  | generated class name                        | `User`, `CustomUser`, `Model`       |
 
-## Unsupported Keywords
+## Unknown Keywords
 
 All JSON Schema 2020-12 validation and applicator keywords are now enforced on conversion.
 Unknown or custom keywords are still parsed and preserved on the `Schema` model (`extra="allow"`)

--- a/docs/converters.md
+++ b/docs/converters.md
@@ -123,7 +123,7 @@ Use this table as the quick reference for what each JSON Schema feature becomes.
 
 ## Unknown Keywords
 
-All JSON Schema 2020-12 validation and applicator keywords are now enforced on conversion.
+All JSON Schema 2020-12 validation and applicator keywords are enforced on conversion.
 Unknown or custom keywords are still parsed and preserved on the `Schema` model (`extra="allow"`)
 but do not affect the generated model.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -172,7 +172,7 @@ All members: `NULL`, `STRING`, `NUMBER`, `INTEGER`, `BOOLEAN`, `ARRAY`, `OBJECT`
 ## Field Reference
 
 `Schema` fields map directly to JSON Schema keywords. Other or custom keywords are preserved via `extra="allow"`.
-Some declared keywords round-trip through parsing and serialization but are not yet consumed by the converter.
+The converter consumes every declared keyword (`format` is annotation-only unless a matching entry is passed in [`formats`](formats.md), per the spec). Unknown or custom keywords round-trip through parsing and serialization without affecting the generated model.
 
 ### Composition
 

--- a/pydantic_jsonschema/schema/_models.py
+++ b/pydantic_jsonschema/schema/_models.py
@@ -71,7 +71,8 @@ class Schema(BaseModel):
     Declares the JSON Schema 2020-12 validation and applicator keywords; any other or
     custom keyword is still preserved via ``extra="allow"`` per spec §4.3.1 / §6.5.
 
-    Not every declared keyword is consumed by the converter yet: unsupported ones
+    The converter consumes every declared keyword (`format` is annotation-only unless a
+    matching `formats` entry is supplied, per the spec). Unknown or custom keywords still
     round-trip through parsing and serialization but do not affect the generated model.
 
     See:


### PR DESCRIPTION
Fixes a now-inaccurate statement: the converter consumes **every** declared `Schema` keyword.

## Why

The `Schema` docstring and `docs/schema.md` claimed "Not every declared keyword is consumed by the converter **yet** … unsupported ones … do not affect the generated model." Since the applicator round-trip work (#45/#46) every declared field is consumed:

- field-level keywords (`title`, `description`, `examples`, `default`, all numeric/string/array constraints) -> `build_field_kwargs` / `get_field_default`;
- `enum`/`const`, composition (`allOf`/`anyOf`/`oneOf`), and every applicator (`not`, `if`/`then`/`else`, `contains`, `prefixItems`, `patternProperties`, `propertyNames`, `dependentSchemas`, `min`/`maxProperties`, `dependentRequired`) -> their builders.

The only nuance is `format`, which is annotation-only unless a matching `formats` entry is supplied — by spec, not "unsupported".

## Changes

- `schema/_models.py` `Schema` docstring and `docs/schema.md`: reworded to "every declared keyword is consumed" with the `format` nuance; unknown/custom keywords still round-trip via `extra="allow"`.
- `docs/converters.md`: renamed the contradictory heading `Unsupported Keywords` -> `Unknown Keywords` (the body already says everything is enforced; it is about unknown/custom keywords).

Docs-only / docstring-only; no behavior change.

## Verification

- `just lint` / `just test` — clean, 100.00% coverage.