### PR TITLE
chore(sonarcloud): add `.sonarcloud.properties` for automatic analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -6,4 +6,6 @@ sonar.sources=pydantic_jsonschema
 sonar.tests=tests
 
 # Keep in sync with the canonical Python matrix (`python-version` in `ci.yml`'s `test` job).
-sonar.python.version=3.12, 3.13, 3.14, 3.15
+# NOTE: `3.15` is omitted — SonarCloud's Python analyzer supports versions up to `3.14` only, and an unknown version risks the whole setting being ignored.
+# Add `3.15` once https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/languages/python lists it as supported.
+sonar.python.version=3.12, 3.13, 3.14

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,8 @@
+# SonarCloud Automatic Analysis configuration. Only source layout and exclusions are
+# file-configurable; quality gate thresholds live in the SonarCloud UI.
+sonar.sources=pydantic_jsonschema
+sonar.tests=tests
+
+# Exclude tests from copy-paste detection: parametrized suites and full-snapshot
+# assertions duplicate structurally by design.
+sonar.cpd.exclusions=tests/**

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -2,7 +2,3 @@
 # file-configurable; quality gate thresholds live in the SonarCloud UI.
 sonar.sources=pydantic_jsonschema
 sonar.tests=tests
-
-# Exclude tests from copy-paste detection: parametrized suites and full-snapshot
-# assertions duplicate structurally by design.
-sonar.cpd.exclusions=tests/**

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,9 @@
-# SonarCloud Automatic Analysis configuration. Only source layout and exclusions are
-# file-configurable; quality gate thresholds live in the SonarCloud UI.
+# SonarCloud Automatic Analysis configuration.
+# Dashboard: https://sonarcloud.io/project/overview?id=Danipulok_pydantic-jsonschema
+# Only source layout, exclusions, and the Python version are configurable here.
+# Quality gate thresholds and rule profiles live in the SonarCloud UI.
 sonar.sources=pydantic_jsonschema
 sonar.tests=tests
+
+# Keep in sync with the canonical Python matrix (`python-version` in `ci.yml`'s `test` job).
+sonar.python.version=3.12, 3.13, 3.14, 3.15


### PR DESCRIPTION
# Summary

Adds `.sonarcloud.properties` so SonarCloud Automatic Analysis knows the source layout and skips copy-paste detection in tests.

## What changed

- `sonar.sources` / `sonar.tests` — mark `pydantic_jsonschema/` as production code and `tests/` as tests.
- `sonar.cpd.exclusions=tests/**` — parametrized suites and full-snapshot assertions duplicate structurally by design, so tests are excluded from the duplication metric.

## How it was tested

The file only takes effect once the SonarCloud GitHub App is installed and the repository is imported on sonarcloud.io; the first analyzed PR after that will confirm it is picked up (the analysis summary lists the configuration source).

## Notes

Quality gate thresholds are not file-configurable — they live in the SonarCloud UI (default `Sonar way` gate). Coverage conditions do not apply in Automatic Analysis mode; coverage stays with Codecov.

---

- [x] I followed the [contribution guide](https://danipulok.github.io/pydantic-jsonschema/contributing/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added SonarCloud automatic analysis configuration for the Python project.
  * Defined the source and test directories for accurate scanning.
  * Set a Python version matrix and tuned analysis scope to focus on relevant results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->