### PR TITLE
chore(project): add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown: trailing spaces are meaningful (hard line breaks), matching the
+# `trailing-whitespace --markdown-linebreak-ext=md` pre-commit hook.
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds an `.editorconfig` so editors apply the project's whitespace conventions consistently.

Matches the existing setup (no conflicts with `ruff` / `markdownlint` / the YAML files):
- default: UTF-8, LF, final newline, trim trailing whitespace, 4-space indent (Python / TOML);
- `*.{yml,yaml}`: 2-space indent (workflows / pre-commit / mkdocs);
- `*.md`: keep trailing whitespace (hard line breaks — matches `trailing-whitespace --markdown-linebreak-ext=md`).

`codespell` clean; pre-commit (eof / trailing-whitespace) passes.