### PR TITLE
chore(sbom): add on-demand `just sbom` recipe (`CycloneDX` via `cyclonedx-py`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ docs/assets/copy-to-llm/
 dist/
 build/
 *.egg-info/
+
+# On-demand CycloneDX SBOM (`just sbom`) — generated, never committed
+sbom/

--- a/justfile
+++ b/justfile
@@ -56,6 +56,21 @@ audit:
 audit-workflows:
     uvx zizmor --offline .github/workflows/
 
+# Generate a CycloneDX SBOM of the runtime dependency tree into `sbom/`. On-demand convenience only —
+# deliberately NOT wired into releases: the published wheel's `Requires-Dist` already declares deps,
+# and `uv audit` covers active CVE scanning, so this is just a standardized bill-of-materials for
+# anyone who explicitly needs one. `--no-default-groups` restricts it to runtime deps; `uv export`
+# carries hashes for component integrity. `cyclonedx-py` has no native `uv` lockfile support, hence
+# the `requirements` bridge. See https://github.com/CycloneDX/cyclonedx-python/issues/857
+sbom:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p sbom
+    uv export --frozen --no-default-groups --no-emit-project --format requirements-txt \
+        | uvx --from cyclonedx-bom cyclonedx-py requirements - \
+            --of JSON --sv 1.6 --output-file sbom/pydantic-jsonschema.cdx.json
+    printf 'Wrote sbom/pydantic-jsonschema.cdx.json\n'
+
 # Run pre-commit on all files
 precommit:
     uv run pre-commit run --all-files
@@ -312,6 +327,7 @@ clean:
     rm -rf .coverage
     rm -rf htmlcov
     rm -rf site
+    rm -rf sbom
     # Remove throwaway envs (`.venv312`-`.venv315`, `.venv-floor`, `.venv-ceil`) but keep the
     # main `.venv` so a clean doesn't force a full re-sync of the working environment.
     find . -maxdepth 1 -type d -name ".venv*" ! -name ".venv" -exec rm -rf {} +

--- a/justfile
+++ b/justfile
@@ -65,11 +65,23 @@ audit-workflows:
 sbom:
     #!/usr/bin/env bash
     set -euo pipefail
+
     mkdir -p sbom
-    uv export --frozen --no-default-groups --no-emit-project --format requirements-txt \
+    output_file="sbom/pydantic-jsonschema.cdx.json"
+
+    # Export the runtime dependency tree (pinned, with hashes) as requirements, then convert it to a
+    # CycloneDX document. `cyclonedx-py` reads the requirements from stdin (the trailing `-`).
+    uv export \
+        --frozen \
+        --no-default-groups \
+        --no-emit-project \
+        --format requirements-txt \
         | uvx --from cyclonedx-bom cyclonedx-py requirements - \
-            --of JSON --sv 1.6 --output-file sbom/pydantic-jsonschema.cdx.json
-    printf 'Wrote sbom/pydantic-jsonschema.cdx.json\n'
+            --output-format JSON \
+            --spec-version 1.7 \
+            --output-file "$output_file"
+
+    printf 'Wrote %s\n' "$output_file"
 
 # Run pre-commit on all files
 precommit:


### PR DESCRIPTION
Adds an **on-demand** `just sbom` recipe that writes a CycloneDX SBOM of the runtime dependency tree to `sbom/pydantic-jsonschema.cdx.json`.

## Scope: convenience only, NOT in releases

This is deliberately *not* wired into `release.yml`. The library has a single runtime dependency (`pydantic`); the published wheel's `Requires-Dist` already declares it, and `uv audit` already covers active CVE scanning. A release-attached SBOM would mostly duplicate wheel metadata for an audience (regulated enterprise consuming CycloneDX files) this library doesn't have. The recipe exists so the artifact is one command away if anyone ever needs a standardized bill-of-materials.

## How it works

```
uv export --frozen --no-default-groups --no-emit-project --format requirements-txt \
    | uvx --from cyclonedx-bom cyclonedx-py requirements - \
        --of JSON --sv 1.6 --output-file sbom/pydantic-jsonschema.cdx.json
```

- `--no-default-groups` restricts the SBOM to runtime deps (no dev/test/docs tooling).
- `uv export` carries per-package hashes → component integrity in the SBOM.
- `cyclonedx-py` has no native `uv` lockfile support ([issue #857](https://github.com/CycloneDX/cyclonedx-python/issues/857)), so the `requirements` subcommand is the bridge.
- Run via `uvx` — no new project dependency (same pattern as `uvx zizmor`).

## Verified locally

Generates a valid **CycloneDX 1.6** document with 5 runtime components and correct purls:

```
annotated-types==0.7.0     pkg:pypi/annotated-types@0.7.0
pydantic==2.13.4           pkg:pypi/pydantic@2.13.4
pydantic-core==2.46.4      pkg:pypi/pydantic-core@2.46.4
typing-extensions==4.15.0  pkg:pypi/typing-extensions@4.15.0
typing-inspection==0.4.2   pkg:pypi/typing-inspection@0.4.2
```

## Other changes

- `.gitignore` — `sbom/` (generated, never committed).
- `justfile` `clean` — removes `sbom/`.
