### PR TITLE
chore(release): route the changelog through a PR instead of pushing `main`

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,26 +33,29 @@ Before the first public release:
 
 ## Creating a release
 
-1. Generate the changelog for the target version:
+The changelog lands on `main` through a regular PR; the tag is pushed as a separate ref, so
+`main` is never pushed directly. Pass the version without the leading `v` in all commands.
+
+1. Open the release PR:
 
    ```bash
-   just changelog X.Y.Z
+   just release-pr X.Y.Z
    ```
 
-2. Commit the updated changelog:
+   This creates branch `release/X.Y.Z` from up-to-date `main`, generates `docs/changelog.md`,
+   commits it as `chore(version): update to X.Y.Z`, and opens the PR via `gh`.
+
+2. Review and squash-merge the release PR (keep the PR title as the commit message).
+
+3. Tag the merged commit:
 
    ```bash
-   git add docs/changelog.md
-   git commit -m 'docs(changelog): add `X.Y.Z` release section'
-   ```
-
-3. Run the release recipe:
-
-   ```bash
+   git switch main && git pull
    just release X.Y.Z
    ```
 
-   Pass the version without the leading `v`. This validates `docs/changelog.md`, creates tag `vX.Y.Z`, and pushes `main` plus the tag.
+   This verifies you are on `main` matching `origin/main`, validates `docs/changelog.md`,
+   creates tag `vX.Y.Z`, and pushes only the tag.
 
 4. The `release.yml` workflow will automatically:
     - Build sdist and wheel (version derived from git tag via `hatch-vcs`).

--- a/justfile
+++ b/justfile
@@ -302,11 +302,44 @@ build:
 smoke-test version:
     UV_NO_SYNC=false uv run --isolated --no-project --exclude-newer-package "pydantic-jsonschema=2999-12-31" --with "pydantic-jsonschema=={{ version }}" python -c "from pydantic_jsonschema import Schema, to_model; print(to_model(Schema.model_validate({'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}))(x=1).model_dump())"
 
-# Tag a release and push (triggers `release.yml` workflow)
+# Generate the changelog on a `release/X.Y.Z` branch and open the release PR
+release-pr version: (_check-release-version version)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    version="{{version}}"
+    if [[ -n "$(git status --porcelain)" ]]; then
+        printf 'Working tree must be clean before preparing a release PR.\n' >&2
+        exit 2
+    fi
+    git switch main
+    git pull --ff-only
+    git switch -c "release/$version"
+    just changelog "v$version"
+    if [[ -z "$(git status --porcelain docs/changelog.md)" ]]; then
+        printf 'docs/changelog.md is unchanged — nothing to release.\n' >&2
+        exit 2
+    fi
+    git add docs/changelog.md
+    git commit -m "chore(version): update to \`$version\`"
+    git push -u origin "release/$version"
+    gh pr create --title "chore(version): update to \`$version\`" --body "Changelog for \`v$version\`. After merge, run \`just release $version\` to tag and publish."
+
+# Tag the merged release from up-to-date `main` and push only the tag (triggers `release.yml`)
 release version: (_check-release-version version)
     #!/usr/bin/env bash
     set -euo pipefail
     version="{{version}}"
+    # The changelog lands on `main` via the release PR (`just release-pr`); the tag is a
+    # separate ref, so pushing it never pushes `main` itself.
+    if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
+        printf 'Releases are tagged from `main`; current branch is `%s`.\n' "$(git rev-parse --abbrev-ref HEAD)" >&2
+        exit 2
+    fi
+    git fetch origin main
+    if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+        printf 'Local `main` must match `origin/main` — merge the release PR and `git pull` first.\n' >&2
+        exit 2
+    fi
     if ! grep -q "^## \[$version\]" docs/changelog.md; then
         printf 'docs/changelog.md must contain release section `## [%s]`.\n' "$version" >&2
         exit 2
@@ -316,23 +349,7 @@ release version: (_check-release-version version)
         exit 2
     fi
     git tag "v$version"
-    git push origin main "v$version"
-
-# Generate changelog, commit it, and run `just release`
-release-auto version: (_check-release-version version)
-    #!/usr/bin/env bash
-    set -euo pipefail
-    version="{{version}}"
-    if [[ -n "$(git status --porcelain)" ]]; then
-        printf 'Working tree must be clean before release.\n' >&2
-        exit 2
-    fi
-    just changelog "v$version"
-    if [[ -n "$(git status --porcelain docs/changelog.md)" ]]; then
-        git add docs/changelog.md
-        git commit -m "chore(version): update to \`$version\`"
-    fi
-    just release "$version"
+    git push origin "v$version"
 
 # Validate release version format
 _check-release-version version:


### PR DESCRIPTION
## Summary

Release flow no longer pushes `main` directly. The changelog now lands through a regular PR, and the tag is pushed as a separate ref.

## What changed

- `just release-pr X.Y.Z` (replaces `release-auto`): branches `release/X.Y.Z` off up-to-date `main`, generates `docs/changelog.md`, commits, and opens the release PR via `gh`.
- `just release X.Y.Z` now refuses to run unless on `main` matching `origin/main`, and pushes **only** the tag `vX.Y.Z` (previously `git push origin main vX.Y.Z`).
- `RELEASING.md` "Creating a release" rewritten for the two-step flow: release PR → squash-merge → tag.

Same shape as `pydantic`'s "Prepare release" PRs, minus version files — `hatch-vcs` still derives the version from the tag.

## How it was tested

`just --list` parses; `just release 0.0.14` from a non-`main` branch correctly fails with exit 2 before tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release instructions to use a pull request workflow for changelog updates.
  * Clarified version formatting and branch protection requirements.

* **Chores**
  * Added automation to prepare release pull requests.
  * Updated release automation to verify the main branch and publish tags only.
  * Removed the previous automated release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->