### PR TITLE
fix(formats): prevent ReDoS in `_URI_RE` via possessive quantifiers

### DIFF
--- a/pydantic_jsonschema/formats/_hostname.py
+++ b/pydantic_jsonschema/formats/_hostname.py
@@ -20,7 +20,7 @@ __all__ = [
 # Trailing dot allowed (absolute FQDN).
 # Case-insensitive.
 _HOSTNAME_RE: Final[re.Pattern[str]] = re.compile(
-    r"^(?![-])[-A-Z\d]{1,63}(?<!-)(?:\.(?![-])[-A-Z\d]{1,63}(?<!-))*\.?$",
+    r"^(?!-)[-A-Z\d]{1,63}(?<!-)(?:\.(?!-)[-A-Z\d]{1,63}(?<!-))*\.?$",
     re.IGNORECASE,
 )
 

--- a/pydantic_jsonschema/formats/_uri.py
+++ b/pydantic_jsonschema/formats/_uri.py
@@ -18,8 +18,19 @@ __all__ = [
 
 # See: https://www.rfc-editor.org/rfc/rfc3986#appendix-B
 # Decompose a URI-reference into scheme, authority, path, query, and fragment.
+#
+# NOTE: Quantifiers are possessive (`++`/`*+`) to keep matching linear: the `scheme`,
+#       `authority`, `path`, and query character classes overlap, so on non-matching
+#       input greedy backtracking between them is quadratic, and a long crafted value
+#       hangs validation (ReDoS, Sonar S8786). Possessiveness cannot change what
+#       matches — each class excludes the delimiter that follows it, so giving
+#       characters back never enables a match the possessive form misses.
+#
+# Reproduce:
+#   >>> _URI_RE.match("//" + "a" * 16_000 + "#\nx")
+#   ~8.6s with greedy quantifiers, <1ms with possessive ones
 _URI_RE: Final[re.Pattern[str]] = re.compile(
-    r"^(?:(?P<scheme>[^:/?#]+):)?(?://(?P<authority>[^/?#]*))?(?P<path>[^?#]*)(?:\?[^#]*)?(?:#.*)?$",
+    r"^(?:(?P<scheme>[^:/?#]++):)?(?://(?P<authority>[^/?#]*+))?(?P<path>[^?#]*+)(?:\?[^#]*+)?(?:#.*)?$",
 )
 
 # See: https://www.rfc-editor.org/rfc/rfc3986#section-3.1

--- a/tests/formats/test_uri.py
+++ b/tests/formats/test_uri.py
@@ -8,6 +8,8 @@ https://github.com/python-hyper/rfc3986/blob/7fc9af07b14f98c5270908c86a4cfe6715a
 https://github.com/python-hyper/rfc3986/blob/0dc64f8de4327709e34e4a3039df01c46fa94a87/tests/conftest.py
 """
 
+import time
+
 import pytest
 
 from pydantic_jsonschema.formats._uri import (
@@ -241,8 +243,14 @@ class TestInvalidUri:
         With greedy quantifiers in `_URI_RE` this input took ~8.6s (quadratic backtracking);
         possessive quantifiers keep it under a millisecond. See the `_URI_RE` note.
         """
+        started_at = time.perf_counter()
         with pytest.raises(ValueError, match=r"Invalid URI"):
             validate_uri("//" + "a" * 16_000 + "#\nx")
+        elapsed = time.perf_counter() - started_at
+
+        # The possessive regex finishes in ~0.1ms even on slow runners; the quadratic
+        # regression takes ~8.6s on this payload, so 1s separates them by orders of magnitude.
+        assert elapsed < 1.0
 
 
 class TestValidUriReference:

--- a/tests/formats/test_uri.py
+++ b/tests/formats/test_uri.py
@@ -235,6 +235,15 @@ class TestInvalidUri:
         with pytest.raises(ValueError, match=r"Invalid URI"):
             validate_uri("http://host#frag\nmore")
 
+    def test_pathological_backtracking_input(self) -> None:
+        """ReDoS regression: a crafted non-matching value must fail fast, not hang.
+
+        With greedy quantifiers in `_URI_RE` this input took ~8.6s (quadratic backtracking);
+        possessive quantifiers keep it under a millisecond. See the `_URI_RE` note.
+        """
+        with pytest.raises(ValueError, match=r"Invalid URI"):
+            validate_uri("//" + "a" * 16_000 + "#\nx")
+
 
 class TestValidUriReference:
     """Valid URI references per RFC 3986 (scheme optional)."""


### PR DESCRIPTION
# Summary

Fixes a real ReDoS in the URI/IRI format validators found by SonarCloud (rule S8786), plus a cosmetic regex simplification in `_HOSTNAME_RE` (S6397).

## What changed

- `_URI_RE` quantifiers are now possessive (`++`/`*+`): the `scheme`/`authority`/`path`/query character classes overlap, so greedy backtracking on non-matching input was quadratic — a 16k-char crafted value took **~8.6s**; with possessive quantifiers it is **<1ms**. Decomposition is bitwise-identical on valid and edge-case inputs (verified against a sample set including IPv6 literals, empty components, and multiline fragments) because each class excludes the delimiter that follows it.
- Regression test `TestInvalidUri.test_pathological_backtracking_input` with the adversarial payload.
- `_HOSTNAME_RE`: single-char class `[-]` in lookaheads replaced with plain `-` (no behavior change).

## How it was tested

`just lint` and `just test` pass (100% coverage). Timing measured on payload sizes 1k-16k: quadratic growth before (34ms → 8.6s), flat after (<0.2ms).

## Notes

Remaining SonarCloud findings (S3516, S1192, S6353) are false positives for this codebase and will be marked as accepted in the SonarCloud UI instead of code changes.

---

- [x] I followed the [contribution guide](https://danipulok.github.io/pydantic-jsonschema/contributing/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URI validation performance by preventing excessive backtracking on specially crafted invalid inputs.
  * Corrected hostname pattern matching for hostnames beginning with hyphens.
  * Added regression coverage to ensure problematic invalid URIs fail promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->