### PR TITLE
ci(github): add `alls-green` gate job (single required status check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,18 @@ jobs:
 
       - name: Build documentation
         run: just ci-docs-build
+
+  # Single required status check: branch protection points only at this job, so matrix legs
+  # can be added/removed without editing protection rules. Fails if any needed job failed.
+  check:
+    name: CI ok
+    if: always()
+    needs: [lint, test, audit, docs]
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+      - name: Decide whether all jobs passed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Adds one aggregate status check so branch protection can point at a single job.

## What

New `check` job in `ci.yml`:
- `if: always()`, `needs: [lint, test, audit, docs]`, `permissions: {}`
- `re-actors/alls-green@05ac938 # release/v1` with `jobs: ${{ toJSON(needs) }}` — passes only if every needed job passed (and surfaces a clear failure otherwise).

## Why

Point branch protection at **`CI ok`** only. Then matrix legs (e.g. the upcoming OS matrix) or jobs can be added/removed without editing branch-protection rules — the gate aggregates them. `allowed-skips` can later whitelist optional legs.

## Follow-up (manual, by maintainer)

After merge: in repo Settings → Branches → `main` protection, set the required status check to **`CI ok`** (and drop the individual `Lint` / `Test …` / `Build documentation` / `Audit` checks if they were listed).

## Verification

- YAML parses; `needs` wired to all four leaf jobs.
- `just audit-workflows` (zizmor) — clean; action SHA-pinned.