### PR TITLE
docs(index): add `Applicators` to the Next Steps list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,7 @@ print(post.author.name)
 - [Installation](install.md) - Install the package and third-party validator libraries
 - [Schema](schema.md) - Schema models, fields, and serialization
 - [Converters](converters.md) - Learn how schema conversion works
+- [Applicators](applicators.md) - Validate `not`, `oneOf`, `if`/`then`/`else`, and other subschema keywords
 - [Formats](formats.md) - Add validation for JSON Schema `format` values
 - [Examples](examples.md) - Run complete examples
 - [Contributing](contributing.md) - Help improve the library


### PR DESCRIPTION
Adds the missing `Applicators` link to the home page Next Steps.

## Why

`docs/applicators.md` exists and is in the `mkdocs.yml` nav, but the home page Next Steps listed every guide except Applicators. Added it in the same position as the nav (between Converters and Formats).

Docs-only.

## Verification

- `markdownlint` / `just docs-build` — clean.