### PR TITLE
ci(github): extract a composite `setup` action (single source for `uv` + `just` SHAs)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,11 @@
+name: Set up uv and just
+description: Install the pinned uv and just toolchain (single source for both action SHAs).
+
+runs:
+  using: composite
+  steps:
+    - name: Install `uv`
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+    - name: Install `just`
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,8 @@ jobs:
       - name: Set up `Python`
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
-      - name: Install `uv`
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install `just`
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: just ci-install
@@ -71,11 +68,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - name: Install `uv`
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install `just`
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
 
       # Retry the whole install: on 3.15 it builds `pydantic-core` from source, so a flaky
       # crates.io download (not a code fault) shouldn't fail the run. See `CARGO_NET_RETRY` above.
@@ -113,11 +107,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install `uv`
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install `just`
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
 
       - name: Run tests at the dependency floor
         run: just ci-test-floor
@@ -132,11 +123,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install `uv`
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install `just`
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
 
       - name: Run tests at the dependency ceiling
         run: just ci-test-ceil
@@ -152,11 +140,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install `uv`
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install `just`
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: just ci-install
@@ -180,11 +165,8 @@ jobs:
       - name: Set up `Python`
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
-      - name: Install `uv`
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Install `just`
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: just ci-install-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
     rev: 0.37.3
     hooks:
       - id: check-github-workflows
+      - id: check-github-actions
       - id: check-dependabot
 
   # Deep static analysis of the workflows (expression errors, deprecated syntax, shellcheck).


### PR DESCRIPTION
Deduplicates the `uv` + `just` setup across the CI jobs.

## What

- New `.github/actions/setup/action.yml` (composite) bundling the pinned `setup-uv` + `setup-just`.
- All six `ci.yml` jobs (`lint`, `test`, `test-floor`, `test-ceil`, `audit`, `docs`) now `uses: ./.github/actions/setup` instead of repeating the two steps.
- Added `check-github-actions` to the `check-jsonschema` pre-commit hooks (deferred from #70 — now there is an `action.yml` to validate).

## Why

The two setup-action SHAs were duplicated across six jobs. Now they live in **one file** — one place for Dependabot to bump, one place to read. (`release.yml` keeps its own `setup-uv` because it pins `enable-cache: false`; per-job `setup-python` stays in the jobs since the version differs.)

## Verification

- `actionlint` + `zizmor` — clean; `check-github-actions` validates the new `action.yml` (passes).
- ci.yml parses; all six jobs reference the composite. End-to-end exercised by this PRs own CI run.