### PR TITLE
docs(ssot): dedupe format-spec caveat and Python-version list

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,7 @@ Run `just` to list all available commands.
 | Format code                       | `just format`          | `ruff format` and autofix-only `ruff check`          |
 | Lint everything                   | `just lint`            | `ruff`, `mypy`, `codespell`, and `markdownlint-cli2` |
 | Run tests                         | `just test`            | `pytest` with coverage reporting                     |
-| Run all supported Python versions | `just test-all-python` | Python 3.12, 3.13, 3.14, and 3.15 test runs          |
+| Run all supported Python versions | `just test-all-python` | Test suite on every supported Python version         |
 | Generate HTML coverage            | `just testcov`         | `just test` plus `coverage html`                     |
 | Run pre-commit hooks              | `just precommit`       | `pre-commit run --all-files`                         |
 | Run the full local gate           | `just all`             | format, lint, tests, and docs build                  |

--- a/docs/converters.md
+++ b/docs/converters.md
@@ -138,9 +138,8 @@ but do not affect the generated model.
   branch is validated as a plain `dict[str, Any]` — sibling `properties` are not applied.
 - On objects that declare both `properties` and a schema-valued `additionalProperties`,
   extra fields are accepted (`extra="allow"`) but their values are not validated against the `additionalProperties` schema.
-- `format` is metadata unless a matching entry is passed in `formats` — see [Formats](formats.md).
-  Built-in aliases cover all 19 spec-defined formats;
-  `idn-*` formats use the stdlib IDNA 2003 codec and `regex` uses the Python `re` dialect (see the differences from the specification in [Formats](formats.md)).
+- `format` is metadata unless a matching entry is passed in `formats`. Built-in aliases cover all
+  19 spec-defined formats, some with minor differences from the spec — see [Formats](formats.md).
 - `not` is only as precise as the converter's coverage of its subschema. A subschema that maps to
   `Any` (an empty schema, or `required` without `type` / `properties`) matches every value, so
   `not` then rejects everything.


### PR DESCRIPTION
Single-source two facts that were stated in more than one place.

## Deduplicated

- **`idn-*` IDNA 2003 / `regex` ECMA-262 caveat** — was stated in full in `docs/formats.md` AND restated in `docs/converters.md`. Canonical home: `docs/formats.md` ("Differences from the specification"). `docs/converters.md` now just references it ("some with minor differences from the spec — see Formats") instead of repeating the IDNA/regex detail.
- **Supported Python version list** (`3.12, 3.13, 3.14, 3.15`) — was enumerated in `docs/contributing.md` on top of the CI matrix (`ci.yml`), the `justfile` recipes, and the `pyproject` classifiers. The doc line now says "every supported Python version" and defers the list to the `just test-all-python` recipe.

## Cross-referenced / left as-is (reported, not changed)

- **`requires-python` / "Python 3.12+"** — appears in `pyproject.toml` (machine-canonical) plus user-facing entry points (`README.md`, `docs/index.md`, `docs/install.md`, `docs/contributing.md`). Left as conventional per-page quick-start info; deduping into "see pyproject" would worsen the docs.
- **Coverage `100%`** — `pyproject` `fail_under = 100` is canonical; `docs/contributing.md` states "Maintain 100% coverage" as a process guideline. Left as-is (permanent project target, negligible drift risk).
- **Version list across config** (`ci.yml` matrix / `justfile` recipes / `pyproject` classifiers) — unavoidable cross-format duplication; not worth comment noise.

## Verification

- `markdownlint` / `just lint` / `just test` — clean, 100% coverage.