### PR TITLE
chore(coderabbit): add `.coderabbit.yaml` with `assertive` review profile

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+
+reviews:
+  # NOTE: `assertive` is the verbose profile — we start with maximum feedback
+  #       to evaluate the tool; downgrade to `chill` if the noise outweighs
+  #       the signal.
+  profile: assertive
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+  path_filters:
+    - "!dist/**"
+    - "!site/**"
+    - "!sbom/**"
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
# Summary

Adds a `.coderabbit.yaml` config so CodeRabbit reviews PRs with sensible repo-specific settings once the GitHub App is installed.

## What changed

- `reviews.profile: assertive` — start with maximum feedback to evaluate the tool; downgrade to `chill` if noise outweighs signal.
- `high_level_summary` enabled, `poem` disabled.
- `dist/`, `site/`, `sbom/` excluded from review via `path_filters`.

## How it was tested

Config validated against the CodeRabbit `schema.v2.json` (YAML lint via pre-commit). Behavior is verifiable only after the GitHub App is installed — this PR itself will be the first test.

## Notes

The config is inert until the CodeRabbit GitHub App is granted access to this repository.

---

- [x] I followed the [contribution guide](https://danipulok.github.io/pydantic-jsonschema/contributing/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration with English-language summaries and assertive review settings.
  * Enabled automatic review responses and chat replies.
  * Excluded generated build, site, and software bill of materials files from automated review processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->