### PR TITLE
chore(github): tighten issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -44,6 +44,7 @@ body:
       label: Actual Result
       description: |
         Please provide a result of the MRE above.
+        If an exception was raised, include the full traceback as text, not a screenshot.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 Read the Documentation
+    url: 'https://danipulok.github.io/pydantic-jsonschema/'
+    about: Usage guides and API reference — check here before opening an issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
+<!-- Thank you for contributing to Pydantic JSON Schema! 👺 -->
+<!-- For non-trivial changes, please open an issue to discuss them before creating a PR. -->
+
 Closes #<!-- issue number, or remove this line -->
 
-# Summary
+## Summary
 
 <!-- One or two sentences, written for a human: what does this PR do, and why? -->
 
@@ -19,3 +22,6 @@ Closes #<!-- issue number, or remove this line -->
 ---
 
 - [ ] I followed the [contribution guide](https://danipulok.github.io/pydantic-jsonschema/contributing/)
+- [ ] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`) — it becomes the squash commit and the changelog entry
+- [ ] Documentation reflects the changes where applicable
+- [ ] Any AI-generated code has been reviewed line-by-line by the human PR author, who stands by it


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false`, so every new issue must go through the bug/feature forms, plus a contact link to the [documentation](https://danipulok.github.io/pydantic-jsonschema/) for usage questions.
- Ask for the full traceback (as text, not a screenshot) in the bug report `Actual Result` field.
- Tighten the PR template: an issue-first note for non-trivial changes, checkboxes for a Conventional-Commits title (it becomes the squash commit and the changelog entry), docs updates, and line-by-line review of AI-generated code; `# Summary` demoted to `##`.

Follows the `contact_links` and checklist patterns used by `pydantic` and `pydantic-ai`.