### PR TITLE
test(config): enable `xfail_strict` + warnings-as-errors (fix `parametrize` deprecation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,10 @@ addopts = [
     "--strict-markers",     # Raise error for unregistered markers
     "--strict-config",      # Raise error for unknown config options
 ]
+xfail_strict = true         # An `xfail` test that unexpectedly passes is a failure
+filterwarnings = ["error"]  # Any warning is an error — catches deprecations early (e.g. in the
+                            # dependency-ceiling run); add targeted `ignore::...` entries if a
+                            # third-party warning is genuinely out of our control
 
 # https://coverage.readthedocs.io/en/latest/config.html#run
 [tool.coverage.run]

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,6 +1,5 @@
 """Test that code examples in documentation work correctly."""
 
-from collections.abc import Iterable
 from pathlib import Path
 from typing import Final, Literal
 
@@ -22,7 +21,7 @@ def get_example_files() -> list[Path]:
     return sorted(path for path in examples_dir.glob("*.py") if path.name != "__init__.py")
 
 
-def get_examples() -> Iterable[CodeExample]:
+def get_examples() -> list[CodeExample]:
     """Find all Python code examples in documentation files.
 
     :returns: A list of Python code examples.
@@ -33,7 +32,11 @@ def get_examples() -> Iterable[CodeExample]:
     # NOTE: `examples.md` uses `--8<--` file inclusion, so its code blocks are not standalone.
     paths = [readme, *(path for path in docs_dir.glob("*.md") if path.name != "examples.md")]
 
-    return find_examples(*paths)
+    # NOTE: `list(...)` is required — `find_examples` returns a generator, and `parametrize`
+    # deprecated non-`Collection` iterables (`PytestRemovedIn10Warning`, surfaced by the ceiling
+    # test on a newer pytest). Reproduce:
+    #   uv run --upgrade pytest -W error -q   # -> error during collection of `tests/test_docs.py`
+    return list(find_examples(*paths))
 
 
 @pytest.mark.parametrize("example", get_examples(), ids=str)


### PR DESCRIPTION
Turns warnings into failures so deprecations are caught early — and fixes the first one it found.

## Changes

- `[tool.pytest.ini_options]`: `xfail_strict = true` (an `xfail` that passes is a failure) and `filterwarnings = ["error"]` (any warning fails the run; add targeted `ignore::...` later if a third-party warning is out of our control).
- `tests/test_docs.py`: `get_examples()` now returns `list(find_examples(...))` instead of the raw generator. Passing a non-`Collection` iterable to `parametrize` is deprecated (`PytestRemovedIn10Warning`) — it was already failing the **dependency-ceiling** job on a newer pytest.

## Why this is the payoff of floor/ceil

The ceiling job (`--upgrade`, latest pytest) is exactly what surfaced this deprecation before it reached the lockfile. With warnings-as-errors, the same class of issue now fails CI immediately.

## Verification

- `just test` — 100% coverage, no warnings (locked deps).
- `just ci-test-floor` / `just ci-test-ceil` — 762 passed each (ceiling now clean).
- `just lint` — clean.
- Lockfile intentionally not touched.