### PR TITLE
ci(github): add per-job `timeout-minutes` to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -41,6 +42,7 @@ jobs:
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # `UV_PYTHON` pins `uv` to the matrix interpreter — otherwise `uv` skips prereleases
     # (like the `3.15` beta) and silently picks a stable one. `UV_NO_SYNC` keeps `uv run`
     # on the test-only env from `ci-install-test` (no `docs` group: `Pillow` has no 3.15 wheel).
@@ -100,6 +102,7 @@ jobs:
   test-floor:
     name: Test (dependency floor)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -116,6 +119,7 @@ jobs:
   test-ceil:
     name: Test (dependency ceiling)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -133,6 +137,7 @@ jobs:
     name: Audit
     needs: [lint, test]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -155,6 +160,7 @@ jobs:
   docs:
     name: Build documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -181,6 +187,7 @@ jobs:
     if: always()
     needs: [lint, test, test-floor, test-ceil, audit, docs]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions: {}
 
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,7 @@ jobs:
   title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       # NOTE: PR title must follow Conventional Commits because squash-merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -44,6 +45,7 @@ jobs:
     name: Publish to `PyPI`
     needs: [build]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: pypi
     permissions:
       id-token: write
@@ -67,6 +69,7 @@ jobs:
     name: Create GitHub Release
     needs: [build, publish-pypi]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 
@@ -110,6 +113,7 @@ jobs:
     name: Deploy documentation
     needs: [github-release]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
 


### PR DESCRIPTION
Caps every job so a hung step (network stall, runaway build) gets killed instead of burning the full 6h default.

## Timeouts

- `ci.yml`: `lint` 10, `test` 20 (headroom for the 3.15 from-source build + install retries), `test-floor` / `test-ceil` 15, `audit` 10, `docs` 10, `check` 5.
- `release.yml`: `build` 15, `publish-pypi` 10, `github-release` 10, `deploy-docs` 15.
- `pr.yml`: `title` 5.

## Verification

- All three workflows parse; every job now has `timeout-minutes`.
- `actionlint` + `zizmor` — clean.