### PR TITLE
ci(github): add on-demand cross-OS test matrix (`workflow_dispatch`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # `UV_PYTHON` pins `uv` to the matrix interpreter — otherwise `uv` skips prereleases
-    # (like the `3.15` beta) and silently picks a stable one. `UV_NO_SYNC` keeps `uv run`
-    # on the test-only env from `ci-install-test` (no `docs` group: `Pillow` has no 3.15 wheel).
+    # (like the `3.15` beta) and silently picks a stable one. (No `UV_NO_SYNC` needed: the
+    # `ci-*` recipes already run `uv run --no-sync`, staying on the `ci-install-test` env.)
     env:
       UV_PYTHON: ${{ matrix.python-version }}
-      UV_NO_SYNC: "1"
       # `pydantic-core` ships no `cp315` wheel yet, so on 3.15 `uv` builds it from source via
       # `cargo`, whose crates.io downloads intermittently fail (transient TLS / unexpected EOF).
       # Make `cargo` retry each download before the step-level retry kicks in.

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -27,13 +27,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12", "3.13", "3.14"]
-    # `UV_PYTHON` pins `uv` to the matrix interpreter. `UV_NO_SYNC` keeps `uv run` (inside
-    # `just ci-test`) on the test-only env built by `ci-install-test` instead of re-syncing to the
-    # full dev env — that would pull the `docs` group's native deps (Pillow / imaging), which are
-    # slow and fragile to install on macOS / Windows and are not needed to run the tests.
+    # `UV_PYTHON` pins `uv` to the matrix interpreter. (No `UV_NO_SYNC`: `ci-test` already runs
+    # `uv run --no-sync`, staying on the test-only env from `ci-install-test` — so the `docs`
+    # group's native deps, e.g. Pillow / imaging, are never pulled on macOS / Windows.)
     env:
       UV_PYTHON: ${{ matrix.python-version }}
-      UV_NO_SYNC: "1"
 
     steps:
       - name: Checkout

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -27,6 +27,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12", "3.13", "3.14"]
+    # `UV_PYTHON` pins `uv` to the matrix interpreter. `UV_NO_SYNC` keeps `uv run` (inside
+    # `just ci-test`) on the test-only env built by `ci-install-test` instead of re-syncing to the
+    # full dev env — that would pull the `docs` group's native deps (Pillow / imaging), which are
+    # slow and fragile to install on macOS / Windows and are not needed to run the tests.
     env:
       UV_PYTHON: ${{ matrix.python-version }}
       UV_NO_SYNC: "1"

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -1,0 +1,52 @@
+name: OS matrix
+
+# Manual-only cross-OS sanity sweep (e.g. before a release). Not run on PRs: this library has no
+# OS-specific runtime surface (pure in-memory schema -> model logic; no file I/O, paths, or
+# subprocess), so per-PR cross-OS testing is not worth the cost — the PR matrix stays ubuntu-only.
+# PyPy is omitted: its latest is 3.11, below our `requires-python = ">=3.12"`.
+# 3.15 is omitted: it is a prerelease that builds `pydantic-core` from source (no wheel) on every
+# OS, and it is already covered on ubuntu by the main CI.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Cancel superseded runs: a new dispatch on the same ref aborts the in-flight one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.12", "3.13", "3.14"]
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+      UV_NO_SYNC: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up `Python` ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
+
+      - name: Install dependencies
+        run: just ci-install-test
+
+      - name: Run tests
+        run: uv run pytest

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -48,5 +48,5 @@ jobs:
       - name: Install dependencies
         run: just ci-install-test
 
-      - name: Run tests
-        run: uv run pytest
+      - name: Run tests with coverage
+        run: just ci-test

--- a/justfile
+++ b/justfile
@@ -206,18 +206,18 @@ ci-install-release: _check-uv
 
 # Run linting in CI
 ci-lint:
-    uv run ruff format --check
-    uv run ruff check
-    uv run mypy
-    uv run codespell
+    uv run --no-sync ruff format --check
+    uv run --no-sync ruff check
+    uv run --no-sync mypy
+    uv run --no-sync codespell
     npx --yes markdownlint-cli2
 
 # Run tests with coverage XML output for CI
 ci-test:
-    uv run coverage run -m pytest
-    uv run coverage combine
-    uv run coverage report
-    uv run coverage xml
+    uv run --no-sync coverage run -m pytest
+    uv run --no-sync coverage combine
+    uv run --no-sync coverage report
+    uv run --no-sync coverage xml
 
 # Test the dependency FLOOR: lowest Python + lowest direct deps our bounds allow.
 # `--resolution lowest-direct` re-resolves direct deps to their declared minimums (e.g.
@@ -253,7 +253,8 @@ ci-smoke-test version:
     uv run --isolated --no-project --exclude-newer-package "pydantic-jsonschema=2999-12-31" --with "pydantic-jsonschema=={{ version }}" python -c "from pydantic_jsonschema import Schema, to_model; print(to_model(Schema.model_validate({'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}))(x=1).model_dump())"
 
 # Build documentation in CI
-ci-docs-build: docs-build
+ci-docs-build:
+    uv run --no-sync mkdocs build
 
 # Deploy versioned docs to a single-commit `gh-pages` in CI (history never grows).
 #
@@ -267,8 +268,8 @@ ci-docs-deploy version: _ci-configure-git
     set -euo pipefail
     # Bring the existing versions local so `mike` preserves them in the new tree.
     git fetch origin gh-pages:gh-pages 2>/dev/null || true
-    uv run mike deploy --update-aliases "{{version}}" latest
-    uv run mike set-default latest
+    uv run --no-sync mike deploy --update-aliases "{{version}}" latest
+    uv run --no-sync mike set-default latest
     # Squash the entire branch to one orphan commit, then replace the remote branch.
     git checkout gh-pages
     git checkout --orphan _gh_pages_squashed


### PR DESCRIPTION
## 1. On-demand cross-OS test matrix

New `os-matrix.yml`, triggered by `workflow_dispatch` only (a "Run workflow" button, nothing on PRs). Matrix: `ubuntu/macos/windows` x Python `3.12/3.13/3.14`, `fail-fast: false`, reusing the composite `setup` action and `just ci-test`.

Manual-only because this library has no OS-specific runtime surface (pure in-memory schema -> model logic; no file I/O / paths / subprocess), so per-PR cross-OS testing is not worth tripling CI — but a dormant pre-release button costs nothing.

Exclusions (documented in the file): **PyPy** (latest is 3.11, below `requires-python = ">=3.12"`) and **3.15** (prerelease, builds `pydantic-core` from source on every OS; already covered on ubuntu).

## 2. Consolidate `--no-sync` into the `ci-*` recipes

Previously the "don't re-sync" behaviour was a `UV_NO_SYNC` env var duplicated across `ci.yml` and `os-matrix.yml`. Moved it into the recipes instead — `ci-lint`, `ci-test`, `ci-docs-build`, `ci-docs-deploy` now run `uv run --no-sync ...`, so they stay on the env that `ci-install*` built and never re-pull the `docs` group. Dropped the `UV_NO_SYNC` env from both workflows.

Left syncing: `ci-install*` (they *are* the sync). Left re-resolving: `ci-test-floor` / `ci-test-ceil` (`--resolution` / `--upgrade` on purpose) and `ci-smoke-test` (`--isolated --no-project`).

## Verification

- `just ci-lint` / `just ci-test` — pass with `--no-sync` (100% coverage).
- `actionlint`, `check-github-workflows`, `zizmor` — clean.
