### PR TITLE
ci(lint): add `pyright` as a second type checker alongside `mypy`

### DIFF
--- a/examples/custom_formats.py
+++ b/examples/custom_formats.py
@@ -34,10 +34,10 @@ def validate_price(value: float) -> float:
 
 
 # A custom format is a Pydantic type, the same shape as the built-in formats
-# (e.g. `Email = Annotated[str, AfterValidator(...)]`). The wrapper you pick
+# (e.g. `type Email = Annotated[str, AfterValidator(...)]`). The wrapper you pick
 # (`AfterValidator`, `BeforeValidator`, ...) controls when validation runs.
-Sku = Annotated[str, AfterValidator(validate_sku)]
-Price = Annotated[float, AfterValidator(validate_price)]
+type Sku = Annotated[str, AfterValidator(validate_sku)]
+type Price = Annotated[float, AfterValidator(validate_price)]
 
 
 product_schema = Schema.model_validate(

--- a/justfile
+++ b/justfile
@@ -44,6 +44,7 @@ lint:
     uv run ruff format --check
     uv run ruff check
     uv run mypy
+    uv run pyright
     uv run codespell
     npx --yes markdownlint-cli2
 
@@ -209,6 +210,7 @@ ci-lint:
     uv run --no-sync ruff format --check
     uv run --no-sync ruff check
     uv run --no-sync mypy
+    uv run --no-sync pyright
     uv run --no-sync codespell
     npx --yes markdownlint-cli2
 

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -5,7 +5,7 @@
 # and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from types import NoneType
 from typing import (
@@ -137,7 +137,7 @@ class SchemaConverter:
         self,
         segment: str,
         /,
-    ) -> Iterator[None]:
+    ) -> Generator[None]:
         """Context manager for tracking resolution path.
 
         :param segment: Path segment to add.
@@ -348,15 +348,16 @@ class SchemaConverter:
         applicators = self._build_object_applicators(schema)
 
         # For some reason, `create_model` "accepts" `fields` values as `tuple[str, Any]`,
-        # when in reality it accepts `tuple[type, FieldInfo]`
-        created_model = create_model(  # type: ignore[call-overload]
+        # when in reality it accepts `tuple[type, FieldInfo]`. Neither `mypy` nor `pyright` can
+        # match the `**fields` splat to a `create_model` overload.
+        created_model = create_model(  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue]
             model_name,
             __config__=model_config,
             __doc__=unwrap(schema.description, default=None),
             __base__=base_classes,
             __module__=__name__,
             __validators__=validators,
-            **fields,
+            **fields,  # pyright: ignore[reportArgumentType]
         )
         return self._wrap_object_applicators(cast("type[BaseModel]", created_model), applicators)
 
@@ -1107,7 +1108,9 @@ class SchemaConverter:
             union_args = [_DATA_TYPE_ANNOTATION_MAPPING[data_type] for data_type in schema.type]
             return make_union(union_args)
 
-        return Any
+        # `Any` is a valid annotation but is not a `type`, so `pyright` rejects it under the
+        # `-> type` return; the same `Any`-as-annotation pattern recurs below for `item_type`.
+        return Any  # pyright: ignore[reportReturnType]
 
     def _array_annotation(
         self,
@@ -1124,7 +1127,7 @@ class SchemaConverter:
         # is the homogeneous element type.
         prefix_items = self._build_prefix_items(schema)
 
-        item_type: type | ForwardRef = Any
+        item_type: type | ForwardRef = Any  # pyright: ignore[reportAssignmentType]
         if prefix_items is None and schema.items is not MISSING:
             with self._track_path("items"):
                 item_type = self._schema_to_annotation(schema.items)

--- a/pydantic_jsonschema/converters/_field_kwargs.py
+++ b/pydantic_jsonschema/converters/_field_kwargs.py
@@ -5,6 +5,7 @@
 # and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
+from types import EllipsisType
 from typing import Any, Final, Literal, TypedDict
 
 import annotated_types
@@ -22,10 +23,9 @@ __all__ = [
 
 type FieldKindType = Literal["required", "optional", "root"]  # How a field is used in a model
 
-# Missing value for `default` field
+# Pydantic's "required, no default" marker for a field default (`...`).
 # See: https://github.com/pydantic/pydantic/blob/6800281ba87625346daf5826563740ded8a9851b/pydantic/fields.py#L241-L247
-# For mypy issue, see: https://github.com/python/mypy/issues/7818
-_PYDANTIC_DEFAULT_MISSING: Final[Ellipsis] = ...  # type: ignore[valid-type]
+_PYDANTIC_DEFAULT_MISSING: Final[EllipsisType] = ...
 
 
 class _FieldKwargs(TypedDict, total=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ lint = [
     "codespell>=2.4.0",
     "mypy>=1.17.1",
     "pre-commit>=4.0.0",
+    "pyright[nodejs]>=1.1.409",
     "ruff>=0.12.10",
 ]
 test = [
@@ -140,6 +141,37 @@ enable_error_code = [
     "deprecated",
 ]
 files = ["pydantic_jsonschema", "tests", "examples"]
+
+# Second type checker alongside `mypy`: the two disagree often enough that running both
+# catches issues neither finds alone (e.g. `pyright` flagged the `examples/custom_formats.py`
+# alias that used bare `X = Annotated[...]` instead of the canonical `type X = ...`).
+#
+# `tests` are intentionally excluded: `pyright` has no Pydantic plugin, so it (a) cannot resolve
+# field aliases (`$ref`, `if_`, `else_`, `not_`) and (b) flags the deliberate "wrong" inputs our
+# validation tests feed to coercing fields. `mypy` (with `pydantic.mypy`) covers `tests`.
+[tool.pyright]
+# https://github.com/microsoft/pyright/blob/main/docs/configuration.md
+venvPath = "."
+venv = ".venv"
+typeCheckingMode = "standard"
+# Scoped to the library source. `tests` and `examples` *consume* the models that `to_model`
+# builds at runtime, whose attributes/types are unknowable statically (`post.comments`,
+# `Reference(ref=...)` wanting the `$ref` alias, raw strings fed to coercing fields) — `pyright`
+# can only add `# pyright: ignore` noise there. `mypy` (+ `pydantic.mypy`) already covers both.
+include = ["pydantic_jsonschema"]
+# `# type: ignore` belongs to `mypy`; `pyright` uses `# pyright: ignore`. Without this, `pyright`
+# flags `mypy`-only ignores as unnecessary (and vice versa) when both checkers run.
+enableTypeIgnoreComments = false
+reportUnusedImport = "error"
+reportUnnecessaryCast = "error"
+reportUnnecessaryComparison = "error"
+reportUnnecessaryIsInstance = "error"
+reportMatchNotExhaustive = "error"
+reportPrivateUsage = "error"
+reportMissingTypeStubs = "error"
+reportUnknownLambdaType = "error"
+reportUnnecessaryTypeIgnoreComment = "error"
+reportDeprecated = "error"
 
 [tool.ruff]
 target-version = "py312"

--- a/uv.lock
+++ b/uv.lock
@@ -1009,6 +1009,22 @@ wheels = [
 ]
 
 [[package]]
+name = "nodejs-wheel-binaries"
+version = "24.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/22/2a5beb4e21417c73233d9f65cf6f3e96e891b80d2f550a8f630ebc6b88c6/nodejs_wheel_binaries-24.16.0.tar.gz", hash = "sha256:c973cb69dc5fd16e6f6dc6e579e2c3d5534e2a1f57619dddf5ba070efa7dde37", size = 8056, upload-time = "2026-05-30T16:52:09.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/d1/68b43b53cd0fa83ae6fd406705023ca988d9e0ca41c724d82e66fbeb2ef6/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9f8f677dcf30e37ac244f07869726abe043f01eb0f45722b1df31cc2af7093c", size = 55666374, upload-time = "2026-05-30T16:51:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b2/40a989159599080da485de966c4c2d207e852ac7aa7864702626d96c8bf5/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:3d0370fe7120ce9697a4f60d40480d2bd8808d9f30131458d5afc0040d4e5a51", size = 55838487, upload-time = "2026-05-30T16:51:43.383Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a7/cd42174fb5ff6faff7fa8d326a18914d8f232098ab5de055b57c16fa13ca/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85dc92bbb79c851569c5925dcc2a4c915a034efab375f99e4e7e6bbe9cca8342", size = 60179540, upload-time = "2026-05-30T16:51:47.036Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/c8a1f9ae140aa28df8744d984d01d4b3af7cdd6555af12127f40ceb45a7d/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2f3036292811514ba847b3708492644764f88a833ac425c5f55007014308ddfd", size = 60716262, upload-time = "2026-05-30T16:51:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/7c35b3737f59e36d0249c265397b7bff570519b95301d6e16ea361e904ad/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:db8a8a76ebd2b28ecbfc9ad464baa3707241b9e050a30e2efdf6f60c0f886502", size = 62230592, upload-time = "2026-05-30T16:51:55Z" },
+    { url = "https://files.pythonhosted.org/packages/04/96/d931255cf9d11a84d6b54d882dba7434646467d568ccf070ea3418638df3/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03", size = 62841759, upload-time = "2026-05-30T16:51:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7b/8b7a3f41bc255411be30b6d7d288aab8ffd9ea2055db8555ced3548007b9/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa", size = 42027734, upload-time = "2026-05-30T16:52:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/17/66/1ed71f1f529b8ca727d42c7ceb9db0bef145ce4a13dfc86fb50aa44f3be6/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36", size = 39714528, upload-time = "2026-05-30T16:52:06.421Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1272,6 +1288,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pydantic-extra-types" },
+    { name = "pyright", extra = ["nodejs"] },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-examples" },
@@ -1290,6 +1307,7 @@ lint = [
     { name = "codespell" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pyright", extra = ["nodejs"] },
     { name = "ruff" },
 ]
 release = [
@@ -1321,6 +1339,7 @@ dev = [
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pydantic-extra-types", specifier = ">=2.3.0" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-examples", specifier = ">=0.0.18" },
@@ -1339,6 +1358,7 @@ lint = [
     { name = "codespell", specifier = ">=2.4.0" },
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "pre-commit", specifier = ">=4.0.0" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.409" },
     { name = "ruff", specifier = ">=0.12.10" },
 ]
 release = [{ name = "git-cliff", specifier = ">=2.0.0" }]
@@ -1379,6 +1399,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.410"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
+]
+
+[package.optional-dependencies]
+nodejs = [
+    { name = "nodejs-wheel-binaries" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds [`pyright`](https://github.com/microsoft/pyright) to the lint pipeline next to `mypy`. Config modelled on the `mwdx-ai` setup: `standard` mode with a curated list of useful checks promoted to `error`, rather than plain `standard` or the over-strict `strict` (whose `reportUnknown*` family floods this dynamic-type-building codebase with ~200 false positives).

## Config (`[tool.pyright]`)

- `pyright[nodejs]>=1.1.409` — the `nodejs` extra bundles Node, so no runtime download in CI.
- `typeCheckingMode = "standard"` + explicit `error` reports: `reportUnusedImport`, `reportUnnecessaryCast`, `reportUnnecessaryComparison`, `reportUnnecessaryIsInstance`, `reportMatchNotExhaustive`, `reportPrivateUsage`, `reportMissingTypeStubs`, `reportUnknownLambdaType`, `reportUnnecessaryTypeIgnoreComment`, `reportDeprecated`.
- `enableTypeIgnoreComments = false` — `# type: ignore` belongs to `mypy`, `pyright` uses `# pyright: ignore`. Required when both run with `reportUnnecessaryTypeIgnoreComment` on, otherwise each flags the other's suppressions as unnecessary.
- `include = ["pydantic_jsonschema"]` — **scoped to source**. `tests`/`examples` *consume* the models `to_model` builds at runtime (`post.comments`, `Reference(ref=...)` wanting the `$ref` alias, raw strings fed to coercing fields) — statically unknowable, so `pyright` there is pure `# pyright: ignore` noise. `mypy` (+ `pydantic.mypy`) already covers them.

Wired into `just lint` and `just ci-lint`.

## What `pyright` caught (real)

1. **Deprecation** — `_track_path` used `@contextmanager` with `-> Iterator[None]`, deprecated in current typeshed in favour of `-> Generator[None]`. Fixed.
2. **Example bug** (from the earlier scope) — `examples/custom_formats.py` used bare `Sku = Annotated[...]` instead of the canonical PEP 695 `type Sku = ...` the `formats=` parameter expects. Fixed.

## Suppressions

`# pyright: ignore[...]` (alongside the existing `mypy` `# type: ignore`) on the dynamic-type machinery in `_converter.py` / `_field_kwargs.py` — `create_model` overload, `Any`-as-annotation, `Final[Ellipsis]`. `pyright` can't follow runtime-constructed types; `reportUnnecessaryTypeIgnoreComment` keeps these honest (an ignore that stops being needed fails the lint).

## Verification

- `just ci-lint` — `ruff` / `mypy` / `pyright` (0 errors) / `codespell` / `markdownlint` clean.
- `just ci-test` 100%; `ci-test-floor` (3.12) / `ci-test-ceil` (3.14) — 762 passed (the `Generator[None]` change holds on both).
