### PR TITLE
ci(dependabot): add 7-day `cooldown` mirroring `tool.uv.exclude-newer`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 # Automated dependency update PRs.
-# NOTE: Python resolution still respects `tool.uv.exclude-newer` ("7 days"),
-# so Dependabot PRs only land versions older than the supply-chain cutoff.
+#
+# NOTE: Dependabot does NOT respect `uv`'s `tool.uv.exclude-newer` — it always targets the latest
+# release. The two are separate systems that only collide at lock time: Dependabot runs `uv` to
+# update `uv.lock`, and `uv` then refuses any version inside the `exclude-newer` window, producing a
+# broken (unlockable) PR. `uv`'s own docs therefore recommend mirroring the cutoff as a `cooldown`.
+# `cooldown.default-days` is duplicated from `tool.uv.exclude-newer` ("7 days") in `pyproject.toml` —
+# keep the two values in sync. See: https://docs.astral.sh/uv/guides/integration/dependabot/
 version: 2
 
 updates:
@@ -8,6 +13,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Canonical cutoff: `tool.uv.exclude-newer` in `pyproject.toml`. Mirrored here so Dependabot
+    # never opens a PR for a version `uv` would refuse to lock.
+    cooldown:
+      default-days: 7
     groups:
       # Single weekly PR for all Python dependency bumps instead of one PR each.
       python-dependencies:
@@ -18,6 +27,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # `exclude-newer` is a `uv`-only resolver setting and does not cover GitHub Actions, so this is
+    # the *only* supply-chain delay for action bumps. Matched to the Python cutoff for consistency.
+    cooldown:
+      default-days: 7
     groups:
       # Single weekly PR for all action SHA bumps.
       github-actions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ docs = [
 # NOTE: Supply-chain safety net — only resolve packages published at least
 # 7 days ago so a compromised or typo-squatted release has time to be caught
 # and yanked before it lands in our lockfile.
+#
+# This is the canonical cutoff. It is mirrored as `cooldown.default-days` in
+# `.github/dependabot.yml` (Dependabot ignores `exclude-newer`) — keep both in sync.
 [tool.uv]
 exclude-newer = "7 days"
 


### PR DESCRIPTION
Adds `cooldown: { default-days: 7 }` to both Dependabot ecosystems.

## Why

Dependabot does **not** respect `uv`'s `tool.uv.exclude-newer` — it always targets the latest release. The two systems only collide at lock time: Dependabot runs `uv` to update `uv.lock`, and `uv` then refuses any version inside the `exclude-newer` window, producing a broken (unlockable) PR. `uv`'s own docs recommend mirroring the cutoff as a `cooldown`.

- **`uv` ecosystem** — `cooldown` mirrors the canonical `tool.uv.exclude-newer` ("7 days") so Dependabot never opens a PR for a version `uv` would refuse to lock.
- **`github-actions` ecosystem** — `exclude-newer` is a `uv`-only resolver setting and does not cover Actions, so this `cooldown` is the *only* supply-chain delay for action bumps. Matched to the Python cutoff for consistency.

## Changes

- `.github/dependabot.yml` — `cooldown.default-days: 7` on both ecosystems; rewrote the misleading header comment (it claimed Dependabot honoured `exclude-newer`).
- `pyproject.toml` — note that `exclude-newer` is the canonical cutoff, mirrored in `dependabot.yml`; keep the two in sync.

## Docs

- https://docs.astral.sh/uv/guides/integration/dependabot/
