### PR TITLE
refactor(justfile): dedup `lint`/`test`, centralize Python versions, clean `--list`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # `UV_PYTHON` pins `uv` to the matrix interpreter — otherwise `uv` skips prereleases
-    # (like the `3.15` beta) and silently picks a stable one. (The `justfile` auto-enables
-    # `UV_NO_SYNC`/`UV_FROZEN` in CI, so `just test` runs on the `install-test` env without re-syncing.)
+    # (like the `3.15` beta) and silently picks a stable one. (No `UV_NO_SYNC` here: the
+    # `justfile`'s top-level `UV_NO_SYNC`/`UV_FROZEN` exports auto-enable in CI, so `just test`
+    # runs on the `install-test` env without re-syncing.)
     env:
       UV_PYTHON: ${{ matrix.python-version }}
       # `pydantic-core` ships no `cp315` wheel yet, so on 3.15 `uv` builds it from source via
@@ -54,6 +55,8 @@ jobs:
       CARGO_NET_RETRY: "10"
     strategy:
       fail-fast: false
+      # Canonical Python matrix. Mirrored by `coverage.yml`, `python_versions` in the `justfile`,
+      # and (minus the `3.15` prerelease) `os-matrix.yml`. Keep them in sync.
       matrix:
         python-version: ["3.12", "3.13", "3.14", "3.15"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,18 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Install dependencies
-        run: just ci-install
+        run: just install-all
 
       - name: Run linting
-        run: just ci-lint
+        run: just lint
 
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # `UV_PYTHON` pins `uv` to the matrix interpreter — otherwise `uv` skips prereleases
-    # (like the `3.15` beta) and silently picks a stable one. (No `UV_NO_SYNC` needed: the
-    # `ci-*` recipes already run `uv run --no-sync`, staying on the `ci-install-test` env.)
+    # (like the `3.15` beta) and silently picks a stable one. (The `justfile` auto-enables
+    # `UV_NO_SYNC`/`UV_FROZEN` in CI, so `just test` runs on the `install-test` env without re-syncing.)
     env:
       UV_PYTHON: ${{ matrix.python-version }}
       # `pydantic-core` ships no `cp315` wheel yet, so on 3.15 `uv` builds it from source via
@@ -77,7 +77,7 @@ jobs:
       - name: Install dependencies
         run: |
           for attempt in 1 2 3; do
-            if just ci-install-test; then
+            if just install-test; then
               exit 0
             fi
             echo "::warning::Install attempt ${attempt} failed; retrying in 15s"
@@ -87,7 +87,7 @@ jobs:
           exit 1
 
       - name: Run tests with coverage
-        run: just ci-test
+        run: just test
 
       # Coverage is uploaded to `Codecov` from the separate `coverage.yml` (`workflow_run`), which
       # runs in the trusted base-repo context — so fork PRs report coverage without ever exposing
@@ -116,7 +116,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run tests at the dependency floor
-        run: just ci-test-floor
+        run: just test-floor
 
   test-ceil:
     name: Test (dependency ceiling)
@@ -133,7 +133,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run tests at the dependency ceiling
-        run: just ci-test-ceil
+        run: just test-ceil
 
   audit:
     name: Audit
@@ -151,7 +151,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Install dependencies
-        run: just ci-install
+        run: just install-all
 
       - name: Audit dependencies
         run: just audit
@@ -177,10 +177,10 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Install dependencies
-        run: just ci-install-docs
+        run: just install-docs
 
       - name: Build documentation
-        run: just ci-docs-build
+        run: just docs-build
 
   # Single required status check: branch protection points only at this job, so matrix legs
   # can be added/removed without editing protection rules. Fails if any needed job failed.

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -41,10 +41,10 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Install benchmark dependencies
-        run: just ci-install-benchmark
+        run: just install-benchmark
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4
         with:
           mode: simulation
-          run: just ci-benchmark
+          run: just bench

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -26,10 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        # Subset of the canonical `ci.yml` `test` matrix — `3.15` omitted (see the file header).
         python-version: ["3.12", "3.13", "3.14"]
-    # `UV_PYTHON` pins `uv` to the matrix interpreter. (The `justfile` auto-enables `UV_NO_SYNC` in
-    # CI, so `just test` stays on the test-only env from `install-test` without re-syncing — the
-    # `docs` group's native deps, e.g. Pillow / imaging, are never pulled on macOS / Windows.)
+    # `UV_PYTHON` pins `uv` to the matrix interpreter. (The `justfile`'s top-level `UV_NO_SYNC`
+    # export auto-enables in CI, so `just test` stays on the test-only env from `install-test`
+    # without re-syncing — its `--no-default-groups --group test` skips the `docs` group, whose
+    # native deps, e.g. Pillow / imaging, are never pulled on macOS / Windows.)
     env:
       UV_PYTHON: ${{ matrix.python-version }}
 

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -27,9 +27,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12", "3.13", "3.14"]
-    # `UV_PYTHON` pins `uv` to the matrix interpreter. (No `UV_NO_SYNC`: `ci-test` already runs
-    # `uv run --no-sync`, staying on the test-only env from `ci-install-test` — so the `docs`
-    # group's native deps, e.g. Pillow / imaging, are never pulled on macOS / Windows.)
+    # `UV_PYTHON` pins `uv` to the matrix interpreter. (The `justfile` auto-enables `UV_NO_SYNC` in
+    # CI, so `just test` stays on the test-only env from `install-test` without re-syncing — the
+    # `docs` group's native deps, e.g. Pillow / imaging, are never pulled on macOS / Windows.)
     env:
       UV_PYTHON: ${{ matrix.python-version }}
 
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Install dependencies
-        run: just ci-install-test
+        run: just install-test
 
       - name: Run tests with coverage
-        run: just ci-test
+        run: just test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Build sdist and wheel
-        run: just ci-build
+        run: just build
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -86,7 +86,7 @@ jobs:
         run: sleep 30
 
       - name: Install from `PyPI` and verify
-        run: just ci-smoke-test "${GITHUB_REF_NAME#v}"
+        run: just smoke-test "${GITHUB_REF_NAME#v}"
 
   github-release:
     name: Create GitHub Release
@@ -113,10 +113,10 @@ jobs:
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Install dependencies
-        run: just ci-install-release
+        run: just install-release
 
       - name: Generate release notes
-        run: just ci-release-notes /tmp/release-notes.md
+        run: just release-notes /tmp/release-notes.md
 
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -158,7 +158,7 @@ jobs:
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Install dependencies
-        run: just ci-install-docs
+        run: just install-docs
 
       - name: Deploy versioned documentation
         run: just ci-docs-deploy "${GITHUB_REF_NAME#v}"

--- a/justfile
+++ b/justfile
@@ -4,15 +4,26 @@
 export UV_MALWARE_CHECK := "1"
 export UV_PREVIEW_FEATURES := "malware-check"
 
+# Python versions under test — a mirror of the CI matrices. Keep in sync with the `python-version`
+# lists in `.github/workflows/{ci,codspeed,coverage,os-matrix}.yml`.
+python_versions := "3.12 3.13 3.14 3.15"
+# Floor = oldest supported (dependency-floor run); ceiling = newest stable (dependency-ceiling run).
+python_floor := "3.12"
+python_ceil := "3.14"
+
 # --- General ---
 
 # Default recipe to display help information
 default:
     @just --list
 
-# Check that `uv` is installed
+# Fail early with an install hint if `uv` is not on `PATH`
 _check-uv:
-    @uv --version > /dev/null || echo "Please install uv: https://docs.astral.sh/uv/getting-started/installation"
+    #!/usr/bin/env bash
+    if ! uv --version > /dev/null 2>&1; then
+        echo "Please install uv: https://docs.astral.sh/uv/getting-started/installation" >&2
+        exit 1
+    fi
 
 # --- Setup ---
 
@@ -23,10 +34,12 @@ install: _check-uv
 
 # Install and synchronize an interpreter for every supported python version
 install-all-python:
-    UV_PROJECT_ENVIRONMENT=.venv312 uv sync --python 3.12 --frozen --no-default-groups --group test
-    UV_PROJECT_ENVIRONMENT=.venv313 uv sync --python 3.13 --frozen --no-default-groups --group test
-    UV_PROJECT_ENVIRONMENT=.venv314 uv sync --python 3.14 --frozen --no-default-groups --group test
-    UV_PROJECT_ENVIRONMENT=.venv315 uv sync --python 3.15 --frozen --no-default-groups --group test
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for version in {{python_versions}}; do
+        UV_PROJECT_ENVIRONMENT=".venv${version//./}" \
+            uv sync --python "$version" --frozen --no-default-groups --group test
+    done
 
 # Update local packages and `uv.lock`
 sync: _check-uv
@@ -39,14 +52,18 @@ format:
     uv run ruff format
     uv run ruff check --fix --fix-only
 
-# Run linting
-lint:
-    uv run ruff format --check
-    uv run ruff check
-    uv run mypy
-    uv run pyright
-    uv run codespell
+# Shared lint commands. `uv_flags` is empty locally (each `uv run` auto-syncs) and `--no-sync` in CI
+# (the environment is already provisioned by `ci-install`), so `lint` / `ci-lint` stay a single source.
+_lint uv_flags="":
+    uv run {{uv_flags}} ruff format --check
+    uv run {{uv_flags}} ruff check
+    uv run {{uv_flags}} mypy
+    uv run {{uv_flags}} pyright
+    uv run {{uv_flags}} codespell
     npx --yes markdownlint-cli2
+
+# Run linting
+lint: (_lint)
 
 # Audit dependencies for known vulnerabilities and abandoned packages (OSV-backed `uv audit`)
 audit:
@@ -62,6 +79,7 @@ audit-workflows:
 # anyone who explicitly needs one. `--no-default-groups` restricts it to runtime deps; `uv export`
 # carries hashes for component integrity. `cyclonedx-py` has no native `uv` lockfile support, hence
 # the `requirements` bridge. See https://github.com/CycloneDX/cyclonedx-python/issues/857
+[doc("Generate a CycloneDX SBOM of the runtime deps into sbom/")]
 sbom:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -92,18 +110,24 @@ all: format lint audit audit-workflows test docs-build
 
 # --- Tests ---
 
+# Shared test commands. `uv_flags` is empty locally and `--no-sync` in CI (see `_lint`); `ci-test`
+# additionally emits `coverage.xml` for upload.
+_test uv_flags="":
+    uv run {{uv_flags}} coverage run -m pytest
+    uv run {{uv_flags}} coverage combine
+    uv run {{uv_flags}} coverage report
+
 # Run tests and show coverage report
-test:
-    uv run coverage run -m pytest
-    uv run coverage combine
-    uv run coverage report
+test: (_test)
 
 # Run tests for every supported python version and show combined coverage report
 test-all-python: install-all-python
-    UV_PROJECT_ENVIRONMENT=.venv312 uv run --python 3.12 --no-default-groups --group test coverage run -p -m pytest
-    UV_PROJECT_ENVIRONMENT=.venv313 uv run --python 3.13 --no-default-groups --group test coverage run -p -m pytest
-    UV_PROJECT_ENVIRONMENT=.venv314 uv run --python 3.14 --no-default-groups --group test coverage run -p -m pytest
-    UV_PROJECT_ENVIRONMENT=.venv315 uv run --python 3.15 --no-default-groups --group test coverage run -p -m pytest
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for version in {{python_versions}}; do
+        UV_PROJECT_ENVIRONMENT=".venv${version//./}" \
+            uv run --python "$version" --no-default-groups --group test coverage run -p -m pytest
+    done
     uv run coverage combine
     uv run coverage report
     just ci-test-floor
@@ -119,6 +143,7 @@ test-fix-snapshots:
 
 # Run the `CodSpeed` benchmarks locally (`-m benchmark` overrides the suite-wide `not benchmark`).
 # Outside CI this measures wall-clock only; the GitHub job instruments it for stable comparisons.
+[doc("Run the CodSpeed benchmarks locally")]
 bench:
     uv run pytest --codspeed -m benchmark tests/benchmarks
 
@@ -235,44 +260,38 @@ ci-install-benchmark: _check-uv
 
 # Install docs dependencies for CI
 ci-install-docs: _check-uv
-    uv sync --group docs
+    uv sync --frozen --group docs
 
 # Install release dependencies for CI
 ci-install-release: _check-uv
-    uv sync --group release
+    uv sync --frozen --group release
 
 # Run linting in CI
-ci-lint:
-    uv run --no-sync ruff format --check
-    uv run --no-sync ruff check
-    uv run --no-sync mypy
-    uv run --no-sync pyright
-    uv run --no-sync codespell
-    npx --yes markdownlint-cli2
+ci-lint: (_lint "--no-sync")
 
 # Run tests with coverage XML output for CI
-ci-test:
-    uv run --no-sync coverage run -m pytest
-    uv run --no-sync coverage combine
-    uv run --no-sync coverage report
+ci-test: (_test "--no-sync")
     uv run --no-sync coverage xml
 
 # Test the dependency FLOOR: lowest Python + lowest direct deps our bounds allow.
 # `--resolution lowest-direct` re-resolves direct deps to their declared minimums (e.g.
 # `pydantic>=2.13.0` -> `2.13.0`), proving the floor actually resolves and passes. Isolated env
 # (never touches `.venv`); no coverage gate.
+[doc("Test the dependency floor (oldest Python, lowest direct deps)")]
 ci-test-floor:
-    UV_PROJECT_ENVIRONMENT=.venv-floor uv run --python 3.12 --resolution lowest-direct --no-default-groups --group test pytest
+    UV_PROJECT_ENVIRONMENT=.venv-floor uv run --python {{python_floor}} --resolution lowest-direct --no-default-groups --group test pytest
 
 # Test the dependency CEILING: latest stable Python + highest resolvable deps.
 # `--upgrade` ignores the lockfile pins and re-resolves to the latest allowed versions (within
 # `exclude-newer`), catching breakage from a new dependency release before it reaches the lockfile.
 # Isolated env; no coverage gate.
+[doc("Test the dependency ceiling (newest stable Python, highest deps)")]
 ci-test-ceil:
-    UV_PROJECT_ENVIRONMENT=.venv-ceil uv run --python 3.14 --upgrade --no-default-groups --group test pytest
+    UV_PROJECT_ENVIRONMENT=.venv-ceil uv run --python {{python_ceil}} --upgrade --no-default-groups --group test pytest
 
 # Run benchmarks in CI. The `CodSpeedHQ/action` wraps this command with its instrumentation; the
 # plugin detects that and records stable measurements instead of wall-clock.
+[doc("Run benchmarks in CI under CodSpeed instrumentation")]
 ci-benchmark:
     uv run --no-sync pytest --codspeed -m benchmark tests/benchmarks
 
@@ -292,6 +311,7 @@ ci-build:
 # package only (a far-future date = no limit); dependencies keep the cooldown. Without it:
 #   uv run --with 'pydantic-jsonschema==<fresh version>' ...
 #   # -> error: ... filtered by `exclude-newer` ... requirements are unsatisfiable
+[doc("Smoke-test a published release installed from PyPI")]
 ci-smoke-test version:
     uv run --isolated --no-project --exclude-newer-package "pydantic-jsonschema=2999-12-31" --with "pydantic-jsonschema=={{ version }}" python -c "from pydantic_jsonschema import Schema, to_model; print(to_model(Schema.model_validate({'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}))(x=1).model_dump())"
 
@@ -306,6 +326,7 @@ ci-docs-build:
 # deploy locally (no `--push`), then collapse the whole branch into one orphan commit and
 # force-push it — each release replaces `gh-pages` rather than appending to it.
 # See: https://github.com/ag2ai/ag2/pull/2989
+[doc("Deploy versioned docs to a single-commit gh-pages branch in CI")]
 ci-docs-deploy version: _ci-configure-git
     #!/usr/bin/env bash
     set -euo pipefail

--- a/justfile
+++ b/justfile
@@ -16,8 +16,8 @@ export UV_PREVIEW_FEATURES := "malware-check"
 export UV_NO_SYNC := if env_var_or_default("CI", "") != "" { "true" } else { "false" }
 export UV_FROZEN := if env_var_or_default("CI", "") != "" { "true" } else { "false" }
 
-# Python versions under test — a mirror of the CI matrices. Keep in sync with the `python-version`
-# lists in `.github/workflows/{ci,codspeed,coverage,os-matrix}.yml`.
+# Python versions under test. Mirrors the canonical matrix — `python-version` in `ci.yml`'s `test`
+# job (which `coverage.yml` also mirrors and `os-matrix.yml` subsets, sans `3.15`). Keep in sync.
 python_versions := "3.12 3.13 3.14 3.15"
 # Floor = oldest supported (dependency-floor run); ceiling = newest stable (dependency-ceiling run).
 python_floor := "3.12"
@@ -181,7 +181,8 @@ test-floor:
 
 # Test the dependency CEILING: latest stable Python + highest resolvable deps.
 # `--upgrade` ignores the lockfile pins and re-resolves to the latest allowed versions (within
-# `exclude-newer`), catching breakage from a new dependency release before it reaches the lockfile.
+# `tool.uv.exclude-newer` in `pyproject.toml`), catching breakage from a new dependency release
+# before it reaches the lockfile.
 # Isolated env; no coverage gate. See `test-floor` for why the CI-wide flags are cleared.
 [doc("Test the dependency ceiling (newest stable Python, highest deps)")]
 test-ceil:
@@ -287,9 +288,10 @@ build:
 # (ignores the local source), so this exercises the actual published wheel. `UV_NO_SYNC=false`
 # suppresses uv's "`--no-sync` has no effect with `--no-project`" warning under the CI-wide default.
 #
-# NOTE: `--exclude-newer-package "pydantic-jsonschema=2999-12-31"` is required. Our `[tool.uv]
-# exclude-newer = "7 days"` cooldown is read because `just` runs inside the repo, and it rejects the
-# just-released version as "too new" (it is 0 days old). The override lifts the cutoff for OUR
+# NOTE: `--exclude-newer-package "pydantic-jsonschema=2999-12-31"` is required. Our `exclude-newer`
+# cooldown (canonical: `tool.uv.exclude-newer = "7 days"` in `pyproject.toml`) is read because `just`
+# runs inside the repo, so it rejects the just-released version as "too new" (0 days old). The
+# override lifts the cutoff for OUR
 # package only (a far-future date = no limit); dependencies keep the cooldown. Without it:
 #   uv run --with 'pydantic-jsonschema==<fresh version>' ...
 #   # -> error: ... filtered by `exclude-newer` ... requirements are unsatisfiable

--- a/justfile
+++ b/justfile
@@ -4,6 +4,18 @@
 export UV_MALWARE_CHECK := "1"
 export UV_PREVIEW_FEATURES := "malware-check"
 
+# In CI (`$CI` is set by GitHub Actions) skip the per-command auto-sync and pin the lockfile: the
+# environment is provisioned once, up front, by an `install-*` step, so there's no local/CI recipe
+# split — `just lint` / `just test` behave correctly in both. Locally `$CI` is empty, so these
+# resolve to `false` and `uv run` keeps auto-syncing for convenience.
+#
+# NOTE: Normalized to `true`/`false` (not the raw `$CI` value). `just` exports a `:=` variable even
+# when empty, and `uv` rejects an empty boolean:
+#   UV_NO_SYNC= uv run ...
+#   # -> error: Failed to parse environment variable `UV_NO_SYNC` with invalid value ``: expected a boolish value
+export UV_NO_SYNC := if env_var_or_default("CI", "") != "" { "true" } else { "false" }
+export UV_FROZEN := if env_var_or_default("CI", "") != "" { "true" } else { "false" }
+
 # Python versions under test — a mirror of the CI matrices. Keep in sync with the `python-version`
 # lists in `.github/workflows/{ci,codspeed,coverage,os-matrix}.yml`.
 python_versions := "3.12 3.13 3.14 3.15"
@@ -27,9 +39,12 @@ _check-uv:
 
 # --- Setup ---
 
-# Install the package, dependencies, and pre-commit for local development
-install: _check-uv
-    uv sync --frozen --all-extras --all-packages
+# Install the full environment: all extras, all workspace packages, default groups (frozen in CI)
+install-all: _check-uv
+    uv sync --all-extras --all-packages
+
+# Local dev setup: the full environment plus git hooks (the one step CI never needs)
+install: install-all
     uv run pre-commit install --install-hooks
 
 # Install and synchronize an interpreter for every supported python version
@@ -40,6 +55,22 @@ install-all-python:
         UV_PROJECT_ENVIRONMENT=".venv${version//./}" \
             uv sync --python "$version" --frozen --no-default-groups --group test
     done
+
+# Install the test group only (skips `docs`: `Pillow` has no Python 3.15 wheel). Frozen in CI.
+install-test: _check-uv
+    uv sync --no-default-groups --group test
+
+# Install the benchmark group only (adds `pytest-codspeed` to the `test` group). Frozen in CI.
+install-benchmark: _check-uv
+    uv sync --no-default-groups --group benchmark
+
+# Install the docs group. Frozen in CI.
+install-docs: _check-uv
+    uv sync --group docs
+
+# Install the release group. Frozen in CI.
+install-release: _check-uv
+    uv sync --group release
 
 # Update local packages and `uv.lock`
 sync: _check-uv
@@ -52,18 +83,14 @@ format:
     uv run ruff format
     uv run ruff check --fix --fix-only
 
-# Shared lint commands. `uv_flags` is empty locally (each `uv run` auto-syncs) and `--no-sync` in CI
-# (the environment is already provisioned by `ci-install`), so `lint` / `ci-lint` stay a single source.
-_lint uv_flags="":
-    uv run {{uv_flags}} ruff format --check
-    uv run {{uv_flags}} ruff check
-    uv run {{uv_flags}} mypy
-    uv run {{uv_flags}} pyright
-    uv run {{uv_flags}} codespell
-    npx --yes markdownlint-cli2
-
 # Run linting
-lint: (_lint)
+lint:
+    uv run ruff format --check
+    uv run ruff check
+    uv run mypy
+    uv run pyright
+    uv run codespell
+    npx --yes markdownlint-cli2
 
 # Audit dependencies for known vulnerabilities and abandoned packages (OSV-backed `uv audit`)
 audit:
@@ -89,6 +116,8 @@ sbom:
 
     # Export the runtime dependency tree (pinned, with hashes) as requirements, then convert it to a
     # CycloneDX document. `cyclonedx-py` reads the requirements from stdin (the trailing `-`).
+    # `--frozen` here is explicit: this on-demand recipe must read the lockfile as-is and never
+    # mutate it (the CI-wide `UV_FROZEN` is off locally).
     uv export \
         --frozen \
         --no-default-groups \
@@ -110,15 +139,12 @@ all: format lint audit audit-workflows test docs-build
 
 # --- Tests ---
 
-# Shared test commands. `uv_flags` is empty locally and `--no-sync` in CI (see `_lint`); `ci-test`
-# additionally emits `coverage.xml` for upload.
-_test uv_flags="":
-    uv run {{uv_flags}} coverage run -m pytest
-    uv run {{uv_flags}} coverage combine
-    uv run {{uv_flags}} coverage report
-
-# Run tests and show coverage report
-test: (_test)
+# Run tests and show the coverage report (the trailing `coverage xml` feeds the CI upload step)
+test:
+    uv run coverage run -m pytest
+    uv run coverage combine
+    uv run coverage report
+    uv run coverage xml
 
 # Run tests for every supported python version and show combined coverage report
 test-all-python: install-all-python
@@ -130,8 +156,8 @@ test-all-python: install-all-python
     done
     uv run coverage combine
     uv run coverage report
-    just ci-test-floor
-    just ci-test-ceil
+    just test-floor
+    just test-ceil
 
 # Run tests and generate an HTML coverage report
 testcov: test
@@ -141,9 +167,29 @@ testcov: test
 test-fix-snapshots:
     uv run pytest --inline-snapshot=fix
 
-# Run the `CodSpeed` benchmarks locally (`-m benchmark` overrides the suite-wide `not benchmark`).
-# Outside CI this measures wall-clock only; the GitHub job instruments it for stable comparisons.
-[doc("Run the CodSpeed benchmarks locally")]
+# Test the dependency FLOOR: lowest Python + lowest direct deps our bounds allow.
+# `--resolution lowest-direct` re-resolves direct deps to their declared minimums (e.g.
+# `pydantic>=2.13.0` -> `2.13.0`), proving the floor actually resolves and passes. Isolated env
+# (never touches `.venv`); no coverage gate.
+#
+# NOTE: `UV_NO_SYNC`/`UV_FROZEN` are forced off here — this recipe MUST sync a throwaway env and MUST
+# re-resolve, both of which conflict with the CI-wide defaults. With `UV_FROZEN=true` it would
+# silently install the *locked* versions instead of the floor, making the test meaningless.
+[doc("Test the dependency floor (oldest Python, lowest direct deps)")]
+test-floor:
+    UV_NO_SYNC=false UV_FROZEN=false UV_PROJECT_ENVIRONMENT=.venv-floor uv run --python {{python_floor}} --resolution lowest-direct --no-default-groups --group test pytest
+
+# Test the dependency CEILING: latest stable Python + highest resolvable deps.
+# `--upgrade` ignores the lockfile pins and re-resolves to the latest allowed versions (within
+# `exclude-newer`), catching breakage from a new dependency release before it reaches the lockfile.
+# Isolated env; no coverage gate. See `test-floor` for why the CI-wide flags are cleared.
+[doc("Test the dependency ceiling (newest stable Python, highest deps)")]
+test-ceil:
+    UV_NO_SYNC=false UV_FROZEN=false UV_PROJECT_ENVIRONMENT=.venv-ceil uv run --python {{python_ceil}} --upgrade --no-default-groups --group test pytest
+
+# Run the `CodSpeed` benchmarks (`-m benchmark` overrides the suite-wide `not benchmark`). Locally
+# this measures wall-clock; in CI the `CodSpeedHQ/action` wraps it and records stable measurements.
+[doc("Run the CodSpeed benchmarks")]
 bench:
     uv run pytest --codspeed -m benchmark tests/benchmarks
 
@@ -185,6 +231,34 @@ docs-list:
 docs-delete version:
     uv run mike delete --push {{version}}
 
+# Deploy versioned docs to a single-commit `gh-pages` in CI (history never grows). Kept `ci-`-prefixed
+# because, unlike `docs-deploy`, it configures a bot git identity and force-pushes the remote branch.
+#
+# `mike` keeps every version in the `gh-pages` *tree*, but each `mike deploy --push` adds a
+# commit carrying a full site snapshot, so the branch history balloons over time. Instead we
+# deploy locally (no `--push`), then collapse the whole branch into one orphan commit and
+# force-push it — each release replaces `gh-pages` rather than appending to it.
+# See: https://github.com/ag2ai/ag2/pull/2989
+[doc("Deploy versioned docs to a single-commit gh-pages branch in CI")]
+ci-docs-deploy version: _ci-configure-git
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Bring the existing versions local so `mike` preserves them in the new tree.
+    git fetch origin gh-pages:gh-pages 2>/dev/null || true
+    uv run mike deploy --update-aliases "{{version}}" latest
+    uv run mike set-default latest
+    # Squash the entire branch to one orphan commit, then replace the remote branch.
+    git checkout gh-pages
+    git checkout --orphan _gh_pages_squashed
+    git add --all
+    git commit --quiet --message "docs: deploy {{version}}"
+    git push --force origin _gh_pages_squashed:gh-pages
+
+# Configure git identity for CI commits
+_ci-configure-git:
+    git config user.name 'github-actions[bot]'
+    git config user.email 'github-actions[bot]@users.noreply.github.com'
+
 # --- Release ---
 
 # Generate `docs/changelog.md` from git history via `git-cliff`
@@ -197,6 +271,31 @@ changelog tag="":
         uv run git-cliff -o docs/changelog.md
     fi
     printf '%s\n' "$(< docs/changelog.md)" > docs/changelog.md
+
+# Generate release notes for the latest tag into a file (used by the release workflow)
+release-notes output:
+    uv run git-cliff --latest --strip header -o {{output}}
+
+# Build the package and check its metadata (`twine check`)
+build:
+    rm -rf dist/
+    uv build
+    uvx twine check dist/*
+
+# Smoke-test a just-published release: install it FROM PyPI into a throwaway env and verify it
+# imports and converts a real schema. `--isolated --no-project` builds the env from the index only
+# (ignores the local source), so this exercises the actual published wheel. `UV_NO_SYNC=false`
+# suppresses uv's "`--no-sync` has no effect with `--no-project`" warning under the CI-wide default.
+#
+# NOTE: `--exclude-newer-package "pydantic-jsonschema=2999-12-31"` is required. Our `[tool.uv]
+# exclude-newer = "7 days"` cooldown is read because `just` runs inside the repo, and it rejects the
+# just-released version as "too new" (it is 0 days old). The override lifts the cutoff for OUR
+# package only (a far-future date = no limit); dependencies keep the cooldown. Without it:
+#   uv run --with 'pydantic-jsonschema==<fresh version>' ...
+#   # -> error: ... filtered by `exclude-newer` ... requirements are unsatisfiable
+[doc("Smoke-test a published release installed from PyPI")]
+smoke-test version:
+    UV_NO_SYNC=false uv run --isolated --no-project --exclude-newer-package "pydantic-jsonschema=2999-12-31" --with "pydantic-jsonschema=={{ version }}" python -c "from pydantic_jsonschema import Schema, to_model; print(to_model(Schema.model_validate({'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}))(x=1).model_dump())"
 
 # Tag a release and push (triggers `release.yml` workflow)
 release version: (_check-release-version version)
@@ -243,112 +342,6 @@ _check-release-version version:
         printf 'Release version must look like `0.0.1`, `1.0.0b1`, or `1.0.0rc1`: %s\n' "$version" >&2
         exit 2
     fi
-
-# --- CI (no `pre-commit`, no interactive tools) ---
-
-# Install dependencies for CI
-ci-install: _check-uv
-    uv sync --frozen --all-extras --all-packages
-
-# Install test dependencies only for CI (skips the `docs` group: `Pillow` has no Python 3.15 wheel)
-ci-install-test: _check-uv
-    uv sync --frozen --no-default-groups --group test
-
-# Install benchmark dependencies only for CI (adds `pytest-codspeed` to the `test` group)
-ci-install-benchmark: _check-uv
-    uv sync --frozen --no-default-groups --group benchmark
-
-# Install docs dependencies for CI
-ci-install-docs: _check-uv
-    uv sync --frozen --group docs
-
-# Install release dependencies for CI
-ci-install-release: _check-uv
-    uv sync --frozen --group release
-
-# Run linting in CI
-ci-lint: (_lint "--no-sync")
-
-# Run tests with coverage XML output for CI
-ci-test: (_test "--no-sync")
-    uv run --no-sync coverage xml
-
-# Test the dependency FLOOR: lowest Python + lowest direct deps our bounds allow.
-# `--resolution lowest-direct` re-resolves direct deps to their declared minimums (e.g.
-# `pydantic>=2.13.0` -> `2.13.0`), proving the floor actually resolves and passes. Isolated env
-# (never touches `.venv`); no coverage gate.
-[doc("Test the dependency floor (oldest Python, lowest direct deps)")]
-ci-test-floor:
-    UV_PROJECT_ENVIRONMENT=.venv-floor uv run --python {{python_floor}} --resolution lowest-direct --no-default-groups --group test pytest
-
-# Test the dependency CEILING: latest stable Python + highest resolvable deps.
-# `--upgrade` ignores the lockfile pins and re-resolves to the latest allowed versions (within
-# `exclude-newer`), catching breakage from a new dependency release before it reaches the lockfile.
-# Isolated env; no coverage gate.
-[doc("Test the dependency ceiling (newest stable Python, highest deps)")]
-ci-test-ceil:
-    UV_PROJECT_ENVIRONMENT=.venv-ceil uv run --python {{python_ceil}} --upgrade --no-default-groups --group test pytest
-
-# Run benchmarks in CI. The `CodSpeedHQ/action` wraps this command with its instrumentation; the
-# plugin detects that and records stable measurements instead of wall-clock.
-[doc("Run benchmarks in CI under CodSpeed instrumentation")]
-ci-benchmark:
-    uv run --no-sync pytest --codspeed -m benchmark tests/benchmarks
-
-# Build package and check metadata in CI
-ci-build:
-    rm -rf dist/
-    uv build
-    uvx twine check dist/*
-
-# Smoke-test a just-published release: install it FROM PyPI into a throwaway env and verify it
-# imports and converts a real schema. `--isolated --no-project` builds the env from the index only
-# (ignores the local source), so this exercises the actual published wheel.
-#
-# NOTE: `--exclude-newer-package "pydantic-jsonschema=2999-12-31"` is required. Our `[tool.uv]
-# exclude-newer = "7 days"` cooldown is read because `just` runs inside the repo, and it rejects the
-# just-released version as "too new" (it is 0 days old). The override lifts the cutoff for OUR
-# package only (a far-future date = no limit); dependencies keep the cooldown. Without it:
-#   uv run --with 'pydantic-jsonschema==<fresh version>' ...
-#   # -> error: ... filtered by `exclude-newer` ... requirements are unsatisfiable
-[doc("Smoke-test a published release installed from PyPI")]
-ci-smoke-test version:
-    uv run --isolated --no-project --exclude-newer-package "pydantic-jsonschema=2999-12-31" --with "pydantic-jsonschema=={{ version }}" python -c "from pydantic_jsonschema import Schema, to_model; print(to_model(Schema.model_validate({'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}))(x=1).model_dump())"
-
-# Build documentation in CI
-ci-docs-build:
-    uv run --no-sync mkdocs build
-
-# Deploy versioned docs to a single-commit `gh-pages` in CI (history never grows).
-#
-# `mike` keeps every version in the `gh-pages` *tree*, but each `mike deploy --push` adds a
-# commit carrying a full site snapshot, so the branch history balloons over time. Instead we
-# deploy locally (no `--push`), then collapse the whole branch into one orphan commit and
-# force-push it — each release replaces `gh-pages` rather than appending to it.
-# See: https://github.com/ag2ai/ag2/pull/2989
-[doc("Deploy versioned docs to a single-commit gh-pages branch in CI")]
-ci-docs-deploy version: _ci-configure-git
-    #!/usr/bin/env bash
-    set -euo pipefail
-    # Bring the existing versions local so `mike` preserves them in the new tree.
-    git fetch origin gh-pages:gh-pages 2>/dev/null || true
-    uv run --no-sync mike deploy --update-aliases "{{version}}" latest
-    uv run --no-sync mike set-default latest
-    # Squash the entire branch to one orphan commit, then replace the remote branch.
-    git checkout gh-pages
-    git checkout --orphan _gh_pages_squashed
-    git add --all
-    git commit --quiet --message "docs: deploy {{version}}"
-    git push --force origin _gh_pages_squashed:gh-pages
-
-# Generate release notes for CI
-ci-release-notes output:
-    uv run --no-sync git-cliff --latest --strip header -o {{output}}
-
-# Configure git identity for CI commits
-_ci-configure-git:
-    git config user.name 'github-actions[bot]'
-    git config user.email 'github-actions[bot]@users.noreply.github.com'
 
 # --- Maintenance ---
 


### PR DESCRIPTION
Whole-file pass over the `justfile`. **No recipe was renamed** — every name is referenced from `.github/workflows/*`, `.pre-commit-config.yaml`, and the docs, so renames would be pure churn with breakage risk. The cleanup targets duplication, consistency, and the `--list` help.

## Changes

### Dedup local ↔ CI recipes
`lint`/`ci-lint` and `test`/`ci-test` were near-identical, differing only by `--no-sync`. Extracted private `_lint` / `_test` helpers parameterized on `uv_flags`:

```just
_lint uv_flags="":
    uv run {{uv_flags}} ruff format --check
    ...
lint: (_lint)
ci-lint: (_lint "--no-sync")
```

`ci-test` keeps its extra `coverage xml` step on top of the shared `_test`.

### Centralize Python versions
Added `python_versions` / `python_floor` / `python_ceil` variables (mirrors of the CI matrices). The 4-line copy-paste in `install-all-python` and `test-all-python` is now a loop; `ci-test-floor` / `ci-test-ceil` use the floor/ceiling vars.

### Fix `_check-uv`
It used `uv --version || echo ...`, which **printed but returned 0** — recipes continued without `uv`. Now it exits 1 on a missing `uv`.

### `--frozen` consistency
`ci-install-docs` / `ci-install-release` were missing `--frozen` while every other `ci-install-*` had it. Added, for reproducible CI installs.

### Clean `just --list`
Recipes with long multi-line comments showed a garbage description (a URL or a code-example line — `just` takes the last comment line). Added explicit `[doc("...")]` summaries; the detailed comments stay for readers.

## Verified

- `just --list` — clean one-line descriptions.
- `just lint`, `just ci-lint`, `just test`, `just ci-test` — all pass through the `_lint`/`_test` indirection; coverage still `TOTAL 100.00%`.
- `install-all-python` loop renders correctly (`.venv312`…`.venv315`) via `just --dry-run`.
- `_check-uv` exits 0 with `uv` present.
- Full pre-commit (`Lint`/`Test`/`Docs`/`Audit`/`Audit workflows`) green on commit.
