### PR TITLE
ci(codspeed): add continuous benchmarking via `pytest-codspeed`

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,50 @@
+name: CodSpeed
+
+# Continuous benchmarking: runs the `tests/benchmarks/` suite under `CodSpeed`'s simulation
+# instrument and reports performance deltas on each PR (vs the `main` baseline). Not part of the
+# `CI` required-check gate — perf is informational and must never block a merge.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+# Cancel superseded runs: a new push to the same ref aborts the in-flight run for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Tokenless upload for public repos: `CodSpeed` verifies the run via OIDC, so no
+      # `CODSPEED_TOKEN` secret is needed. See https://docs.codspeed.io/integrations/ci/github-actions
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up `Python`
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
+
+      - name: Install benchmark dependencies
+        run: just ci-install-benchmark
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4
+        with:
+          mode: simulation
+          run: just ci-benchmark

--- a/justfile
+++ b/justfile
@@ -90,6 +90,11 @@ testcov: test
 test-fix-snapshots:
     uv run pytest --inline-snapshot=fix
 
+# Run the `CodSpeed` benchmarks locally (`-m benchmark` overrides the suite-wide `not benchmark`).
+# Outside CI this measures wall-clock only; the GitHub job instruments it for stable comparisons.
+bench:
+    uv run pytest --codspeed -m benchmark tests/benchmarks
+
 # --- Documentation ---
 
 # Format documentation examples
@@ -197,6 +202,10 @@ ci-install: _check-uv
 ci-install-test: _check-uv
     uv sync --frozen --no-default-groups --group test
 
+# Install benchmark dependencies only for CI (adds `pytest-codspeed` to the `test` group)
+ci-install-benchmark: _check-uv
+    uv sync --frozen --no-default-groups --group benchmark
+
 # Install docs dependencies for CI
 ci-install-docs: _check-uv
     uv sync --group docs
@@ -234,6 +243,11 @@ ci-test-floor:
 # Isolated env; no coverage gate.
 ci-test-ceil:
     UV_PROJECT_ENVIRONMENT=.venv-ceil uv run --python 3.14 --upgrade --no-default-groups --group test pytest
+
+# Run benchmarks in CI. The `CodSpeedHQ/action` wraps this command with its instrumentation; the
+# plugin detects that and records stable measurements instead of wall-clock.
+ci-benchmark:
+    uv run --no-sync pytest --codspeed -m benchmark tests/benchmarks
 
 # Build package and check metadata in CI
 ci-build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,15 @@ Changelog = "https://github.com/Danipulok/pydantic-jsonschema/blob/main/docs/cha
 dev = [
     {include-group = "lint"},
     {include-group = "test"},
+    {include-group = "benchmark"},
     {include-group = "docs"},
     {include-group = "release"},
+]
+# `pytest-codspeed` provides the `benchmark` fixture and powers the `CodSpeed` CI job. Kept out of
+# the `test` group so the coverage-gated suite never pulls it (and the floor/ceiling runs stay lean).
+benchmark = [
+    {include-group = "test"},
+    "pytest-codspeed>=5.0.0",
 ]
 release = [
     "git-cliff>=2.0.0",
@@ -238,6 +245,13 @@ testpaths = ["tests"]
 addopts = [
     "--strict-markers",     # Raise error for unregistered markers
     "--strict-config",      # Raise error for unknown config options
+    # Benchmarks (`tests/benchmarks/`) need `pytest-codspeed` and run only in the `CodSpeed` job,
+    # which overrides this with `-m benchmark`. Excluding them here keeps the normal suite plugin-free
+    # and out of the 100% coverage gate.
+    "-m", "not benchmark",
+]
+markers = [
+    "benchmark: performance benchmark executed under `CodSpeed`; excluded from the normal suite",
 ]
 xfail_strict = true         # An `xfail` test that unexpectedly passes is a failure
 filterwarnings = ["error"]  # Any warning is an error — catches deprecations early (e.g. in the

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,7 @@
+"""Performance benchmarks executed under `CodSpeed` (`pytest-codspeed`).
+
+Excluded from the normal suite via the `benchmark` marker (`-m "not benchmark"` in
+`addopts`); the `CodSpeed` job re-selects them with `-m benchmark`. See `pyproject.toml`.
+"""
+
+__all__: list[str] = []

--- a/tests/benchmarks/test_conversion.py
+++ b/tests/benchmarks/test_conversion.py
@@ -1,0 +1,121 @@
+"""Benchmarks for the JSON Schema -> Pydantic conversion pipeline.
+
+Each benchmark validates the `Schema` up front (outside the measured region) and times only
+`to_model`, so the numbers track *our* converter rather than Pydantic's model build. The
+end-to-end case additionally times `Schema.model_validate` to cover the full public entry path.
+"""
+
+from typing import TYPE_CHECKING, Any, Final
+
+import pytest
+
+from pydantic_jsonschema import Schema, to_model
+
+if TYPE_CHECKING:
+    from pytest_codspeed import BenchmarkFixture
+
+__all__: list[str] = []
+
+# A wide, flat object: many primitive properties exercising every scalar branch plus the
+# common constraint keywords (bounds, length, pattern, enum, format).
+_WIDE_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "integer", "minimum": 1},
+        "score": {"type": "number", "minimum": 0.0, "maximum": 100.0},
+        "name": {"type": "string", "minLength": 1, "maxLength": 120},
+        "slug": {"type": "string", "pattern": r"^[a-z0-9-]+$"},
+        "email": {"type": "string", "format": "email"},
+        "homepage": {"type": "string", "format": "uri"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "active": {"type": "boolean"},
+        "status": {"type": "string", "enum": ["draft", "published", "archived"]},
+        "priority": {"type": "integer", "enum": [1, 2, 3, 5, 8]},
+        "tags": {"type": "array", "items": {"type": "string"}, "maxItems": 16},
+        "ratios": {"type": "array", "items": {"type": "number"}},
+        "nickname": {"type": "string"},
+        "age": {"type": "integer", "minimum": 0, "maximum": 150},
+        "balance": {"type": "number"},
+        "verified": {"type": "boolean"},
+        "country": {"type": "string", "minLength": 2, "maxLength": 2},
+        "notes": {"type": "string"},
+        "ref_count": {"type": "integer", "minimum": 0},
+        "weight": {"type": "number", "exclusiveMinimum": 0.0},
+    },
+    "required": ["id", "name", "email", "status"],
+}
+
+# A deep, recursive shape: `$defs` + `$ref`, `allOf` composition, and arrays of nested objects —
+# the paths most likely to regress when the reference resolver or composition logic changes.
+_NESTED_SCHEMA: Final[dict[str, Any]] = {
+    "$defs": {
+        "Address": {
+            "type": "object",
+            "properties": {
+                "street": {"type": "string"},
+                "city": {"type": "string"},
+                "zip": {"type": "string", "pattern": r"^\d{5}$"},
+            },
+            "required": ["street", "city"],
+        },
+        "Timestamps": {
+            "type": "object",
+            "properties": {
+                "created_at": {"type": "string", "format": "date-time"},
+                "updated_at": {"type": "string", "format": "date-time"},
+            },
+        },
+        "Contact": {
+            "allOf": [
+                {"$ref": "#/$defs/Timestamps"},
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "emails": {
+                            "type": "array",
+                            "items": {"type": "string", "format": "email"},
+                        },
+                        "address": {"$ref": "#/$defs/Address"},
+                    },
+                    "required": ["name"],
+                },
+            ],
+        },
+    },
+    "type": "object",
+    "properties": {
+        "owner": {"$ref": "#/$defs/Contact"},
+        "billing_address": {"$ref": "#/$defs/Address"},
+        "contacts": {"type": "array", "items": {"$ref": "#/$defs/Contact"}},
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "labels": {"type": "array", "items": {"type": "string"}},
+                "primary": {"$ref": "#/$defs/Address"},
+            },
+        },
+    },
+    "required": ["owner"],
+}
+
+
+class TestConversionBenchmarks:
+    """Time the converter on representative wide / nested / end-to-end schemas."""
+
+    @pytest.mark.benchmark
+    def test_to_model_wide(self, benchmark: "BenchmarkFixture") -> None:
+        """Time `to_model` on a wide, flat schema (scalar + constraint coverage)."""
+        schema = Schema.model_validate(_WIDE_SCHEMA)
+        benchmark(lambda: to_model(schema))
+
+    @pytest.mark.benchmark
+    def test_to_model_nested(self, benchmark: "BenchmarkFixture") -> None:
+        """Time `to_model` on a deep schema with `$ref` resolution and `allOf` composition."""
+        schema = Schema.model_validate(_NESTED_SCHEMA)
+        benchmark(lambda: to_model(schema))
+
+    @pytest.mark.benchmark
+    def test_validate_and_convert(self, benchmark: "BenchmarkFixture") -> None:
+        """Time the full public entry path: `Schema.model_validate` followed by `to_model`."""
+        benchmark(lambda: to_model(Schema.model_validate(_NESTED_SCHEMA)))

--- a/uv.lock
+++ b/uv.lock
@@ -1274,6 +1274,14 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+benchmark = [
+    { name = "inline-snapshot" },
+    { name = "pydantic-extra-types" },
+    { name = "pytest" },
+    { name = "pytest-codspeed" },
+    { name = "pytest-cov" },
+    { name = "pytest-examples" },
+]
 dev = [
     { name = "codespell" },
     { name = "git-cliff" },
@@ -1290,6 +1298,7 @@ dev = [
     { name = "pydantic-extra-types" },
     { name = "pyright", extra = ["nodejs"] },
     { name = "pytest" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-examples" },
     { name = "ruff" },
@@ -1325,6 +1334,14 @@ test = [
 requires-dist = [{ name = "pydantic", specifier = ">=2.13.0" }]
 
 [package.metadata.requires-dev]
+benchmark = [
+    { name = "inline-snapshot", specifier = ">=0.34.0" },
+    { name = "pydantic-extra-types", specifier = ">=2.3.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-codspeed", specifier = ">=5.0.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-examples", specifier = ">=0.0.18" },
+]
 dev = [
     { name = "codespell", specifier = ">=2.4.0" },
     { name = "git-cliff", specifier = ">=2.0.0" },
@@ -1341,6 +1358,7 @@ dev = [
     { name = "pydantic-extra-types", specifier = ">=2.3.0" },
     { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-codspeed", specifier = ">=5.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-examples", specifier = ">=0.0.18" },
     { name = "ruff", specifier = ">=0.12.10" },
@@ -1433,6 +1451,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-codspeed"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/b4/cf932fcd1960a2fd6d9b09eb403253a8709aeee975961afa6299239a830e/pytest_codspeed-5.0.3.tar.gz", hash = "sha256:91afef90e6a96b013495e4702ef5d6358614a449e71008cdc194ef668778b92f", size = 324571, upload-time = "2026-05-22T16:20:49.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/22/456c48160b761d5028c8afa119f085a9fc42855a783a13d73918078969f0/pytest_codspeed-5.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2eeb25fb1ac3f73c4de50e739e78fea396b89782bdb740bf2a7cd2df21f8d4ee", size = 366255, upload-time = "2026-05-22T16:20:56.214Z" },
+    { url = "https://files.pythonhosted.org/packages/74/33/ac7441fa937c9d9f158083a8c46920a5a5c81ed3c5f96240fc8d650db5c2/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73c5c9d98a3372a42611989ccfa437cce3842431ac6d6b9ab42c4f0e59c070f7", size = 932325, upload-time = "2026-05-22T16:21:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bc/8b994adcb9e9016e7d9a808056a3dd9cca21441e432ef456eae2b697d7fe/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2e0ab65df73e837666d12357280ca50ff6d6ac03ea5266703be518b68170edf", size = 934885, upload-time = "2026-05-22T16:21:01.444Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8e/e032451e9e0a06b0c4bff53105f62b693d9a54595dd8c024693741ce3380/pytest_codspeed-5.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6524c57fec279a22ffef6112af404036afc71b4704758ae9f0abda429b8478d4", size = 366253, upload-time = "2026-05-22T16:20:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7b/ae76fd8ac656b9695806a6aafd5f22ec32e6ce20e266a58f9112e01d3cd8/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c383c9121deb58a69f174188e9e4488ffc0daced0ed276abf87747182511901", size = 932360, upload-time = "2026-05-22T16:20:30.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4a/dfd43d943fdb143be4fd62f34c2793ba349dc27aa188e521d19d629aa7ab/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4bcdb4b6522738152885ef067e0c8524d5699828d780fb6f464cdb3db44369c", size = 934928, upload-time = "2026-05-22T16:20:38.62Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6a/fdcec19c7f267c195f147c51d3fd2245f6b8d09b80495ed0a90c008e0842/pytest_codspeed-5.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:25464363c7f9b9bd5022e969c0addba616fa40ac9b8f0fc9e030c4538863b32d", size = 366259, upload-time = "2026-05-22T16:21:06.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/96/c6b03b81dcd21ae3d6b32cca0b3c10149fa378eb21b338d4b63c9eb8050b/pytest_codspeed-5.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efd43f82ea03ced8488a767ded9473f050791ab7783ea8654107e1e0ac66af40", size = 932395, upload-time = "2026-05-22T16:21:04.804Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/56ad8f1cc7d6962f8a680141b361e93467a2abc53d976cd9d5e1edd740e3/pytest_codspeed-5.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:782f9985b6f6b45b8bc20152d206d3a52b56dd088ba81cb70a71f0b39841be9e", size = 934994, upload-time = "2026-05-22T16:20:28.809Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/54/9096c4545f09da94b1b00f3be2fe4952949e86c9bcafca9a29b26aed1a75/pytest_codspeed-5.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9aa0815b90196f3c20d736ea8691381e97f12bbe8c7d87af10a351e434b452cb", size = 366311, upload-time = "2026-05-22T16:20:41.791Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/3c/24c53f67a38ad48cb087105ac30a8aa0923223ee274ea9bf2dc705edaa59/pytest_codspeed-5.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85505c96a3477c346ec2d2b7dced8478f4c651e2b1666ee102d53a832b511853", size = 933169, upload-time = "2026-05-22T16:20:43.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/de/2213f868fa7694f743f96cccbc07e757f45c920c523cccc2da97bc8652df/pytest_codspeed-5.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20eba63765be9d1b6cacbbfad84b87d49eb04b357a7045a0899880da181f81e3", size = 935522, upload-time = "2026-05-22T16:21:03.398Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/5dfea1c031d6cccc11653464828edf205c30f798caf5b2a85375aacd914a/pytest_codspeed-5.0.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:ec9fa6f0af0a9feb0e0bd517fb59ef28f806fbd50c0c6900ac26cbb4d080eba5", size = 366275, upload-time = "2026-05-22T16:20:59.463Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2b/af4d1b612f03b98a6cf3c7d5f62678917a60110a8bf380d49ab408b31137/pytest_codspeed-5.0.3-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8df77b3409f54f4a268f77f3ff74992fe1d995cdbaf2cecf8ad74d32db217ce7", size = 932537, upload-time = "2026-05-22T16:20:54.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a2/c7ec45e36a61b418efb2a3cccaa67a0c2fcf1f21d5880f64c33114f0c249/pytest_codspeed-5.0.3-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5d8695a227ea1c3a41d25db5b3fe720bf1b4808bd38862be811a4efd902c792", size = 934153, upload-time = "2026-05-22T16:21:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c7/d5bada9618a0af56a5c8065fc61280849cab8e7c1e24025807a51c3157ce/pytest_codspeed-5.0.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bf4cc4178cbace8f4d2bd240408276bc4da3850ac5fcb5fb5f8a74ab417615bb", size = 366339, upload-time = "2026-05-22T16:20:51.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/fb27aeb40a81320e7349553b877a21333c897b27c8dfe215630452908f36/pytest_codspeed-5.0.3-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abe793da40f87295d33988673d34f06ea569848b44490b847552cd416816258a", size = 933055, upload-time = "2026-05-22T16:20:44.861Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d9/6f2d69e96deaf0475a695fc9195af59e7a3b5fab50782855e65c63a7bc28/pytest_codspeed-5.0.3-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3a9ed38dfa776443b86f4b49a982e8443d0953db4974bd2673d63cc904ae1ad", size = 934481, upload-time = "2026-05-22T16:20:58.264Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b2/1d2a993c532146dce9eca5b5942d51898021c3579ce18b2454f932a915f8/pytest_codspeed-5.0.3-py3-none-any.whl", hash = "sha256:fe2ea83c924c2250675b75686c3ee456b8cf0208d83d552e182a195fdf467378", size = 74033, upload-time = "2026-05-22T16:20:26.814Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds [CodSpeed](https://codspeed.io) continuous benchmarking for the JSON Schema → Pydantic conversion pipeline.

## ⚠️ One-time setup required

The benchmark job uploads results via **tokenless OIDC**, which needs the repo registered on CodSpeed:

1. Sign in at https://codspeed.io with GitHub and add `Danipulok/pydantic-jsonschema`.
2. Install the **CodSpeed GitHub App** on the repo.

Until that's done the `Run benchmarks` step will run the suite but fail to upload. That's harmless — this workflow is **not** part of the `CI` required-check gate, so it never blocks a merge.

## What's added

- **`tests/benchmarks/test_conversion.py`** — three benchmarks timing `to_model` on a wide/flat schema, a deep schema (`$ref` + `allOf`), and the full `Schema.model_validate` → `to_model` path. The `Schema` is validated outside the measured region so the numbers track our converter, not Pydantic's build.
- **`.github/workflows/codspeed.yml`** — runs on push to `main`, PRs, and `workflow_dispatch`; `CodSpeedHQ/action@v4` in `simulation` mode on `ubuntu-latest` (SHA-pinned, `id-token: write` for tokenless upload).
- **`benchmark` dependency group** — `pytest-codspeed` kept out of `test` so the coverage-gated suite and floor/ceiling runs stay lean.
- **`just bench`** + CI recipes (`ci-install-benchmark`, `ci-benchmark`).

## Isolation from the normal suite

Benchmarks carry the `benchmark` marker and `addopts` adds `-m "not benchmark"`, so:

- the normal suite never collects them (no `pytest-codspeed` needed in the main env, 100% coverage gate untouched — verified `762 passed, 3 deselected`, `TOTAL 100.00%`);
- the CodSpeed job overrides with `-m benchmark` to run only them.

`pytest-memray` from the original TODO item was skipped — it's Linux-only and a separate memory-profiling concern.

## Docs

- https://docs.codspeed.io/integrations/ci/github-actions
