### PR TITLE
ci(coverage): upload to `Codecov` via `workflow_run` so fork PRs report coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,15 @@ jobs:
       - name: Run tests with coverage
         run: just ci-test
 
-      - name: Upload coverage to `Codecov`
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      # Coverage is uploaded to `Codecov` from the separate `coverage.yml` (`workflow_run`), which
+      # runs in the trusted base-repo context — so fork PRs report coverage without ever exposing
+      # `CODECOV_TOKEN` to untrusted PR code. Here we only stash the report as an artifact.
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: python-${{ matrix.python-version }}
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml
+          if-no-files-found: error
 
   # Dependency floor / ceiling: the recipes pin Python and resolution, `uv` provisions the
   # interpreter, so no `setup-python` is needed.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,48 @@
+name: Coverage
+
+# Uploads coverage to `Codecov` after `CI` finishes. This runs as a `workflow_run`, so the
+# workflow file always comes from the default branch (never the PR) and it consumes only the
+# coverage *data* artifact — it never checks out or runs PR code. That keeps `CODECOV_TOKEN` safe
+# even on untrusted fork PRs, which (by GitHub design) cannot access secrets in the `CI` run itself.
+# See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  codecov:
+    name: Upload to `Codecov` (Python ${{ matrix.python-version }})
+    # Only when `CI` passed — the 100% gate already ran there; skip failed / stale runs.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read # Download artifacts from the triggering `CI` run.
+    strategy:
+      fail-fast: false
+      # Mirrors the `CI` `test` matrix so each leg keeps its own `Codecov` flag.
+      matrix:
+        python-version: ["3.12", "3.13", "3.14", "3.15"]
+
+    steps:
+      # No `actions/checkout` — see the security note above.
+      - name: Download coverage artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-${{ matrix.python-version }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload to `Codecov`
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: python-${{ matrix.python-version }}
+          # This workflow runs on the default branch, so tell `Codecov` which commit / branch the
+          # coverage actually belongs to (the `CI` run's head, i.e. the PR or pushed commit).
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_branch: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
Makes coverage reporting work for fork PRs without exposing `CODECOV_TOKEN` to untrusted code.

## Problem

The `test` job uploaded to `Codecov` directly with `secrets.CODECOV_TOKEN`. GitHub withholds secrets from `pull_request` runs triggered by **forks**, so external contributors' PRs silently get no coverage report. Exposing the token to fork code (e.g. via `pull_request_target`) is the classic [pwn-request](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) vulnerability.

## Solution — split into two workflows

1. **`ci.yml`** (unchanged trigger): runs the (possibly untrusted) PR code **with no secrets**, and now just stashes each leg's `coverage.xml` as an artifact (`coverage-<python>`).
2. **`coverage.yml`** (new, `workflow_run`): fires when `CI` completes, in the **trusted base-repo context** (the workflow file always comes from the default branch). It downloads the coverage *data* artifacts and uploads them to `Codecov` with the token. It **never checks out or runs PR code** — only consumes data — so the token can't be exfiltrated.

`workflow_run` runs on the default branch, so `Codecov` is told the real target via `override_commit` / `override_branch` (the `CI` run's head). Per-python `flags` are preserved by mirroring the test matrix.

## Notes

- All uploads (push + same-repo PR + fork PR) now flow through `coverage.yml` — one consistent, trusted path.
- The 100% coverage **gate** still runs in `ci.yml` (`fail_under = 100` in `ci-test`), which works on forks (no secret needed) — this PR only restores the `Codecov` *reporting*.
- `workflow_run` workflows only trigger once they exist on the default branch, so this activates after merge (it won't run against this PR itself).
- `permissions: {}` top-level; the job takes only `actions: read` to fetch artifacts. `zizmor` clean (the `workflow_run` trigger is annotated, no checkout).

## Verification

`actionlint`, `check-github-workflows`, and `zizmor` all pass.
