### PR TITLE
refactor(converters): rename `build_property_count` to `build_property_count_bounds`

### DIFF
--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -54,7 +54,7 @@ from pydantic_jsonschema.schema import DataType, Reference, Schema
 from ._discriminator import discriminator_property
 from ._field_kwargs import FieldKindType, build_field_kwargs, get_field_default
 from ._metadata import annotate, array_metadata, object_dict_metadata
-from ._object_keywords import build_dependent_required, build_property_count
+from ._object_keywords import build_dependent_required, build_property_count_bounds
 from ._refs import DEFS_KEY, get_inline_defs
 from ._utils import make_union, unwrap
 
@@ -376,7 +376,7 @@ class SchemaConverter:
         :returns: A `create_model(__validators__=...)` mapping (empty when no keyword applies).
         """
         return {
-            **build_property_count(schema),
+            **build_property_count_bounds(schema),
             **build_dependent_required(schema),
         }
 

--- a/pydantic_jsonschema/converters/_object_keywords.py
+++ b/pydantic_jsonschema/converters/_object_keywords.py
@@ -22,13 +22,13 @@ from ._utils import unwrap
 
 __all__ = [
     "build_dependent_required",
-    "build_property_count",
+    "build_property_count_bounds",
 ]
 
 type PythonType = Any
 
 
-def build_property_count(schema: Schema, /) -> dict[str, PythonType]:
+def build_property_count_bounds(schema: Schema, /) -> dict[str, PythonType]:
     """`minProperties` / `maxProperties`: bound the number of properties of an object model.
 
     Counts the raw input mapping's keys before field parsing. That key count is exactly the


### PR DESCRIPTION
Renames the `minProperties` / `maxProperties` builder so the name reflects what it does.

## Why

`build_property_count` reads like "build a property count", but the function builds the validator that **bounds** the property count (`minProperties` / `maxProperties`). The new name matches the docstring ("bound the number of properties") and the internal `_validate_property_count` validator it produces.

## Changes

- `build_property_count` -> `build_property_count_bounds` (private converter helper) in `converters/_object_keywords.py`, its `__all__`, and the call site in `converters/_converter.py`.

Internal-only; no public API or behavior change.

## Verification

- `just lint` / `just test` — clean, 100.00% coverage.