### PR TITLE
chore(project): post-refactor audit cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: check-ast
       - id: check-case-conflict
       # NOTE: `check-docstring-first` is intentionally omitted — it misreads PEP 224
-      # attribute docstrings (strings after assignments in `_schema.py` / `_types.py`)
+      # attribute docstrings (strings after assignments in `schema/_models.py` / `formats/_types.py`)
       # as a second module docstring and aborts the commit.
       - id: check-executables-have-shebangs
       - id: check-json

--- a/pydantic_jsonschema/formats/_regex.py
+++ b/pydantic_jsonschema/formats/_regex.py
@@ -14,7 +14,7 @@ def validate_regex(value: str) -> str:
     """Validate regular expression format per JSON Schema validation, section 7.3.8.
 
     The spec requires the ECMA-262 dialect; this validator compiles with Python `re`,
-    which is a close superset for common patterns (see details in `docs/formats.md`).
+    which is a close superset for common patterns.
 
     :param value: Value to validate.
     :returns: Original value if valid.

--- a/pydantic_jsonschema/schema/_models.py
+++ b/pydantic_jsonschema/schema/_models.py
@@ -22,7 +22,6 @@ __all__ = [
     "DataType",
     "Reference",
     "Schema",
-    "SchemaOrRefType",
 ]
 
 type SchemaOrRefType = Reference | Schema


### PR DESCRIPTION
Small fixes from a from-scratch audit after the public-API refactors. No behavior change.

## Changes

- `.pre-commit-config.yaml`: the `check-docstring-first` NOTE referenced `_schema.py` / `_types.py`; updated to the current paths `schema/_models.py` / `formats/_types.py`.
- `schema/_models.py`: dropped `SchemaOrRefType` from `__all__`. It is an internal alias (used only for field annotations within the module, not re-exported by the `schema` facade), so it should not be advertised.
- `formats/_regex.py`: removed a brittle `docs/formats.md` path from the `validate_regex` docstring (it does not render as a link in the API reference; the detail already lives in the Formats guide).

## Audit result

Full sweep for stale identifiers found nothing else in code, docs, tests, or config. Docs reviewed against current code — consistent. `just lint` / `just test` green at 100.00% coverage.