### PR TITLE
ci(release): smoke-test the published package after `PyPI` publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,29 @@ jobs:
         with:
           attestations: true
 
+  smoke-test:
+    name: Smoke-test the published package
+    needs: [publish-pypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
+
+      # PyPI needs a moment to make a fresh upload installable.
+      - name: Wait for `PyPI` to propagate the release
+        run: sleep 30
+
+      - name: Install from `PyPI` and verify
+        run: just ci-smoke-test "${GITHUB_REF_NAME#v}"
+
   github-release:
     name: Create GitHub Release
     needs: [build, publish-pypi]

--- a/justfile
+++ b/justfile
@@ -239,11 +239,18 @@ ci-build:
     uv build
     uvx twine check dist/*
 
-# Smoke-test a just-published release: install it from PyPI into a throwaway env and verify it
-# imports and converts. `--isolated --no-project` ignores the local source; `--exclude-newer-package`
-# lifts our `exclude-newer` cutoff for the fresh release (it is younger than the cooldown window).
+# Smoke-test a just-published release: install it FROM PyPI into a throwaway env and verify it
+# imports and converts a real schema. `--isolated --no-project` builds the env from the index only
+# (ignores the local source), so this exercises the actual published wheel.
+#
+# NOTE: `--exclude-newer-package "pydantic-jsonschema=2999-12-31"` is required. Our `[tool.uv]
+# exclude-newer = "7 days"` cooldown is read because `just` runs inside the repo, and it rejects the
+# just-released version as "too new" (it is 0 days old). The override lifts the cutoff for OUR
+# package only (a far-future date = no limit); dependencies keep the cooldown. Without it:
+#   uv run --with 'pydantic-jsonschema==<fresh version>' ...
+#   # -> error: ... filtered by `exclude-newer` ... requirements are unsatisfiable
 ci-smoke-test version:
-    uv run --isolated --no-project --exclude-newer-package "pydantic-jsonschema=2099-01-01" --with "pydantic-jsonschema=={{ version }}" python -c "from pydantic_jsonschema import Schema, to_model; print(to_model(Schema.model_validate({'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}))(x=1).model_dump())"
+    uv run --isolated --no-project --exclude-newer-package "pydantic-jsonschema=2999-12-31" --with "pydantic-jsonschema=={{ version }}" python -c "from pydantic_jsonschema import Schema, to_model; print(to_model(Schema.model_validate({'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}))(x=1).model_dump())"
 
 # Build documentation in CI
 ci-docs-build: docs-build

--- a/justfile
+++ b/justfile
@@ -239,6 +239,12 @@ ci-build:
     uv build
     uvx twine check dist/*
 
+# Smoke-test a just-published release: install it from PyPI into a throwaway env and verify it
+# imports and converts. `--isolated --no-project` ignores the local source; `--exclude-newer-package`
+# lifts our `exclude-newer` cutoff for the fresh release (it is younger than the cooldown window).
+ci-smoke-test version:
+    uv run --isolated --no-project --exclude-newer-package "pydantic-jsonschema=2099-01-01" --with "pydantic-jsonschema=={{ version }}" python -c "from pydantic_jsonschema import Schema, to_model; print(to_model(Schema.model_validate({'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}))(x=1).model_dump())"
+
 # Build documentation in CI
 ci-docs-build: docs-build
 


### PR DESCRIPTION
Verifies that what landed on PyPI actually installs and works — a post-publish alarm.

## What

- New `just ci-smoke-test <version>` recipe: installs `pydantic-jsonschema==<version>` from PyPI into a throwaway env (`--isolated --no-project`) and runs a real round-trip (`to_model(...)` on a small schema, instantiate, dump). `--exclude-newer-package "pydantic-jsonschema=2099-01-01"` lifts our `exclude-newer` cooldown for the just-released version (younger than the window).
- New `smoke-test` job in `release.yml` (`needs: [publish-pypi]`): waits 30s for PyPI propagation, then runs the recipe on the released tag. Reuses the composite `setup` action; `permissions: {}`.

It runs after publish (the package is already public), so it does not gate the release — it is an alarm that the published wheel is broken, so you can yank / fix-forward.

## Verification

- Recipe verified locally against the current release: `just ci-smoke-test 0.0.12` prints the dumped model.
- `release.yml` parses; `actionlint` + `zizmor` clean. The job only runs on a tag, so it is first exercised on the next release.
