### PR TITLE
ci(github): test dependency floor and ceiling (`lowest-direct` / `--upgrade`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,46 @@ jobs:
           files: ./coverage.xml
           flags: python-${{ matrix.python-version }}
 
+  # Dependency floor / ceiling: the recipes pin Python and resolution, `uv` provisions the
+  # interpreter, so no `setup-python` is needed.
+  test-floor:
+    name: Test (dependency floor)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install `uv`
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install `just`
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Run tests at the dependency floor
+        run: just ci-test-floor
+
+  test-ceil:
+    name: Test (dependency ceiling)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install `uv`
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install `just`
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Run tests at the dependency ceiling
+        run: just ci-test-ceil
+
   audit:
     name: Audit
     needs: [lint, test]
@@ -157,7 +197,7 @@ jobs:
   check:
     name: CI ok
     if: always()
-    needs: [lint, test, audit, docs]
+    needs: [lint, test, test-floor, test-ceil, audit, docs]
     runs-on: ubuntu-latest
     permissions: {}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 
 # Virtual environment
-.venv
+.venv*
 
 # IDE & OS
 .vscode/

--- a/justfile
+++ b/justfile
@@ -282,7 +282,8 @@ clean:
     rm -rf .coverage
     rm -rf htmlcov
     rm -rf site
-    rm -rf .venv-floor
-    rm -rf .venv-ceil
+    # Remove throwaway envs (`.venv312`-`.venv315`, `.venv-floor`, `.venv-ceil`) but keep the
+    # main `.venv` so a clean doesn't force a full re-sync of the working environment.
+    find . -maxdepth 1 -type d -name ".venv*" ! -name ".venv" -exec rm -rf {} +
     find . -type d -name __pycache__ -exec rm -rf {} +
     find . -type f -name "*.pyc" -delete

--- a/justfile
+++ b/justfile
@@ -78,6 +78,8 @@ test-all-python: install-all-python
     UV_PROJECT_ENVIRONMENT=.venv315 uv run --python 3.15 --no-default-groups --group test coverage run -p -m pytest
     uv run coverage combine
     uv run coverage report
+    just ci-test-floor
+    just ci-test-ceil
 
 # Run tests and generate an HTML coverage report
 testcov: test
@@ -217,6 +219,20 @@ ci-test:
     uv run coverage report
     uv run coverage xml
 
+# Test the dependency FLOOR: lowest Python + lowest direct deps our bounds allow.
+# `--resolution lowest-direct` re-resolves direct deps to their declared minimums (e.g.
+# `pydantic>=2.13.0` -> `2.13.0`), proving the floor actually resolves and passes. Isolated env
+# (never touches `.venv`); no coverage gate.
+ci-test-floor:
+    UV_PROJECT_ENVIRONMENT=.venv-floor uv run --python 3.12 --resolution lowest-direct --no-default-groups --group test pytest
+
+# Test the dependency CEILING: latest stable Python + highest resolvable deps.
+# `--upgrade` ignores the lockfile pins and re-resolves to the latest allowed versions (within
+# `exclude-newer`), catching breakage from a new dependency release before it reaches the lockfile.
+# Isolated env; no coverage gate.
+ci-test-ceil:
+    UV_PROJECT_ENVIRONMENT=.venv-ceil uv run --python 3.14 --upgrade --no-default-groups --group test pytest
+
 # Build package and check metadata in CI
 ci-build:
     rm -rf dist/
@@ -266,5 +282,7 @@ clean:
     rm -rf .coverage
     rm -rf htmlcov
     rm -rf site
+    rm -rf .venv-floor
+    rm -rf .venv-ceil
     find . -type d -name __pycache__ -exec rm -rf {} +
     find . -type f -name "*.pyc" -delete


### PR DESCRIPTION
Adds two dependency-range guard jobs so both ends of the support window are exercised, not just the pinned lockfile.

## What

- **`just ci-test-floor`** — `uv run --python 3.12 --resolution lowest-direct --group test pytest`: re-resolves direct deps to their declared minimums (`pydantic>=2.13.0` -> `2.13.0`) and runs the suite. Proves the lower bounds actually resolve and pass.
- **`just ci-test-ceil`** — `uv run --python 3.14 --upgrade --group test pytest`: ignores the lockfile pins and re-resolves to the latest allowed versions (within `exclude-newer`). Catches breakage from a new dependency release before it reaches the lockfile.
- Two CI jobs (`test-floor`, `test-ceil`) wired into the `check` gate. Recipes pin Python + resolution and run in **isolated envs** (`.venv-floor` / `.venv-ceil`), so they never touch `.venv` — also added to `just test-all-python` and `just clean`.
- `.gitignore`: `.venv` -> `.venv*` (covers `.venv-floor` / `.venv-ceil` / the existing `.venv31x`).

## Verification (local)

- `just ci-test-floor` — 762 passed (pydantic 2.13.0).
- `just ci-test-ceil` — 762 passed (pydantic 2.13.4, current latest).
- YAML parses; `check.needs` includes both; `just audit-workflows` (zizmor) clean.
- Lockfile intentionally not touched in this PR.