### PR TITLE
ci(release): pin PEP 740 build attestations explicitly on `PyPI` publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,13 @@ jobs:
           name: dist
           path: dist/
 
+      # PEP 740 build attestations (sigstore-signed provenance for each artifact). Already the
+      # default in v1.14.0, but pinned explicitly so a future default change can't silently drop
+      # release provenance. Requires Trusted Publishing + `id-token: write` (set on this job).
       - name: Publish distribution to `PyPI`
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          attestations: true
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
Makes release artifact provenance explicit.

## What I verified first

`pypa/gh-action-pypi-publish@v1.14.0` (our pin) **already defaults `attestations: 'true'`** — confirmed by reading its `action.yml` at the pinned SHA. We use Trusted Publishing + `id-token: write` on `publish-pypi`, so PEP 740 sigstore attestations are **already generated** on every release. So this is not a functional gap for us.

## What this changes

Sets `attestations: true` explicitly (with a comment) so the security property is documented and a future change to the action default cannot silently drop release provenance. No behavior change today.

## Verification

- `action.yml` @ `cef2210` (v1.14.0): `attestations` default `'true'`, "Only works with PyPI and TestPyPI via Trusted Publishing" — requirements met.
- YAML parses; `just audit-workflows` (zizmor) clean.