### PR TITLE
ci(pre-commit): add `actionlint` + workflow/dependabot schema validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,27 @@ repos:
       - id: trailing-whitespace
         args: [ --markdown-linebreak-ext=md ]
 
+  # Validate GitHub Actions workflows and the Dependabot config against their JSON schemas.
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.3
+    hooks:
+      - id: check-github-workflows
+      - id: check-dependabot
+
+  # Deep static analysis of the workflows (expression errors, deprecated syntax, shellcheck).
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  # `pre-commit`'s own meta hook: flag `exclude` patterns that no longer match any file.
+  # NOTE: `check-hooks-apply` is intentionally omitted — it would force removing the standard
+  # safety hooks (`check-json` / `check-xml` / ...) that currently match no files but are kept
+  # as cheap insurance for when such files appear.
+  - repo: meta
+    hooks:
+      - id: check-useless-excludes
+
   - repo: local
     hooks:
       - id: format


### PR DESCRIPTION
Adds GitHub-Actions-focused pre-commit hooks that catch workflow mistakes before they reach CI.

## Added hooks

- **`actionlint`** (`rhysd/actionlint` `v1.7.12`) — deep workflow linting: expression errors, deprecated syntax, shellcheck on `run:` scripts. Pre-commit builds it via its `golang` integration (no manual install). Verified: passes on all current workflows.
- **`check-github-workflows`** + **`check-dependabot`** (`python-jsonschema/check-jsonschema` `0.37.3`) — validate the workflow files and `dependabot.yml` against their official JSON schemas. Pure-Python, auto-scoped.
- **`check-useless-excludes`** (`pre-commit` meta) — flags `exclude:` patterns that no longer match any file.

All four run only on the files they target.

## Not added: `check-hooks-apply`

It would force removing the standard safety hooks (`check-json` / `check-xml` / `check-executables-have-shebangs` / `check-symlinks` / `pretty-format-json`) that currently match no files in this minimal repo. Those are kept as cheap insurance for when such files appear, so `check-hooks-apply` is intentionally omitted (a NOTE documents this). Happy to flip to the lean approach (adopt it + drop the dead hooks) if you prefer.

## Verification

- `pre-commit validate-config` — valid.
- `pre-commit run actionlint / check-github-workflows / check-dependabot / check-useless-excludes --all-files` — all pass.