### PR TITLE
test(converters): add `Hypothesis` property-based tests for constraint bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ docs/assets/copy-to-llm/
 dist/
 build/
 *.egg-info/
+
+# Hypothesis example database
+.hypothesis/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ test = [
     #   # -> 35 passed, 4 warnings (`general_after_validator_function` is deprecated)
     "pydantic-extra-types>=2.3.0",
     "inline-snapshot>=0.34.0",
+    "hypothesis>=6.100.0",
 ]
 docs = [
     "mike>=2.1.0",

--- a/tests/converters/test_properties.py
+++ b/tests/converters/test_properties.py
@@ -1,0 +1,109 @@
+"""Property-based tests for constraint conversion (Hypothesis).
+
+These complement the example-based tests in `test_field_kwargs.py`: instead of a
+handful of hand-picked values, they fuzz many inputs and assert the boundary
+relationship that each constraint keyword promises. They target only constraints
+with an unambiguous, coercion-free acceptance rule (numeric bounds, string
+length, integer `multipleOf`) so the property never has to second-guess Pydantic's
+lax-mode coercion — that is what keeps them non-flaky under `filterwarnings=error`.
+"""
+
+from typing import TYPE_CHECKING
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from pydantic_jsonschema import to_model
+from pydantic_jsonschema.schema import Schema
+
+if TYPE_CHECKING:
+    from tests.conftest import SchemaRaw
+
+__all__: list[str] = []
+
+# NOTE: `deadline=None` because each example rebuilds a model via `to_model`, whose
+#       timing varies on shared CI runners; a per-example deadline would flake without
+#       testing anything about correctness. `max_examples=50` keeps the suite fast.
+_settings = settings(max_examples=50, deadline=None)
+
+
+class TestIntegerBounds:
+    """`minimum` / `maximum` map to inclusive integer bounds."""
+
+    @_settings
+    @given(
+        bounds=st.tuples(
+            st.integers(min_value=-1000, max_value=1000),
+            st.integers(min_value=-1000, max_value=1000),
+        ).map(lambda pair: (min(pair), max(pair))),
+        value=st.integers(min_value=-2000, max_value=2000),
+    )
+    def test_inclusive_bounds(self, bounds: tuple[int, int], value: int) -> None:
+        low, high = bounds
+        property_schema: SchemaRaw = {"type": "integer", "minimum": low, "maximum": high}
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {"value": property_schema},
+            "required": ["value"],
+        }
+        model = to_model(Schema.model_validate(schema_raw))
+
+        if low <= value <= high:
+            assert model(value=value).model_dump() == {"value": value}
+        else:
+            with pytest.raises(ValidationError):
+                model(value=value)
+
+
+class TestStringLength:
+    """`minLength` / `maxLength` map to inclusive string-length bounds."""
+
+    @_settings
+    @given(
+        bounds=st.tuples(
+            st.integers(min_value=0, max_value=30),
+            st.integers(min_value=0, max_value=30),
+        ).map(lambda pair: (min(pair), max(pair))),
+        text=st.text(max_size=40),
+    )
+    def test_inclusive_length(self, bounds: tuple[int, int], text: str) -> None:
+        low, high = bounds
+        property_schema: SchemaRaw = {"type": "string", "minLength": low, "maxLength": high}
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {"value": property_schema},
+            "required": ["value"],
+        }
+        model = to_model(Schema.model_validate(schema_raw))
+
+        if low <= len(text) <= high:
+            assert model(value=text).model_dump() == {"value": text}
+        else:
+            with pytest.raises(ValidationError):
+                model(value=text)
+
+
+class TestIntegerMultipleOf:
+    """An integer `multipleOf` accepts exactly the integer multiples of its divisor."""
+
+    @_settings
+    @given(
+        divisor=st.integers(min_value=1, max_value=100),
+        value=st.integers(min_value=-1000, max_value=1000),
+    )
+    def test_accepts_multiples(self, divisor: int, value: int) -> None:
+        property_schema: SchemaRaw = {"type": "integer", "multipleOf": divisor}
+        schema_raw: SchemaRaw = {
+            "type": "object",
+            "properties": {"value": property_schema},
+            "required": ["value"],
+        }
+        model = to_model(Schema.model_validate(schema_raw))
+
+        if value % divisor == 0:
+            assert model(value=value).model_dump() == {"value": value}
+        else:
+            with pytest.raises(ValidationError):
+                model(value=value)

--- a/uv.lock
+++ b/uv.lock
@@ -516,6 +516,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.155.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/77/13ec9b6390bce44f5badab39837dd6789bbfe6342a2ac611a71537a7756f/hypothesis-6.155.3.tar.gz", hash = "sha256:1e34b17ae9873515384312cb7640abd773eb096c7eef8c0d9c614fa2c306e9bb", size = 477961, upload-time = "2026-06-16T00:33:23.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/23/ce3a543935a01e478349e82f6c1440776f92d4cb346662c4d81574878fed/hypothesis-6.155.3-py3-none-any.whl", hash = "sha256:ede5a3d142d9c5c9f70cb3075541905b228d6c3a682bcec3d4fe0722e9eda127", size = 544401, upload-time = "2026-06-16T00:33:20.497Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -1261,6 +1273,7 @@ dependencies = [
 dev = [
     { name = "codespell" },
     { name = "git-cliff" },
+    { name = "hypothesis" },
     { name = "inline-snapshot" },
     { name = "mike" },
     { name = "mkdocs" },
@@ -1296,6 +1309,7 @@ release = [
     { name = "git-cliff" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "inline-snapshot" },
     { name = "pydantic-extra-types" },
     { name = "pytest" },
@@ -1310,6 +1324,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.13.0" }]
 dev = [
     { name = "codespell", specifier = ">=2.4.0" },
     { name = "git-cliff", specifier = ">=2.0.0" },
+    { name = "hypothesis", specifier = ">=6.100.0" },
     { name = "inline-snapshot", specifier = ">=0.34.0" },
     { name = "mike", specifier = ">=2.1.0" },
     { name = "mkdocs", specifier = ">=1.6.1" },
@@ -1343,6 +1358,7 @@ lint = [
 ]
 release = [{ name = "git-cliff", specifier = ">=2.0.0" }]
 test = [
+    { name = "hypothesis", specifier = ">=6.100.0" },
     { name = "inline-snapshot", specifier = ">=0.34.0" },
     { name = "pydantic-extra-types", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -1641,6 +1657,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adopts [Hypothesis](https://hypothesis.readthedocs.io/) for property-based testing, starting with the constraint keywords that have an unambiguous acceptance rule.

## What

New `tests/converters/test_properties.py` with three property tests that fuzz many inputs and assert the boundary each keyword promises:

- **`minimum` / `maximum`** — an integer validates iff `low <= value <= high` (inclusive).
- **`minLength` / `maxLength`** — a string validates iff `low <= len(s) <= high` (inclusive).
- **integer `multipleOf`** — a value validates iff `value % divisor == 0`.

These complement the hand-picked cases in `test_field_kwargs.py` — same conversion path, but boundaries are now exercised across hundreds of generated values rather than a couple of examples.

## Scope choice

Deliberately limited to constraints with a **coercion-free** acceptance rule, so the property never has to second-guess Pydantic's lax-mode coercion. `enum` was left out on purpose: `Literal[...]` membership across mixed `int`/`str` values has str↔int coercion edge cases that would make the property flaky for no real gain.

`@settings(deadline=None)` because each example rebuilds a model via `to_model` (timing varies on shared runners); `max_examples=50` keeps the suite fast.

## Dependency

- `hypothesis>=6.100.0` added to the `test` group (floor `6.100.0` is the first release supporting Python 3.12; `uv.lock` adds it + its only runtime dep `sortedcontainers`).
- `.hypothesis/` (the example database) added to `.gitignore`.

## Verification

- `just ci-lint` — clean (`ruff`, `mypy`, `codespell`, `markdownlint`).
- `just ci-test` — 100% coverage.
- `just ci-test-floor` (Python 3.12, `hypothesis==6.100.0`) and `just ci-test-ceil` — both 765 passed.
