### PR TITLE
test(docs): read example-linting config from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,14 @@ ignore = [
     "T201",     # Remove `print`
 ]
 
+# Manually read by `tests/test_docs.py` (`pytest-examples` has no native `pyproject.toml` support).
+[tool.pytest-examples]
+ruff-ignore = [
+    "T201",     # Remove `print`
+    "D",        # Missing docstrings (doc blocks are fragments, no module to document)
+    "PLR2004",  # Magic values in comparisons (e.g. `len(parts) != 3` in `docs/formats.md`)
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = [

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,15 +1,43 @@
 """Test that code examples in documentation work correctly."""
 
+import tomllib
 from pathlib import Path
-from typing import Final, Literal
+from typing import Any, Final
 
 import pytest
 from pytest_examples import CodeExample, EvalExample, find_examples
 
 __all__ = []
 
-QUOTES: Final[Literal["single", "double", "either"]] = "double"
-LINE_LENGTH: Final[int] = 88
+# `pytest-examples` has no native `pyproject.toml` support, so source its settings here instead of
+# hardcoding them: `line-length` / `target-version` / `quote-style` track `[tool.ruff]`, and the
+# doc/example-only `ruff` ignores live in `[tool.pytest-examples]`. A `None` (key absent) means
+# "leave the `pytest-examples` default" — the value is simply not forwarded to `set_config`.
+_PYPROJECT_TOML_DATA: Final[dict[str, Any]] = tomllib.loads(
+    (Path(__file__).parent.parent / "pyproject.toml").read_text(encoding="utf-8"),
+)
+_TOOL_DATA: Final[dict[str, Any]] = _PYPROJECT_TOML_DATA["tool"]
+_RUFF_DATA: Final[dict[str, Any]] = _TOOL_DATA["ruff"]
+
+LINE_LENGTH: Final[int | None] = _RUFF_DATA.get("line-length")
+TARGET_VERSION: Final[str | None] = _RUFF_DATA.get("target-version")
+QUOTES: Final[str | None] = _RUFF_DATA.get("format", {}).get("quote-style")
+RUFF_IGNORE: Final[list[str]] = _TOOL_DATA.get("pytest-examples", {}).get("ruff-ignore", [])
+
+
+def _configure(eval_example: EvalExample, /) -> None:
+    """Apply the example-linting config sourced from `pyproject.toml`.
+
+    :param eval_example: Fixture for evaluating examples.
+    """
+    config: dict[str, Any] = {"ruff_ignore": RUFF_IGNORE}
+    if LINE_LENGTH is not None:
+        config["line_length"] = LINE_LENGTH
+    if TARGET_VERSION is not None:
+        config["target_version"] = TARGET_VERSION
+    if QUOTES is not None:
+        config["quotes"] = QUOTES
+    eval_example.set_config(**config)
 
 
 def get_example_files() -> list[Path]:
@@ -46,16 +74,7 @@ def test_docs_examples(example: CodeExample, eval_example: EvalExample) -> None:
     :param example: An example object.
     :param eval_example: Fixture for evaluating examples.
     """
-    eval_example.set_config(
-        line_length=LINE_LENGTH,
-        ruff_ignore=[
-            "T201",  # Allow print()
-            "D",  # Skip all docstring checks
-            "PLR2004",  # Allow magic values in comparisons
-            "COM812",  # Allow missing trailing commas
-        ],
-        quotes=QUOTES,
-    )
+    _configure(eval_example)
 
     if eval_example.update_examples:
         eval_example.format_ruff(example)
@@ -72,15 +91,7 @@ def test_example_files(example_file: Path, eval_example: EvalExample) -> None:
     :param example_file: Path to the example file.
     :param eval_example: Fixture for evaluating examples.
     """
-    eval_example.set_config(
-        line_length=LINE_LENGTH,
-        ruff_ignore=[
-            "T201",  # Allow print()
-            "D",  # Skip all docstring checks
-            "PLR2004",  # Allow magic values in comparisons
-        ],
-        quotes=QUOTES,
-    )
+    _configure(eval_example)
 
     code = example_file.read_text(encoding="utf-8")
     example = CodeExample.create(


### PR DESCRIPTION
`tests/test_docs.py` hardcoded the `ruff` settings used to lint doc/example snippets, duplicating config that belongs in `pyproject.toml` — and it had drifted (`line_length = 88` vs the project's `100`).

## Change

All example-linting config is now read from `pyproject.toml` via `tomllib`, with `.get()` so a missing key falls back to the `pytest-examples` default (the value is simply not forwarded to `set_config`):

- **`line-length`**, **`target-version`**, **`quote-style`** ← `[tool.ruff]` / `[tool.ruff.format]`.
- **`ruff-ignore`** ← a new `[tool.pytest-examples]` table.

Net effects:
- `line-length` → `100` (was a stale `88`).
- `target-version` → `py312` (was `pytest-examples`' default `py37`), matching `requires-python` — this is what lets examples use modern syntax (e.g. PEP 695 `type X = ...`).
- `quote-style` is unset in `[tool.ruff.format]`, so quotes are no longer force-checked (was hardcoded `double`).

## The `ruff-ignore` list (audited, not guessed)

Ran example linting with **no** ignores to see what actually fires:

| code | hits | where | verdict |
|------|------|-------|---------|
| `T201` | 55 | `print()` in examples | keep |
| `D` (`D100`/`D101`/`D103`) | 41 | doc blocks are fragments — no module to document (`D100` is unfixable) | keep |
| `PLR2004` | 6 | magic values in `docs/formats.md` validators (`len(parts) != 3`, `value > 150`, …) | keep |
| `COM812` | 0 | never triggered | **dropped** |

The two `set_config` blocks also collapse into one `_configure(...)` (the only difference was the dead `COM812`).

## No more `# type: ignore`

`set_config` is now called with a `**dict[str, Any]` splat, which sidesteps its stale `target_version` `Literal` (it stops at `py310`, but `ruff` accepts `py312`) — so the previous `# type: ignore[arg-type]` is gone.

## Verification

- `just ci-lint` — clean. `just ci-test` — 100% coverage, 38 doc/example tests pass.
