### PR TITLE
chore(project): add `SECURITY.md` and `codecov.yml`

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,7 @@
 globs:
   - "README.md"
   - "RELEASING.md"
+  - "SECURITY.md"
   - "examples/README.md"
   - "docs/**/*.md"
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version receives security fixes.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Report it privately through GitHub's private vulnerability reporting: open the repository's
+**Security** tab and choose **Report a vulnerability**
+([how-to](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)).
+
+Please include:
+
+- a description of the vulnerability,
+- steps to reproduce,
+- the potential impact.
+
+You can expect an initial response within 72 hours.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.com/docs/codecovyml-reference
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+    patch:
+      default:
+        target: 100%
+
+comment:
+  layout: "diff, flags, files"
+  require_changes: true


### PR DESCRIPTION
Two standard project-metadata files.

## `SECURITY.md`

Vulnerability-report policy. Uses GitHub **private vulnerability reporting** (Security tab → Report a vulnerability) rather than a hardcoded email. Also added `SECURITY.md` to the `markdownlint-cli2` globs so it is linted.

> Maintainer action: enable *Private vulnerability reporting* in Settings → Code security (if not already on). If you prefer the email-based policy used elsewhere, add your address — I left it out per the no-PII convention.

## `codecov.yml`

Makes the coverage gate explicit (codecov was on defaults): `project` and `patch` target `100%`, and `comment.require_changes: true` so PRs only get a coverage comment when coverage actually changes.

## Verification

- `markdownlint` (now incl. `SECURITY.md`) — clean.
- `codecov.yml` parses; `codespell` clean.