### PR TITLE
chore(mypy): enable stricter error codes and add `@override` across applicators

### DIFF
--- a/pydantic_jsonschema/applicators/_contains.py
+++ b/pydantic_jsonschema/applicators/_contains.py
@@ -3,7 +3,7 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.3
 """
 
-from typing import Final
+from typing import Final, override
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
@@ -45,6 +45,7 @@ class Contains(AnnotationApplicator):
         self._max_contains: int | None = max_contains
         self._adapter: TypeAdapter[AnnotationType] | None = None
 
+    @override
     def __get_pydantic_core_schema__(
         self,
         source_type: AnnotationType,
@@ -53,6 +54,7 @@ class Contains(AnnotationApplicator):
         """Wrap the array schema with the match-count check."""
         return core_schema.no_info_after_validator_function(self._validate, handler(source_type))
 
+    @override
     def __get_pydantic_json_schema__(
         self,
         schema: CoreSchema,

--- a/pydantic_jsonschema/applicators/_dependent_schemas.py
+++ b/pydantic_jsonschema/applicators/_dependent_schemas.py
@@ -3,6 +3,8 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4
 """
 
+from typing import override
+
 from pydantic import TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 
@@ -45,6 +47,7 @@ class DependentSchemas(ObjectApplicator):
             }
         return self._adapters
 
+    @override
     def json_schema_keyword(self) -> JsonSchemaValue:
         """Return the `dependentSchemas` keyword fragment for the dumped JSON Schema."""
         return {
@@ -53,6 +56,7 @@ class DependentSchemas(ObjectApplicator):
             }
         }
 
+    @override
     def validate(
         self,
         data: AnnotationType,

--- a/pydantic_jsonschema/applicators/_if_then_else.py
+++ b/pydantic_jsonschema/applicators/_if_then_else.py
@@ -3,6 +3,8 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2
 """
 
+from typing import override
+
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
@@ -44,6 +46,7 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
         self._then_adapter: TypeAdapter[AnnotationType] | None = None
         self._else_adapter: TypeAdapter[AnnotationType] | None = None
 
+    @override
     def __get_pydantic_core_schema__(
         self,
         source_type: AnnotationType,
@@ -52,6 +55,7 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
         """Wrap the value schema with the conditional check (on the raw input)."""
         return core_schema.no_info_wrap_validator_function(self._validate, handler(source_type))
 
+    @override
     def __get_pydantic_json_schema__(
         self,
         schema: CoreSchema,
@@ -62,6 +66,7 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
         json_schema.update(self.json_schema_keyword())
         return json_schema
 
+    @override
     def json_schema_keyword(self) -> JsonSchemaValue:
         """Return the `if` / `then` / `else` keyword fragment for the dumped JSON Schema."""
         if_adapter = self._build_adapters()
@@ -88,6 +93,7 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
             self._else_adapter = self._build_adapter(self._else)
         return if_adapter
 
+    @override
     def validate(
         self,
         value: AnnotationType,

--- a/pydantic_jsonschema/applicators/_not.py
+++ b/pydantic_jsonschema/applicators/_not.py
@@ -3,6 +3,8 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.4
 """
 
+from typing import override
+
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
@@ -39,6 +41,7 @@ class Not(AnnotationApplicator, ObjectApplicator):
         self._branch: AnnotationType = branch
         self._adapter: TypeAdapter[AnnotationType] | None = None
 
+    @override
     def __get_pydantic_core_schema__(
         self,
         source_type: AnnotationType,
@@ -47,6 +50,7 @@ class Not(AnnotationApplicator, ObjectApplicator):
         """Wrap the value schema with the `not` check (on the raw input)."""
         return core_schema.no_info_wrap_validator_function(self._validate, handler(source_type))
 
+    @override
     def __get_pydantic_json_schema__(
         self,
         schema: CoreSchema,
@@ -57,6 +61,7 @@ class Not(AnnotationApplicator, ObjectApplicator):
         json_schema.update(self.json_schema_keyword())
         return json_schema
 
+    @override
     def json_schema_keyword(self) -> JsonSchemaValue:
         """Return the `not` keyword fragment for the dumped JSON Schema."""
         return {"not": self._get_adapter().json_schema()}
@@ -73,6 +78,7 @@ class Not(AnnotationApplicator, ObjectApplicator):
         """
         return self._validates(self._get_adapter(), value)
 
+    @override
     def validate(
         self,
         value: AnnotationType,

--- a/pydantic_jsonschema/applicators/_one_of.py
+++ b/pydantic_jsonschema/applicators/_one_of.py
@@ -4,7 +4,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3
 """
 
 from collections.abc import Iterable
-from typing import Annotated, Union
+from typing import Annotated, Union, override
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
@@ -48,6 +48,7 @@ class OneOf(AnnotationApplicator):
         union_annotation = Union[self._branches]  # type: ignore[name-defined]  # noqa: UP007
         return Annotated[union_annotation, self]
 
+    @override
     def __get_pydantic_core_schema__(
         self,
         source_type: AnnotationType,
@@ -56,6 +57,7 @@ class OneOf(AnnotationApplicator):
         """Wrap the union schema with the exactly-one-branch check."""
         return core_schema.no_info_wrap_validator_function(self._validate, handler(source_type))
 
+    @override
     def __get_pydantic_json_schema__(
         self,
         schema: CoreSchema,

--- a/pydantic_jsonschema/applicators/_pattern_properties.py
+++ b/pydantic_jsonschema/applicators/_pattern_properties.py
@@ -4,6 +4,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2
 """
 
 import re
+from typing import override
 
 from pydantic import TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
@@ -48,6 +49,7 @@ class PatternProperties(ObjectApplicator):
             ]
         return self._compiled
 
+    @override
     def json_schema_keyword(self) -> JsonSchemaValue:
         """Return the `patternProperties` keyword fragment for the dumped JSON Schema."""
         return {
@@ -56,6 +58,7 @@ class PatternProperties(ObjectApplicator):
             }
         }
 
+    @override
     def validate(
         self,
         data: AnnotationType,

--- a/pydantic_jsonschema/applicators/_prefix_items.py
+++ b/pydantic_jsonschema/applicators/_prefix_items.py
@@ -4,6 +4,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.1.1
 """
 
 from collections.abc import Iterable
+from typing import override
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter, ValidationError
 from pydantic.json_schema import JsonSchemaValue
@@ -41,6 +42,7 @@ class PrefixItems(AnnotationApplicator):
         self._prefix_adapters: list[TypeAdapter[AnnotationType]] | None = None
         self._tail_adapter: TypeAdapter[AnnotationType] | None = None
 
+    @override
     def __get_pydantic_core_schema__(
         self,
         source_type: AnnotationType,
@@ -49,6 +51,7 @@ class PrefixItems(AnnotationApplicator):
         """Wrap the array schema with positional validation."""
         return core_schema.no_info_after_validator_function(self._validate, handler(source_type))
 
+    @override
     def __get_pydantic_json_schema__(
         self,
         schema: CoreSchema,

--- a/pydantic_jsonschema/applicators/_property_names.py
+++ b/pydantic_jsonschema/applicators/_property_names.py
@@ -3,6 +3,8 @@
 See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.4
 """
 
+from typing import override
+
 from pydantic import TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 
@@ -43,10 +45,12 @@ class PropertyNames(ObjectApplicator):
             self._adapter = self._build_adapter(self._branch)
         return self._adapter
 
+    @override
     def json_schema_keyword(self) -> JsonSchemaValue:
         """Return the `propertyNames` keyword fragment for the dumped JSON Schema."""
         return {"propertyNames": self._get_adapter().json_schema()}
 
+    @override
     def validate(
         self,
         data: AnnotationType,

--- a/pydantic_jsonschema/exceptions.py
+++ b/pydantic_jsonschema/exceptions.py
@@ -1,7 +1,7 @@
 """Custom exceptions for schema conversion, reference resolution, and format validation."""
 
 from dataclasses import dataclass, fields
-from typing import Any
+from typing import Any, override
 
 __all__ = [
     "BasePydanticJsonSchemaError",
@@ -22,6 +22,7 @@ class BasePydanticJsonSchemaError(Exception):
         field_values = tuple(getattr(self, field.name) for field in fields(self))
         super().__init__(*field_values)
 
+    @override
     def __str__(self) -> str:
         """Delegate to `repr` for consistent error display."""
         return repr(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,8 +119,26 @@ plugins = [
     "pydantic.mypy",
 ]
 strict = true
+strict_bytes = true
+local_partial_types = true
 warn_return_any = true
 warn_unused_configs = true
+# NOTE: `warn_unreachable` and the `redundant-expr` code are intentionally NOT enabled — the
+# `X | MISSING` sentinel fields (see `schema/_models.py`) defeat mypy's flow analysis (it doesn't
+# model `MISSING` as a type), so both flag dozens of false "unreachable" / "always true|false"
+# errors. Same root cause as the per-file `comparison-overlap` disables.
+enable_error_code = [
+    "truthy-bool",
+    "truthy-iterable",
+    "unused-awaitable",
+    "ignore-without-code",
+    "possibly-undefined",
+    "redundant-self",
+    "explicit-override",
+    "mutable-override",
+    "unimported-reveal",
+    "deprecated",
+]
 files = ["pydantic_jsonschema", "tests", "examples"]
 
 [tool.ruff]

--- a/tests/converters/test_formats.py
+++ b/tests/converters/test_formats.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 from ipaddress import IPv4Address
-from typing import TYPE_CHECKING, Annotated, Any, TypeAliasType
+from typing import TYPE_CHECKING, Annotated, Any, TypeAliasType, override
 from uuid import UUID
 
 import pytest
@@ -202,6 +202,7 @@ class TestFormats:
                     raise ValueError(msg)
                 self.value = value
 
+            @override
             def __str__(self) -> str:
                 return self.value
 


### PR DESCRIPTION
Tightens mypy with the high-value strict error codes (mined from `chub-downloader` / `pydantic`).

## Config (`[tool.mypy]`)

Added `strict_bytes`, `local_partial_types`, and `enable_error_code`:
`truthy-bool`, `truthy-iterable`, `unused-awaitable`, `ignore-without-code`, `possibly-undefined`, `redundant-self`, `explicit-override`, `mutable-override`, `unimported-reveal`, `deprecated`.

**Intentionally NOT enabled:** `warn_unreachable` and the `redundant-expr` code. The `X | MISSING` sentinel fields defeat mypys flow analysis (it doesnt model `MISSING` as a type), so both produce ~49 false "unreachable" / "always true|false" errors — the same root cause as our per-file `comparison-overlap` disables. A comment documents this.

## Code changes (surfaced by `explicit-override`)

Added `@override` to every method that overrides a base contract — a real, legitimate set:
- the 8 applicators overriding the `AnnotationApplicator` / `ObjectApplicator` abstract roles (`__get_pydantic_core_schema__`, `__get_pydantic_json_schema__`, `validate`, `json_schema_keyword`);
- `BasePydanticJsonSchemaError.__str__` (overrides `BaseException`);
- a tests `CustomType.__str__`.

No behavior change.

## Verification

- `just lint` (incl. mypy) — clean.
- `just test` — 100% coverage; `just ci-test-floor` / `ci-test-ceil` — 762 each.

(Scoped this PR to the mypy hardening; `SECURITY.md` + `codecov.yml` follow in a separate small PR.)