### PR TITLE
ci(github): supply-chain security — audit (`uv audit` + `zizmor`) and install-time malware check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up `Python`
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -60,6 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up `Python` ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -97,6 +101,32 @@ jobs:
           files: ./coverage.xml
           flags: python-${{ matrix.python-version }}
 
+  audit:
+    name: Audit
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install `uv`
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install `just`
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Install dependencies
+        run: just ci-install
+
+      - name: Audit dependencies
+        run: just ci-audit
+
+      - name: Audit GitHub Actions workflows
+        run: just ci-audit-workflows
+
   docs:
     name: Build documentation
     runs-on: ubuntu-latest
@@ -104,6 +134,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up `Python`
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,10 @@ jobs:
         run: just ci-install
 
       - name: Audit dependencies
-        run: just ci-audit
+        run: just audit
 
       - name: Audit GitHub Actions workflows
-        run: just ci-audit-workflows
+        run: just audit-workflows
 
   docs:
     name: Build documentation

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,11 @@
 name: PR
 
+# NOTE: `pull_request_target` is required so the title check works on PRs from
+#       forks (it needs the base-repo token to read PR metadata). This workflow
+#       never checks out or runs untrusted PR code, so the elevated context is
+#       safe — hence the `dangerous-triggers` suppression.
 on:
-  pull_request_target:
+  pull_request_target:  # zizmor: ignore[dangerous-triggers]
     types: [opened, edited, synchronize]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,23 +5,28 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write
+# Least privilege: grant nothing by default, scope per job below.
+permissions: {}
 
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
+      # No cache: a release publishes artifacts, and a poisoned cache could tamper with them.
       - name: Install `uv`
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Install `just`
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -40,6 +45,8 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - name: Download all the dists
@@ -55,15 +62,21 @@ jobs:
     name: Create GitHub Release
     needs: [build, publish-pypi]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
+      # No cache: a release publishes artifacts, and a poisoned cache could tamper with them.
       - name: Install `uv`
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Install `just`
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
@@ -80,8 +93,10 @@ jobs:
           name: dist
           path: dist/
 
+      # NOTE: `softprops/action-gh-release` is the established release-notes/upload path, so the
+      #       `superfluous-actions` suggestion to use `gh release` is intentionally ignored.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1  # zizmor: ignore[superfluous-actions]
         with:
           body_path: /tmp/release-notes.md
           files: dist/*
@@ -90,15 +105,22 @@ jobs:
     name: Deploy documentation
     needs: [github-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
+      # NOTE: `persist-credentials` stays on — `ci-docs-deploy` force-pushes the built site to the
+      #       `gh-pages` branch, which needs the checkout's token. Hence the `artipacked` ignore.
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0  # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
 
+      # No cache: a release publishes artifacts, and a poisoned cache could tamper with them.
       - name: Install `uv`
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Install `just`
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,3 +68,21 @@ repos:
         language: system
         always_run: true
         pass_filenames: false
+
+      # Scoped (not `always_run`): the dependency audit only matters when deps change,
+      # and the workflow audit only when a workflow changes.
+      - id: audit
+        name: Audit dependencies
+        entry: just
+        args: [audit]
+        language: system
+        files: '^(pyproject\.toml|uv\.lock)$'
+        pass_filenames: false
+
+      - id: audit-workflows
+        name: Audit workflows
+        entry: just
+        args: [audit-workflows]
+        language: system
+        files: '^\.github/workflows/.*\.ya?ml$'
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,14 +69,12 @@ repos:
         always_run: true
         pass_filenames: false
 
-      # Scoped (not `always_run`): the dependency audit only matters when deps change,
-      # and the workflow audit only when a workflow changes.
       - id: audit
         name: Audit dependencies
         entry: just
         args: [audit]
         language: system
-        files: '^(pyproject\.toml|uv\.lock)$'
+        always_run: true
         pass_filenames: false
 
       - id: audit-workflows
@@ -84,5 +82,5 @@ repos:
         entry: just
         args: [audit-workflows]
         language: system
-        files: '^\.github/workflows/.*\.ya?ml$'
+        always_run: true
         pass_filenames: false

--- a/justfile
+++ b/justfile
@@ -41,12 +41,20 @@ lint:
     uv run codespell
     npx --yes markdownlint-cli2
 
+# Audit dependencies for known vulnerabilities and abandoned packages (OSV-backed `uv audit`)
+audit:
+    uv audit --preview-features audit-command
+
+# Audit GitHub Actions workflows for security issues (`zizmor`)
+audit-workflows:
+    uvx zizmor --offline .github/workflows/
+
 # Run pre-commit on all files
 precommit:
     uv run pre-commit run --all-files
 
 # Run all checks
-all: format lint test docs-build
+all: format lint audit audit-workflows test docs-build
 
 # --- Tests ---
 
@@ -208,15 +216,6 @@ ci-build:
     rm -rf dist/
     uv build
     uvx twine check dist/*
-
-# Audit dependencies for vulnerabilities and abandoned packages in CI
-# Native `uv audit` (OSV-backed): flags known vulnerabilities and archived/abandoned deps.
-ci-audit:
-    uv audit --preview-features audit-command
-
-# Audit GitHub Actions workflows for security issues in CI
-ci-audit-workflows:
-    uvx zizmor --offline .github/workflows/
 
 # Build documentation in CI
 ci-docs-build: docs-build

--- a/justfile
+++ b/justfile
@@ -209,6 +209,15 @@ ci-build:
     uv build
     uvx twine check dist/*
 
+# Audit dependencies for vulnerabilities and abandoned packages in CI
+# Native `uv audit` (OSV-backed): flags known vulnerabilities and archived/abandoned deps.
+ci-audit:
+    uv audit --preview-features audit-command
+
+# Audit GitHub Actions workflows for security issues in CI
+ci-audit-workflows:
+    uvx zizmor --offline .github/workflows/
+
 # Build documentation in CI
 ci-docs-build: docs-build
 

--- a/justfile
+++ b/justfile
@@ -1,3 +1,9 @@
+# Block installing known-malware dependencies (OSV MAL records) before any package code runs.
+# Exported here so every `uv sync` / `uv add` run through `just` is checked — CI and local alike.
+# `malware-check` is a `uv` preview feature; naming it also silences its experimental warning.
+export UV_MALWARE_CHECK := "1"
+export UV_PREVIEW_FEATURES := "malware-check"
+
 # --- General ---
 
 # Default recipe to display help information


### PR DESCRIPTION
Adds supply-chain security across CI and pre-commit, commands defined once.

## 1. Audit recipes (single source)

- **`just audit`** — `uv audit --preview-features audit-command` (OSV): known vulnerabilities + abandoned deps. Clean (0).
- **`just audit-workflows`** — `uvx zizmor --offline .github/workflows/`: workflow security audit.
- Invoked by the CI `audit` job (`needs: [lint, test]`), pre-commit (always-run local hooks), and `just all`. Command text exists once.

## 2. Install-time malware check (env-enabled)

- `justfile` exports `UV_MALWARE_CHECK=1` + `UV_PREVIEW_FEATURES=malware-check`, so every `uv sync` / `uv add` run through `just` (CI + local) checks locked deps against OSV MAL records and blocks known malware **before any package code runs** (e.g. `.pth` import hooks). Silent (preview warning suppressed); no conflict with `uv audit`.

## 3. Workflow hardening (so `zizmor` passes — was 17 findings, now 0)

- `artipacked`: `persist-credentials: false` on every non-pushing checkout; `deploy-docs` keeps creds (force-pushes `gh-pages`) with a justified ignore.
- `excessive-permissions`: `release.yml` → `permissions: {}` top-level, scoped per job.
- `cache-poisoning`: `setup-uv` `enable-cache: false` in `release.yml` (publishes artifacts); CI keeps caching.
- `dangerous-triggers` (`pull_request_target`) and `superfluous-actions` (`action-gh-release`): intentional, suppressed with NOTEs.

## Verification

- `just audit` 0 vulns; `just audit-workflows` `No findings`; malware check active + silent; pre-commit hooks pass; `just lint`/`just test` clean, 100% coverage; CI `Audit` job green.