### PR TITLE
feat(rules): configurable loading `rules` matched by type and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ schema = Schema.model_validate({
     "required": ["tags"],
 })
 
-User = to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+User = to_model(
+    schema,
+    rules=[
+        Rule(ByType(list[str]), Before(csv_to_list)),
+    ],
+)
 
 print(User(tags="a,b,c").tags)
 #> ['a', 'b', 'c']

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ print(user.model_dump())
 
 ## What's inside
 
-Three building blocks — and a fourth on the way.
+Four building blocks.
 
 ### 1. The schema model — `Schema` & `Reference`
 
@@ -102,10 +102,10 @@ print(User(email="alice@example.com").email)
 
 ### 4. Rules
 
-Per-node input coercion and output serialization, matched by type or path — inspired by
-[adaptix](https://github.com/reagento/adaptix). A `Rule` pairs a matcher (`ByType`, `ByPath`,
-`ByFunc`) with one action (`Before`, `After`, `Override`, `Dump`), so a field declared as
-array-of-string can accept a comma-separated string.
+Per-node input coercion and output serialization, matched by type, by JSON Pointer path, or by an
+arbitrary predicate — inspired by [adaptix](https://github.com/reagento/adaptix). A `Rule` pairs a
+matcher (`ByType`, `ByPath`, `ByFunc`) with one action (`Before`, `After`, `Override`, `Dump`), so
+a field declared as array-of-string can accept a comma-separated string, and dump back as one.
 
 ```python
 from pydantic_jsonschema import Schema, to_model

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Per-node input coercion and output serialization, matched by type or path — in
 array-of-string can accept a comma-separated string.
 
 ```python
-from pydantic_jsonschema import Before, ByType, Rule, Schema, to_model
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.rules import Before, ByType, Rule
 
 
 def csv_to_list(value: str | list[str]) -> list[str]:

--- a/README.md
+++ b/README.md
@@ -100,10 +100,32 @@ print(User(email="alice@example.com").email)
 #> alice@example.com
 ```
 
-### Planned: configurable loading by type
+### 4. Rules
 
-Per-object control over how each type is loaded, inspired by
-[adaptix](https://github.com/reagento/adaptix).
+Per-node input coercion and output serialization, matched by type or path — inspired by
+[adaptix](https://github.com/reagento/adaptix). A `Rule` pairs a matcher (`ByType`, `ByPath`,
+`ByFunc`) with one action (`Before`, `After`, `Override`, `Dump`), so a field declared as
+array-of-string can accept a comma-separated string.
+
+```python
+from pydantic_jsonschema import Before, ByType, Rule, Schema, to_model
+
+
+def csv_to_list(value: str | list[str]) -> list[str]:
+    return value.split(",") if isinstance(value, str) else value
+
+
+schema = Schema.model_validate({
+    "type": "object",
+    "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+    "required": ["tags"],
+})
+
+User = to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+
+print(User(tags="a,b,c").tags)
+#> ['a', 'b', 'c']
+```
 
 ## Documentation
 

--- a/docs/api/rules.md
+++ b/docs/api/rules.md
@@ -1,0 +1,5 @@
+# Rules
+
+For usage and examples, see the [Rules guide](../rules.md).
+
+::: pydantic_jsonschema.rules

--- a/docs/converters.md
+++ b/docs/converters.md
@@ -633,6 +633,7 @@ converter = SchemaConverter(
     default_model_name="MyModel",
     refs={},
     formats={},
+    rules=[],
 )
 schema = Schema.model_validate({})
 
@@ -651,11 +652,13 @@ print(Model.__name__)
 |-------------------------------------------|--------------------------------------|--------------------------------------------------------------|
 | One generated model                       | `to_model(schema, model_name="...")` | Shortest path and clear class name                           |
 | Existing model for a `$ref`               | `refs={"#/$defs/Name": Model}`       | Keeps generated models connected to your own classes         |
-| Repeated conversions with shared settings | `SchemaConverter(...)`               | Reuses `refs`, `formats`, and `default_model_name`           |
+| Repeated conversions with shared settings | `SchemaConverter(...)`               | Reuses `refs`, `formats`, `rules`, and `default_model_name`  |
 | Clear validation errors                   | `model_name` or schema `title`       | Avoids generic `Model` in error output                       |
 | Custom `format` handling                  | `formats`                            | Adds validation for strings or domain-specific values        |
+| Input in a shape the schema omits         | `rules`                              | Coerces or serializes a node without hand-writing the model  |
 
 ## Next Steps
 
 - [Formats](formats.md) - Add custom validation for special formats
+- [Rules](rules.md) - Coerce input and reshape output per node
 - [Examples](examples.md) - See real-world applications

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,6 +12,7 @@ Real-world examples showing how to use Pydantic JSON Schema in practice.
 |---------------------------------|-----------------------------------------------------------|-----------------------------------------------|
 | `examples/nested_schemas.py`    | Nested objects, arrays, `$defs`, and `$ref` reuse         | `uv run python examples/nested_schemas.py`    |
 | `examples/custom_formats.py`    | Custom `formats`, normalization, and validation           | `uv run python examples/custom_formats.py`    |
+| `examples/loading_rules.py`     | `rules` for per-node input coercion and output dumping    | `uv run python examples/loading_rules.py`     |
 
 ## Complex Nested Schemas
 
@@ -70,8 +71,39 @@ WDG-1234-PRO
 --8<-- "examples/custom_formats.py"
 ```
 
+## Loading Rules
+
+Use this example when the input arrives in a shape the schema does not describe — a packed cell,
+a value that needs normalizing — or when the output has to go back in that shape.
+
+It demonstrates:
+
+- Coercing raw input with `Before` before the schema type is parsed.
+- Normalizing a single node picked by its JSON Pointer with `ByPath`.
+- Matching every node of one Python type with `ByType`.
+- Pairing a load rule with a `Dump` rule for a round-trip.
+
+Run it with:
+
+```bash
+uv run python examples/loading_rules.py
+```
+
+Expected output:
+
+```text
+WDG-1234-PRO
+['sale', 'clearance']
+{'sku': 'WDG-1234-PRO', 'tags': 'sale,clearance'}
+```
+
+```python
+--8<-- "examples/loading_rules.py"
+```
+
 ## Next Steps
 
 - [Converters](converters.md) - Learn about creating models
 - [Formats](formats.md) - Add custom validation
+- [Rules](rules.md) - Customize loading and dumping per node
 - [Contributing](contributing.md) - Help improve the library

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -7,6 +7,9 @@ matching entry in `formats`.
 Without a matching validator, `format` is treated as metadata and the normal JSON Schema type still
 applies.
 
+An entry applies wherever its `format` appears — on a property, on an array element (`items`), or
+on a typed map value (`additionalProperties`).
+
 ## Third-Party Validator Libraries
 
 All built-in formats work with zero extra dependencies.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -71,12 +71,49 @@ Every node the converter walks has a pointer, not just top-level properties:
 
 | Node                            | Pointer                                  |
 |---------------------------------|------------------------------------------|
-| root value                      | `/`                                      |
+| root value of a non-object root | `/`                                      |
 | property `code`                 | `#/properties/code`                      |
 | element of an array property    | `#/properties/tags/items`                |
 | value of a typed map            | `#/properties/meta/additionalProperties` |
 | second `anyOf` branch           | `#/properties/value/anyOf/1`             |
 | property inside a `$defs` entry | `#/$defs/User/properties/name`           |
+
+`/` addresses the root only when the root is not an object. A scalar or array root becomes the
+value of a `RootModel`, and that value has an annotation to wrap. An object root becomes the model
+class itself, and a class carries no annotation — a rule at `/` has nothing to attach to there and
+never fires. Target its properties instead.
+
+```python title="rules_root_pointer.py"
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.rules import After, ByPath, Rule
+
+
+def strip_upper(value: str) -> str:
+    return value.strip().upper()
+
+
+root_rule = Rule(ByPath("/"), After(strip_upper))
+
+Code = to_model(Schema.model_validate({"type": "string"}), rules=[root_rule])
+
+print(Code("  ab-1  ").root)
+#> AB-1
+
+Product = to_model(
+    Schema.model_validate(
+        {
+            "type": "object",
+            "properties": {"code": {"type": "string"}},
+            "required": ["code"],
+        }
+    ),
+    rules=[root_rule],
+)
+
+# The object root is a class, not an annotation, so the rule never fires.
+print(repr(Product(code="  ab-1  ").code))
+#> '  ab-1  '
+```
 
 A definition is addressed where it is *declared* (`#/$defs/User/...`), not through the `$ref`s that
 point at it, so one rule covers every use of that definition. Property names keep their literal

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,170 @@
+# Rules
+
+Rules attach custom loading behavior to the model `to_model` generates, matched **by type or by
+path** — without hand-writing the model. Each rule has three parts, one object each:
+
+1. **when** — a matcher (`ByType`, `ByPath`, `ByFunc`);
+2. **what** — a callable, held by the action;
+3. **how** — the action kind (`Before`, `After`, `Override`, `Dump`).
+
+One rule performs exactly one action. A load-and-dump round-trip is two rules sharing a matcher.
+
+## Basic Usage
+
+A field declared as array-of-string can accept a comma-separated string by coercing the raw input
+with a `Before` action, matched on the field's Python type with `ByType`.
+
+```python title="rules_basic.py"
+from pydantic_jsonschema import Before, ByType, Rule, Schema, to_model
+
+
+def csv_to_list(value: str | list[str]) -> list[str]:
+    return value.split(",") if isinstance(value, str) else value
+
+
+schema = Schema.model_validate(
+    {
+        "type": "object",
+        "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+        "required": ["tags"],
+    }
+)
+
+User = to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+
+print(User(tags="a,b,c").tags)
+#> ['a', 'b', 'c']
+print(User(tags=["x", "y"]).tags)
+#> ['x', 'y']
+```
+
+## Actions
+
+Each action maps to exactly one Pydantic wrapper, so a rule holding one action does exactly one
+thing.
+
+| Action           | Pydantic wrapper  | When it runs                          |
+|------------------|-------------------|---------------------------------------|
+| `Before(func)`   | `BeforeValidator` | before core parsing, on the raw input |
+| `After(func)`    | `AfterValidator`  | after core parsing, on the value      |
+| `Override(func)` | `PlainValidator`  | replaces core parsing entirely        |
+| `Dump(func)`     | `PlainSerializer` | on serialization (model → output)     |
+
+## Matchers
+
+### `ByType`
+
+Matches when the resolved annotation equals the given type. Parameterized generics match exactly
+(`list[str]`, not `list[int]`).
+
+### `ByPath`
+
+Matches a single node by its JSON Pointer. Accepts `#/properties/code`, `/properties/code`, or
+`properties/code` — all normalize identically.
+
+```python title="rules_by_path.py"
+from pydantic_jsonschema import After, ByPath, Rule, Schema, to_model
+
+
+def strip_upper(value: str) -> str:
+    return value.strip().upper()
+
+
+schema = Schema.model_validate(
+    {
+        "type": "object",
+        "properties": {"code": {"type": "string"}},
+        "required": ["code"],
+    }
+)
+
+Product = to_model(schema, rules=[Rule(ByPath("#/properties/code"), After(strip_upper))])
+
+print(Product(code="  ab-1  ").code)
+#> AB-1
+```
+
+### `ByFunc`
+
+An escape hatch: match on any predicate over the node's `MatchContext` (its `schema`,
+`annotation`, and `path`).
+
+```python title="rules_by_func.py"
+from pydantic_jsonschema import After, ByFunc, MatchContext, Rule, Schema, to_model
+
+
+def is_string(context: MatchContext) -> bool:
+    return context.annotation is str
+
+
+def strip_upper(value: str) -> str:
+    return value.strip().upper()
+
+
+schema = Schema.model_validate(
+    {
+        "type": "object",
+        "properties": {"code": {"type": "string"}},
+        "required": ["code"],
+    }
+)
+
+Product = to_model(schema, rules=[Rule(ByFunc(is_string), After(strip_upper))])
+
+print(Product(code=" ab ").code)
+#> AB
+```
+
+## Load and Dump Round-Trip
+
+`Before` and `Dump` are separate actions, so a round-trip is two rules that share a matcher —
+matcher duplication is intentional.
+
+```python title="rules_round_trip.py"
+from pydantic_jsonschema import Before, ByType, Dump, Rule, Schema, to_model
+
+
+def csv_to_list(value: str | list[str]) -> list[str]:
+    return value.split(",") if isinstance(value, str) else value
+
+
+schema = Schema.model_validate(
+    {
+        "type": "object",
+        "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+        "required": ["tags"],
+    }
+)
+
+User = to_model(
+    schema,
+    rules=[
+        Rule(ByType(list[str]), Before(csv_to_list)),
+        Rule(ByType(list[str]), Dump(",".join)),
+    ],
+)
+
+user = User(tags="a,b,c")
+print(user.tags)
+#> ['a', 'b', 'c']
+print(user.model_dump())
+#> {'tags': 'a,b,c'}
+```
+
+## Rules Are Data
+
+Matchers, actions, and `Rule` are frozen dataclasses, so they compare, hash, and `repr` as plain
+data — convenient for building rule sets programmatically and asserting on them in tests. The only
+non-data field is the held callable (and `ByFunc`'s predicate).
+
+## Rules vs. Formats
+
+Use [`formats`](formats.md) when a schema declares a `format` keyword and you want a type to
+enforce it. Use `rules` when you want to match by Python type or path and control loading with a
+chosen Pydantic slot. The two compose: format substitution runs first, then rules wrap the result.
+
+## Next Steps
+
+- [Formats](formats.md) - Enforce JSON Schema `format` keywords
+- [Converters](converters.md) - Learn how schema conversion works
+- [Examples](examples.md) - Run complete examples

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -83,19 +83,24 @@ neither equal to `str` nor a parameterization of it — so a bare `ByType(str)` 
 
 ### `ByPath`
 
-Matches a single node by its [JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901). Accepts
-`#/properties/code`, `/properties/code`, or `properties/code` — all normalize identically.
+Matches a single node by its [JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901). The pointer
+starts with `/` and carries no `#` prefix, which is exactly how `MatchContext.path` reports it — so
+a `ByPath` rule and a `ByFunc` predicate comparing `context.path` always agree on the same string.
+
+There is only this one accepted spelling. A `$ref` in the schema looks like `#/$defs/User`, and
+pasting that fragment form into `ByPath` raises `ValueError` naming the pointer to use instead,
+rather than silently producing a rule that matches nothing.
 
 Every node the converter walks has a pointer, not just top-level properties:
 
-| Node                            | Pointer                                  |
-|---------------------------------|------------------------------------------|
-| root value of a non-object root | `/`                                      |
-| property `code`                 | `#/properties/code`                      |
-| element of an array property    | `#/properties/tags/items`                |
-| value of a typed map            | `#/properties/meta/additionalProperties` |
-| second `anyOf` branch           | `#/properties/value/anyOf/1`             |
-| property inside a `$defs` entry | `#/$defs/User/properties/name`           |
+| Node                            | Pointer                                 |
+|---------------------------------|-----------------------------------------|
+| root value of a non-object root | `/`                                     |
+| property `code`                 | `/properties/code`                      |
+| element of an array property    | `/properties/tags/items`                |
+| value of a typed map            | `/properties/meta/additionalProperties` |
+| second `anyOf` branch           | `/properties/value/anyOf/1`             |
+| property inside a `$defs` entry | `/$defs/User/properties/name`           |
 
 `/` addresses the root only when the root is not an object. A scalar or array root becomes the
 value of a `RootModel`, and that value has an annotation to wrap. An object root becomes the model
@@ -137,10 +142,10 @@ print(repr(Product(code="  ab-1  ").code))
 #> '  ab-1  '
 ```
 
-A definition is addressed where it is *declared* (`#/$defs/User/...`), not through the `$ref`s that
+A definition is addressed where it is *declared* (`/$defs/User/...`), not through the `$ref`s that
 point at it, so one rule covers every use of that definition. Property names keep their literal
 characters and are escaped per RFC 6901 — `~` becomes `~0` and `/` becomes `~1`, so a property
-named `a/b` is `#/properties/a~1b`.
+named `a/b` is `/properties/a~1b`.
 
 ```python title="rules_by_path.py"
 from pydantic_jsonschema import Schema, to_model
@@ -162,7 +167,7 @@ schema = Schema.model_validate(
 Product = to_model(
     schema,
     rules=[
-        Rule(ByPath("#/properties/code"), After(strip_upper)),
+        Rule(ByPath("/properties/code"), After(strip_upper)),
     ],
 )
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,13 +1,17 @@
 # Rules
 
-Rules attach custom loading behavior to the model `to_model` generates, matched **by type or by
-path** — without hand-writing the model. Each rule has three parts, one object each:
+Rules attach custom loading and dumping behavior to the model `to_model` generates — matched **by
+type, by path, or by an arbitrary predicate** — without hand-writing the model. Each rule has three
+parts, one object each:
 
 1. **when** — a matcher (`ByType`, `ByPath`, `ByFunc`);
 2. **what** — a callable, held by the action;
 3. **how** — the action kind (`Before`, `After`, `Override`, `Dump`).
 
 One rule performs exactly one action. A load-and-dump round-trip is two rules sharing a matcher.
+
+Pass rules to `to_model(schema, rules=[...])`, or to `SchemaConverter(rules=[...])` when you drive
+conversion yourself — the two take the same list.
 
 ## Basic Usage
 
@@ -60,8 +64,24 @@ Matches when the resolved annotation equals the given type. Parameterized generi
 
 ### `ByPath`
 
-Matches a single node by its JSON Pointer. Accepts `#/properties/code`, `/properties/code`, or
-`properties/code` — all normalize identically.
+Matches a single node by its [JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901). Accepts
+`#/properties/code`, `/properties/code`, or `properties/code` — all normalize identically.
+
+Every node the converter walks has a pointer, not just top-level properties:
+
+| Node                            | Pointer                                  |
+|---------------------------------|------------------------------------------|
+| root value                      | `/`                                      |
+| property `code`                 | `#/properties/code`                      |
+| element of an array property    | `#/properties/tags/items`                |
+| value of a typed map            | `#/properties/meta/additionalProperties` |
+| second `anyOf` branch           | `#/properties/value/anyOf/1`             |
+| property inside a `$defs` entry | `#/$defs/User/properties/name`           |
+
+A definition is addressed where it is *declared* (`#/$defs/User/...`), not through the `$ref`s that
+point at it, so one rule covers every use of that definition. Property names keep their literal
+characters and are escaped per RFC 6901 — `~` becomes `~0` and `/` becomes `~1`, so a property
+named `a/b` is `#/properties/a~1b`.
 
 ```python title="rules_by_path.py"
 from pydantic_jsonschema import Schema, to_model

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -15,7 +15,8 @@ A field declared as array-of-string can accept a comma-separated string by coerc
 with a `Before` action, matched on the field's Python type with `ByType`.
 
 ```python title="rules_basic.py"
-from pydantic_jsonschema import Before, ByType, Rule, Schema, to_model
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.rules import Before, ByType, Rule
 
 
 def csv_to_list(value: str | list[str]) -> list[str]:
@@ -63,7 +64,8 @@ Matches a single node by its JSON Pointer. Accepts `#/properties/code`, `/proper
 `properties/code` — all normalize identically.
 
 ```python title="rules_by_path.py"
-from pydantic_jsonschema import After, ByPath, Rule, Schema, to_model
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.rules import After, ByPath, Rule
 
 
 def strip_upper(value: str) -> str:
@@ -90,7 +92,8 @@ An escape hatch: match on any predicate over the node's `MatchContext` (its `sch
 `annotation`, and `path`).
 
 ```python title="rules_by_func.py"
-from pydantic_jsonschema import After, ByFunc, MatchContext, Rule, Schema, to_model
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.rules import After, ByFunc, MatchContext, Rule
 
 
 def is_string(context: MatchContext) -> bool:
@@ -121,7 +124,8 @@ print(Product(code=" ab ").code)
 matcher duplication is intentional.
 
 ```python title="rules_round_trip.py"
-from pydantic_jsonschema import Before, ByType, Dump, Rule, Schema, to_model
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.rules import Before, ByType, Dump, Rule
 
 
 def csv_to_list(value: str | list[str]) -> list[str]:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -64,8 +64,22 @@ thing.
 
 ### `ByType`
 
-Matches when the resolved annotation equals the given type. Parameterized generics match exactly
-(`list[str]`, not `list[int]`).
+Matches on the resolved annotation. A parameterized generic matches exactly — `list[str]` does not
+match `list[int]`.
+
+An **unparameterized** generic matches every parameterization of itself, because the converter never
+produces a bare one: an array becomes `list[str]` (or `list[Any]` without `items`), a typed map
+becomes `dict[str, T]`. Comparing a bare `list` by equality would therefore match nothing at all.
+
+| Target      | Matches                                  |
+|-------------|------------------------------------------|
+| `list`      | `list[str]`, `list[int]`, `list[Any]`, … |
+| `list[str]` | `list[str]`                              |
+| `list[Any]` | `list[Any]` — an array without `items`   |
+| `dict`      | `dict[str, str]`, `dict[str, Any]`, …    |
+
+A node whose annotation a [`formats`](formats.md) entry replaced is `Annotated[str, ...]`, which is
+neither equal to `str` nor a parameterization of it — so a bare `ByType(str)` does not match it.
 
 ### `ByPath`
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -78,8 +78,51 @@ becomes `dict[str, T]`. Comparing a bare `list` by equality would therefore matc
 | `list[Any]` | `list[Any]` — an array without `items`   |
 | `dict`      | `dict[str, str]`, `dict[str, Any]`, …    |
 
-A node whose annotation a [`formats`](formats.md) entry replaced is `Annotated[str, ...]`, which is
-neither equal to `str` nor a parameterization of it — so a bare `ByType(str)` does not match it.
+A PEP 695 alias resolves to whatever it names, so `type Tags = list[str]` and `ByType(Tags)` are
+interchangeable with `ByType(list[str])`.
+
+A node whose annotation a [`formats`](formats.md) entry replaced carries the format type, so target
+it with that same type. `ByType(Email)` reaches the email fields; a bare `ByType(str)` reaches only
+the strings no format touched, because `Annotated[str, ...]` is neither equal to `str` nor a
+parameterization of it.
+
+The format's own validation runs first, so the rule sees a value the format already accepted.
+
+```python title="rules_by_type_format.py"
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.formats import Email
+from pydantic_jsonschema.rules import After, ByType, Rule
+
+
+def to_lower(value: str) -> str:
+    return value.lower()
+
+
+schema = Schema.model_validate(
+    {
+        "type": "object",
+        "properties": {
+            "contact": {"type": "string", "format": "email"},
+            "note": {"type": "string"},
+        },
+        "required": ["contact", "note"],
+    }
+)
+
+User = to_model(
+    schema,
+    formats={"email": Email},
+    rules=[
+        Rule(ByType(Email), After(to_lower)),
+    ],
+)
+
+user = User(contact="User@Example.COM", note="Kept")
+print(user.contact)
+#> user@example.com
+print(user.note)
+#> Kept
+```
 
 ### `ByPath`
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -35,7 +35,12 @@ schema = Schema.model_validate(
     }
 )
 
-User = to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+User = to_model(
+    schema,
+    rules=[
+        Rule(ByType(list[str]), Before(csv_to_list)),
+    ],
+)
 
 print(User(tags="a,b,c").tags)
 #> ['a', 'b', 'c']
@@ -94,7 +99,10 @@ def strip_upper(value: str) -> str:
 
 root_rule = Rule(ByPath("/"), After(strip_upper))
 
-Code = to_model(Schema.model_validate({"type": "string"}), rules=[root_rule])
+Code = to_model(
+    Schema.model_validate({"type": "string"}),
+    rules=[root_rule],
+)
 
 print(Code("  ab-1  ").root)
 #> AB-1
@@ -137,7 +145,12 @@ schema = Schema.model_validate(
     }
 )
 
-Product = to_model(schema, rules=[Rule(ByPath("#/properties/code"), After(strip_upper))])
+Product = to_model(
+    schema,
+    rules=[
+        Rule(ByPath("#/properties/code"), After(strip_upper)),
+    ],
+)
 
 print(Product(code="  ab-1  ").code)
 #> AB-1
@@ -169,7 +182,12 @@ schema = Schema.model_validate(
     }
 )
 
-Product = to_model(schema, rules=[Rule(ByFunc(is_string), After(strip_upper))])
+Product = to_model(
+    schema,
+    rules=[
+        Rule(ByFunc(is_string), After(strip_upper)),
+    ],
+)
 
 print(Product(code=" ab ").code)
 #> AB

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,12 +6,14 @@ All examples are complete and can be run as-is:
 
 ```bash
 uv run python examples/custom_formats.py
+uv run python examples/loading_rules.py
 uv run python examples/nested_schemas.py
 ```
 
 ## Examples
 
 - **[custom_formats.py](custom_formats.py)** - Add domain-specific validation
+- **[loading_rules.py](loading_rules.py)** - Coerce input and reshape output per node
 - **[nested_schemas.py](nested_schemas.py)** - Handle complex schemas with references
 
 See the [documentation](../docs/examples.md) for detailed explanations and more examples.

--- a/examples/loading_rules.py
+++ b/examples/loading_rules.py
@@ -1,0 +1,60 @@
+"""Attach per-node loading and dumping behavior with `rules`."""
+
+from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.rules import After, Before, ByPath, ByType, Dump, Rule
+
+
+def csv_to_list(value: str | list[str]) -> list[str]:
+    """Accept a comma-separated string wherever a list of strings is expected."""
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+
+    return value
+
+
+def normalize_sku(value: str) -> str:
+    """Normalize a product code to its canonical upper-case form."""
+    return value.strip().upper()
+
+
+# A feed exported from a spreadsheet: every column arrives as a string, and `tags`
+# packs several values into one cell.
+order_schema = Schema.model_validate(
+    {
+        "type": "object",
+        "properties": {
+            "sku": {"type": "string"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["sku", "tags"],
+    },
+)
+
+# A rule is a matcher plus one action. `ByType` covers every node of that Python type,
+# `ByPath` targets a single node by its JSON Pointer, and a load-and-dump round-trip is
+# two rules sharing a matcher.
+Order = to_model(
+    order_schema,
+    rules=[
+        Rule(ByType(list[str]), Before(csv_to_list)),
+        Rule(ByPath("#/properties/sku"), After(normalize_sku)),
+        Rule(ByType(list[str]), Dump(",".join)),
+    ],
+)
+
+order = Order(
+    sku="  wdg-1234-pro  ",  # Trimmed and upper-cased by the `ByPath` rule.
+    tags="sale, clearance",  # Split into a list by the `ByType` rule.
+)
+
+# NOTE: `ruff format` rewrites `#>` to `# >`, breaking `pytest-examples` output markers.
+# fmt: off
+print(order.sku)  # type: ignore[attr-defined]
+#> WDG-1234-PRO
+print(order.tags)  # type: ignore[attr-defined]
+#> ['sale', 'clearance']
+
+# The `Dump` rule packs the list back into the shape the feed uses.
+print(order.model_dump())
+#> {'sku': 'WDG-1234-PRO', 'tags': 'sale,clearance'}
+# fmt: on

--- a/examples/loading_rules.py
+++ b/examples/loading_rules.py
@@ -37,7 +37,7 @@ Order = to_model(
     order_schema,
     rules=[
         Rule(ByType(list[str]), Before(csv_to_list)),
-        Rule(ByPath("#/properties/sku"), After(normalize_sku)),
+        Rule(ByPath("/properties/sku"), After(normalize_sku)),
         Rule(ByType(list[str]), Dump(",".join)),
     ],
 )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,12 +78,14 @@ nav:
   - Converters: converters.md
   - Applicators: applicators.md
   - Formats: formats.md
+  - Rules: rules.md
   - Examples: examples.md
   - API Reference:
     - Schema model: api/schema.md
     - Converters: api/converters.md
     - Applicators: api/applicators.md
     - Formats: api/formats.md
+    - Rules: api/rules.md
     - Exceptions: api/exceptions.md
   - Development:
     - Contributing: contributing.md
@@ -149,6 +151,7 @@ plugins:
           - schema.md
           - converters.md
           - formats.md
+          - rules.md
           - examples.md
         API reference:
           - api/*.md

--- a/pydantic_jsonschema/__init__.py
+++ b/pydantic_jsonschema/__init__.py
@@ -9,33 +9,15 @@ from pydantic_jsonschema.exceptions import (
     SchemaConversionError,
     SchemaReferenceError,
 )
-from pydantic_jsonschema.rules import (
-    After,
-    Before,
-    ByFunc,
-    ByPath,
-    ByType,
-    Dump,
-    MatchContext,
-    Override,
-    Rule,
-)
 from pydantic_jsonschema.schema import DataType, Reference, Schema
 
+# NOTE: The rules API (`Rule`, matchers, actions) is intentionally not re-exported here — it lives
+# only under `pydantic_jsonschema.rules` to keep the package root focused on the core surface.
 __all__ = [
-    "After",
     "BasePydanticJsonSchemaError",
-    "Before",
-    "ByFunc",
-    "ByPath",
-    "ByType",
     "DataType",
-    "Dump",
     "FormatValidationError",
-    "MatchContext",
-    "Override",
     "Reference",
-    "Rule",
     "Schema",
     "SchemaConversionError",
     "SchemaConverter",

--- a/pydantic_jsonschema/__init__.py
+++ b/pydantic_jsonschema/__init__.py
@@ -9,13 +9,33 @@ from pydantic_jsonschema.exceptions import (
     SchemaConversionError,
     SchemaReferenceError,
 )
+from pydantic_jsonschema.rules import (
+    After,
+    Before,
+    ByFunc,
+    ByPath,
+    ByType,
+    Dump,
+    MatchContext,
+    Override,
+    Rule,
+)
 from pydantic_jsonschema.schema import DataType, Reference, Schema
 
 __all__ = [
+    "After",
     "BasePydanticJsonSchemaError",
+    "Before",
+    "ByFunc",
+    "ByPath",
+    "ByType",
     "DataType",
+    "Dump",
     "FormatValidationError",
+    "MatchContext",
+    "Override",
     "Reference",
+    "Rule",
     "Schema",
     "SchemaConversionError",
     "SchemaConverter",

--- a/pydantic_jsonschema/_utils.py
+++ b/pydantic_jsonschema/_utils.py
@@ -1,10 +1,15 @@
-"""Internal utilities for identifier sanitization."""
+"""Internal utilities shared across the package."""
 
 import re
+from typing import Any, TypeAliasType
 
 __all__ = [
     "sanitize_identifier",
+    "unwrap_type_alias",
 ]
+
+# Any annotation Pydantic supports (`type`, `Annotated`, `Union`, `Literal`, ...).
+type AnnotationType = Any
 
 _LEADING_NON_ALPHA: re.Pattern[str] = re.compile(r"^[^a-zA-Z_]+")
 _INVALID_CHARS: re.Pattern[str] = re.compile(r"[^a-zA-Z0-9_]")
@@ -18,3 +23,25 @@ def sanitize_identifier(name: str) -> str:
     """
     name = _LEADING_NON_ALPHA.sub("", name)
     return _INVALID_CHARS.sub("", name)
+
+
+def unwrap_type_alias(annotation: AnnotationType, /) -> AnnotationType:
+    """Resolve a PEP 695 `type` alias down to the annotation it names.
+
+    A `TypeAliasType` compares by identity, never by what it aliases, so it is unusable in any
+    equality check against a real annotation:
+
+        type DateTime = datetime.datetime
+        DateTime == datetime.datetime
+        #> False
+
+    The loop covers an alias of an alias (`type Timestamp = DateTime`), which one unwrap step
+    would leave as another `TypeAliasType`.
+
+    :param annotation: Annotation that may be a PEP 695 alias.
+    :returns: The aliased annotation, or `annotation` unchanged when it is not an alias.
+    """
+    while isinstance(annotation, TypeAliasType):
+        annotation = annotation.__value__
+
+    return annotation

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -49,6 +49,7 @@ from pydantic_jsonschema.applicators import (
     PropertyNames,
 )
 from pydantic_jsonschema.exceptions import SchemaConversionError, SchemaReferenceError
+from pydantic_jsonschema.rules import MatchContext, Rule
 from pydantic_jsonschema.schema import DataType, Reference, Schema
 
 from ._discriminator import discriminator_property
@@ -102,17 +103,21 @@ class SchemaConverter:
         default_model_name: str = _DEFAULT_MODEL_NAME,
         refs: dict[Ref, type[BaseModel]] | None = None,
         formats: dict[FormatName, FormatType] | None = None,
+        rules: list[Rule] | None = None,
     ) -> None:
-        """Initialize converter with optional pre-built refs and format types.
+        """Initialize converter with optional pre-built refs, format types, and loading rules.
 
         :param default_model_name: Fallback name for models without `title` (default: `Model`).
         :param refs: Pre-built Pydantic models for `$ref` resolution.
         :param formats: Format types (a `type` or `Annotated` type) keyed by JSON Schema
             `format` value.
+        :param rules: Loading rules matched by type / path, wrapping the field annotation with
+            per-node input coercion or output serialization.
         """
         self._default_model_name: str = default_model_name
         self._refs: dict[Ref, type[BaseModel]] = refs or {}
         self._formats: dict[FormatName, FormatType] = formats or {}
+        self._rules: list[Rule] = rules or []
 
         self._defs_cache: dict[Ref, Schema] = {}
         self._models_cache: dict[SchemaHash, type[BaseModel]] = {}
@@ -735,6 +740,49 @@ class SchemaConverter:
         )
         raise SchemaConversionError(msg)
 
+    def _current_pointer(self) -> str:
+        """Build the current node's canonical JSON Pointer from the resolution path.
+
+        Segments are dotted (`properties.created`) or bracketed (`anyOf[0]`); splitting each on
+        `.` yields the pointer components. The root schema (empty path) is `/`.
+
+        :returns: Canonical pointer like `/properties/created`, or `/` at the root.
+        """
+        parts: list[str] = [
+            component for segment in self._resolution_path for component in segment.split(".")
+        ]
+        return "/" + "/".join(parts) if parts else "/"
+
+    def _apply_rules(
+        self,
+        annotation: AnnotationType,
+        schema: Schema,
+        /,
+    ) -> AnnotationType:
+        """Wrap the annotation with every matching rule's Pydantic metadata.
+
+        Each matcher is tested against the core `annotation` (the same value for all rules), and
+        matching actions are layered as nested `Annotated` metadata in rule order — Pydantic
+        flattens `Annotated[Annotated[T, a], b]` to `Annotated[T, a, b]`.
+
+        :param annotation: The node's core annotation (after format substitution).
+        :param schema: The node's schema.
+        :returns: The annotation, wrapped when any rule matches, else unchanged.
+        """
+        if not self._rules:
+            return annotation
+
+        context = MatchContext(
+            schema=schema,
+            annotation=annotation,
+            path=self._current_pointer(),
+        )
+        result: AnnotationType = annotation
+        for rule in self._rules:
+            if rule.matcher.matches(context):
+                result = Annotated[result, rule.action.metadata()]
+        return result
+
     @staticmethod
     def _build_model_config(
         schema: Schema,
@@ -771,6 +819,7 @@ class SchemaConverter:
             valid_annotation = annotation
 
         valid_annotation = self._apply_format(valid_annotation, schema)
+        valid_annotation = self._apply_rules(valid_annotation, schema)
 
         default = get_field_default(schema, field_kind=field_kind)
 
@@ -916,6 +965,7 @@ class SchemaConverter:
             return annotation
 
         annotation = self._apply_format(annotation, schema)
+        annotation = self._apply_rules(annotation, schema)
         kwargs = build_field_kwargs(schema, include_metadata=not union_branch)
 
         if kwargs and not (union_branch and annotation is Any):
@@ -1230,6 +1280,7 @@ def to_model(
     model_name: str | None = None,
     refs: dict[Ref, type[BaseModel]] | None = None,
     formats: dict[FormatName, FormatType] | None = None,
+    rules: list[Rule] | None = None,
 ) -> type[BaseModel]:
     """Convert schema to Pydantic model.
 
@@ -1237,11 +1288,14 @@ def to_model(
     :param refs: Pre-built reference models.
     :param formats: Format types (a `type` or `Annotated` type) keyed by JSON Schema
         `format` value.
+    :param rules: Loading rules matched by type / path, wrapping the field annotation with
+        per-node input coercion or output serialization.
     :param model_name: Name for the generated model.
     :returns: Pydantic model class.
     """
     converter = SchemaConverter(
         refs=refs,
         formats=formats,
+        rules=rules,
     )
     return converter.convert_schema(schema, model_name=model_name)

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -162,7 +162,7 @@ class SchemaConverter:
                 },
             })
             model = to_model(schema, rules=[
-                Rule(ByPath("#/properties/second/properties/code"), After(str.strip)),
+                Rule(ByPath("/properties/second/properties/code"), After(str.strip)),
             ])
             model(first={"code": " a "}, second={"code": " b "}).model_dump()
             # -> {'first': {'code': ' a '}, 'second': {'code': ' b '}}  (rule never ran: `second`

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -35,7 +35,7 @@ from pydantic.fields import FieldInfo
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
 
-from pydantic_jsonschema._utils import sanitize_identifier
+from pydantic_jsonschema._utils import sanitize_identifier, unwrap_type_alias
 from pydantic_jsonschema.applicators import (
     Applicator,
     Contains,
@@ -816,8 +816,7 @@ class SchemaConverter:
         # Built-in format types (`Email`, `UUID`, ...) are PEP 695 `type` aliases, i.e.
         # `TypeAliasType`. Unwrap to the actual `Annotated` / class they alias so the field
         # annotation stays clean (`str`, `uuid.UUID`) instead of the alias wrapper.
-        if isinstance(format_type, TypeAliasType):
-            format_type = format_type.__value__
+        format_type = unwrap_type_alias(format_type)
 
         if get_origin(format_type) is Annotated:
             return format_type

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -56,7 +56,7 @@ from ._discriminator import discriminator_property
 from ._field_kwargs import FieldKindType, build_field_kwargs, get_field_default
 from ._metadata import annotate, array_metadata, object_dict_metadata
 from ._object_keywords import build_dependent_required, build_property_count_bounds
-from ._refs import DEFS_KEY, escape_pointer_token, get_inline_defs
+from ._refs import DEFS_KEY, ResolvedDef, escape_pointer_token, get_inline_defs
 from ._utils import make_union, unwrap
 
 __all__ = [
@@ -120,6 +120,7 @@ class SchemaConverter:
         self._rules: list[Rule] = rules or []
 
         self._defs_cache: dict[Ref, Schema] = {}
+        self._def_names: dict[Ref, str] = {}  # Ref -> `$defs` name declaring its schema
         self._models_cache: dict[SchemaHash, type[BaseModel]] = {}
         self._resolution_path: list[str] = []  # Track path for error reporting
         self._pointer_tokens: list[str] = []  # Raw JSON Pointer tokens for the same nodes
@@ -137,6 +138,66 @@ class SchemaConverter:
         :returns: hash string (using JSON representation).
         """
         return schema.model_dump_json(exclude_unset=True)
+
+    def _model_cache_key(
+        self,
+        schema: Schema,
+        /,
+    ) -> SchemaHash:
+        """Build the model cache key for a schema at the node currently being converted.
+
+        Without rules a schema converts the same way wherever it is declared, so one entry per
+        shape is correct and shares the model across every occurrence. With rules it no longer is:
+        `ByPath` (and a `ByFunc` reading `context.path`) makes the same shape convert differently
+        per declaration site, so the pointer joins the key.
+
+        Reproduce with a shape-only key — two structurally equal inline objects, one rule aimed at
+        the second one's property:
+
+            schema = Schema.model_validate({
+                "type": "object",
+                "properties": {
+                    "first": {"type": "object", "properties": {"code": {"type": "string"}}},
+                    "second": {"type": "object", "properties": {"code": {"type": "string"}}},
+                },
+            })
+            model = to_model(schema, rules=[
+                Rule(ByPath("#/properties/second/properties/code"), After(str.strip)),
+            ])
+            model(first={"code": " a "}, second={"code": " b "}).model_dump()
+            # -> {'first': {'code': ' a '}, 'second': {'code': ' b '}}  (rule never ran: `second`
+            #    reused the model cached while converting `first`)
+
+        :param schema: Schema about to be converted.
+        :returns: Cache key — the schema hash, prefixed with the node's pointer when rules run.
+        """
+        schema_hash: SchemaHash = self._hash_schema(schema)
+        if not self._rules:
+            return schema_hash
+
+        return f"{self._current_pointer()}\n{schema_hash}"
+
+    @contextmanager
+    def _pinned_pointer(
+        self,
+        tokens: tuple[str, ...],
+        /,
+    ) -> Generator[None]:
+        """Replace the pointer stack for the duration of the block.
+
+        `_track_path` appends to the current node's pointer; this one substitutes it wholesale, so
+        a subtree converts under a pointer of its own regardless of where the converter is
+        standing. Used for `$defs`: a definition is addressed where it is declared, so every `$ref`
+        to it must convert (and cache) under `/$defs/<name>`, not under the referring node.
+
+        :param tokens: Raw JSON Pointer tokens the block converts under.
+        """
+        saved: list[str] = self._pointer_tokens
+        self._pointer_tokens = list(tokens)
+        try:
+            yield
+        finally:
+            self._pointer_tokens = saved
 
     @contextmanager
     def _track_path(
@@ -265,13 +326,13 @@ class SchemaConverter:
     ) -> type[BaseModel]:
         """Build Pydantic model from schema (common logic for root and nested).
 
-        Models are cached by schema hash, so each schema is built at most once.
+        Models are cached per `_model_cache_key`, so each schema is built at most once per key.
 
         :param schema: Schema to convert.
         :param model_name: Name for the generated model.
         :returns: Pydantic model class.
         """
-        cache_key = self._hash_schema(schema)
+        cache_key = self._model_cache_key(schema)
         if cache_key in self._models_cache:
             return self._models_cache[cache_key]
 
@@ -561,20 +622,21 @@ class SchemaConverter:
         # Convert each def with its ref marked in-progress, so a body that references the def
         # currently being built (a recursive / mutual `$ref`) defers to a `ForwardRef` instead
         # of recursing forever. `_rebuild_def_models` binds those refs once every model exists.
-        for ref, schema_def in defs.items():
-            self._defs_cache[ref] = schema_def
+        for ref, resolved in defs.items():
+            self._defs_cache[ref] = resolved.schema
+            self._def_names[ref] = resolved.name
             self._building.add(ref)
-            def_name: str = ref.removeprefix(f"#/{DEFS_KEY}/")
             try:
                 # A def is converted here, at the top of the document, so its nodes must be
                 # tracked under `$defs/<name>` — otherwise they claim the root's pointers and a
                 # `ByPath` rule aimed at a root property also fires inside every same-named def
-                # property.
+                # property. An alias tracks under the name that declares the body, so a rule on
+                # the target covers the alias too.
                 with self._track_path(
-                    f"{DEFS_KEY}.{def_name}",
-                    pointer=(DEFS_KEY, def_name),
+                    f"{DEFS_KEY}.{resolved.name}",
+                    pointer=(DEFS_KEY, resolved.name),
                 ):
-                    self._convert_nested_schema(schema_def)
+                    self._convert_nested_schema(resolved.schema)
             finally:
                 self._building.discard(ref)
 
@@ -582,7 +644,7 @@ class SchemaConverter:
 
     def _rebuild_def_models(
         self,
-        defs: dict[Ref, Schema],
+        defs: dict[Ref, ResolvedDef],
         /,
     ) -> None:
         """Re-resolve `ForwardRef` annotations in def models.
@@ -627,9 +689,12 @@ class SchemaConverter:
                 path=self._resolution_path.copy(),
             )
 
-        # `_build_model` handles model caching by schema hash.
+        # `_build_model` handles model caching. A definition converts under its own
+        # `$defs/<name>` pointer whichever `$ref` asks for it, so a path-scoped cache still keeps
+        # one model per definition and every `$ref` resolves to that same class.
         schema = self._defs_cache[ref]
-        return self._convert_nested_schema(schema)
+        with self._pinned_pointer((DEFS_KEY, self._def_names[ref])):
+            return self._convert_nested_schema(schema)
 
     def _get_base_classes(
         self,

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -56,7 +56,7 @@ from ._discriminator import discriminator_property
 from ._field_kwargs import FieldKindType, build_field_kwargs, get_field_default
 from ._metadata import annotate, array_metadata, object_dict_metadata
 from ._object_keywords import build_dependent_required, build_property_count_bounds
-from ._refs import DEFS_KEY, get_inline_defs
+from ._refs import DEFS_KEY, escape_pointer_token, get_inline_defs
 from ._utils import make_union, unwrap
 
 __all__ = [
@@ -122,6 +122,7 @@ class SchemaConverter:
         self._defs_cache: dict[Ref, Schema] = {}
         self._models_cache: dict[SchemaHash, type[BaseModel]] = {}
         self._resolution_path: list[str] = []  # Track path for error reporting
+        self._pointer_tokens: list[str] = []  # Raw JSON Pointer tokens for the same nodes
         self._applicators: list[Applicator] = []
         self._building: set[Ref] = set()  # Defs whose model is mid-construction
 
@@ -142,15 +143,25 @@ class SchemaConverter:
         self,
         segment: str,
         /,
+        *,
+        pointer: tuple[str, ...] | None = None,
     ) -> Generator[None]:
         """Context manager for tracking resolution path.
 
-        :param segment: Path segment to add.
+        :param segment: Path segment to add, in diagnostic form (`properties.name`, `anyOf[0]`).
+        :param pointer: Raw JSON Pointer tokens for the same step, one per pointer level. Required
+            wherever the diagnostic segment packs two levels into one string — `properties.name`
+            is two tokens, and a property literally named `a.b` is still one. Defaults to
+            `(segment,)`, which is right for the single-keyword steps (`items`, `not`, `if`).
         """
+        tokens: tuple[str, ...] = (segment,) if pointer is None else pointer
+
         self._resolution_path.append(segment)
+        self._pointer_tokens.extend(tokens)
         try:
             yield
         finally:
+            del self._pointer_tokens[len(self._pointer_tokens) - len(tokens) :]
             self._resolution_path.pop()
 
     def convert_schema(
@@ -481,7 +492,10 @@ class SchemaConverter:
 
         branches: dict[str, PythonType] = {}
         for trigger, sub_schema in schema.dependent_schemas.items():
-            with self._track_path(f"dependentSchemas.{trigger}"):
+            with self._track_path(
+                f"dependentSchemas.{trigger}",
+                pointer=("dependentSchemas", trigger),
+            ):
                 branches[trigger] = self._constrained_annotation(sub_schema)
 
         return self._register(DependentSchemas(branches=branches))
@@ -504,7 +518,10 @@ class SchemaConverter:
 
         branches: dict[str, PythonType] = {}
         for pattern, sub_schema in schema.pattern_properties.items():
-            with self._track_path(f"patternProperties.{pattern}"):
+            with self._track_path(
+                f"patternProperties.{pattern}",
+                pointer=("patternProperties", pattern),
+            ):
                 branches[pattern] = self._constrained_annotation(sub_schema)
 
         return self._register(PatternProperties(branches=branches))
@@ -547,8 +564,17 @@ class SchemaConverter:
         for ref, schema_def in defs.items():
             self._defs_cache[ref] = schema_def
             self._building.add(ref)
+            def_name: str = ref.removeprefix(f"#/{DEFS_KEY}/")
             try:
-                self._convert_nested_schema(schema_def)
+                # A def is converted here, at the top of the document, so its nodes must be
+                # tracked under `$defs/<name>` — otherwise they claim the root's pointers and a
+                # `ByPath` rule aimed at a root property also fires inside every same-named def
+                # property.
+                with self._track_path(
+                    f"{DEFS_KEY}.{def_name}",
+                    pointer=(DEFS_KEY, def_name),
+                ):
+                    self._convert_nested_schema(schema_def)
             finally:
                 self._building.discard(ref)
 
@@ -620,7 +646,7 @@ class SchemaConverter:
 
         base_models = []
         for index, sub_schema in enumerate(schema.all_of):
-            with self._track_path(f"allOf[{index}]"):
+            with self._track_path(f"allOf[{index}]", pointer=("allOf", str(index))):
                 if isinstance(sub_schema, Reference):
                     model = self._get_model(sub_schema.ref)
                 else:
@@ -667,7 +693,7 @@ class SchemaConverter:
         required_names: list[str] = unwrap(schema.required, default=[])
 
         for field_name, field_schema in properties.items():
-            with self._track_path(f"properties.{field_name}"):
+            with self._track_path(f"properties.{field_name}", pointer=("properties", field_name)):
                 annotation: AnnotationType | None = None
                 schema_for_field: Schema
 
@@ -741,17 +767,17 @@ class SchemaConverter:
         raise SchemaConversionError(msg)
 
     def _current_pointer(self) -> str:
-        """Build the current node's canonical JSON Pointer from the resolution path.
+        """Build the current node's canonical JSON Pointer from the tracked tokens.
 
-        Segments are dotted (`properties.created`) or bracketed (`anyOf[0]`); splitting each on
-        `.` yields the pointer components. The root schema (empty path) is `/`.
+        Each token is one pointer level, escaped per RFC 6901 on the way out. The root schema
+        (no tokens) is `/`.
 
         :returns: Canonical pointer like `/properties/created`, or `/` at the root.
         """
-        parts: list[str] = [
-            component for segment in self._resolution_path for component in segment.split(".")
-        ]
-        return "/" + "/".join(parts) if parts else "/"
+        if not self._pointer_tokens:
+            return "/"
+
+        return "/" + "/".join(escape_pointer_token(token) for token in self._pointer_tokens)
 
     def _apply_rules(
         self,
@@ -782,6 +808,28 @@ class SchemaConverter:
             if rule.matcher.matches(context):
                 result = Annotated[result, rule.action.metadata()]
         return result
+
+    def _child_annotation(
+        self,
+        schema: Schema | Reference,
+        /,
+    ) -> AnnotationType:
+        """Convert an inline child schema, applying rules at the child's own path.
+
+        For the two child nodes that never become a field or a validated branch of their own — a
+        homogeneous `items` element and a schema-valued `additionalProperties` value — plain
+        `_schema_to_annotation` is the whole conversion, so rules have nowhere else to attach. A
+        `Reference` child carries no schema of its own to match against, so it is returned as is
+        (same rule as `_constrained_annotation`).
+
+        :param schema: The child schema (or reference).
+        :returns: The child's annotation, wrapped by every matching rule.
+        """
+        annotation = self._schema_to_annotation(schema)
+        if isinstance(schema, Reference):
+            return annotation
+
+        return self._apply_rules(annotation, schema)
 
     @staticmethod
     def _build_model_config(
@@ -852,7 +900,7 @@ class SchemaConverter:
         """
         union_args: list[type | ForwardRef] = []
         for index, sub_schema in enumerate(union_schemas):
-            with self._track_path(f"{kind}[{index}]"):
+            with self._track_path(f"{kind}[{index}]", pointer=(kind, str(index))):
                 union_args.append(self._constrained_annotation(sub_schema, union_branch=True))
         return union_args
 
@@ -1180,7 +1228,7 @@ class SchemaConverter:
         item_type: type | ForwardRef = Any  # pyright: ignore[reportAssignmentType]
         if prefix_items is None and schema.items is not MISSING:
             with self._track_path("items"):
-                item_type = self._schema_to_annotation(schema.items)
+                item_type = self._child_annotation(schema.items)
         list_annotation = list[item_type]  # type: ignore[valid-type]
 
         # `uniqueItems` is stateless; `contains` / `prefixItems` need the converter.
@@ -1211,7 +1259,7 @@ class SchemaConverter:
 
         prefixes: list[PythonType] = []
         for index, sub_schema in enumerate(schema.prefix_items):
-            with self._track_path(f"prefixItems[{index}]"):
+            with self._track_path(f"prefixItems[{index}]", pointer=("prefixItems", str(index))):
                 prefixes.append(self._constrained_annotation(sub_schema))
 
         tail: PythonType | None = None
@@ -1266,7 +1314,7 @@ class SchemaConverter:
 
         if isinstance(schema.additional_properties, (Schema, Reference)):
             with self._track_path("additionalProperties"):
-                value_annotation = self._schema_to_annotation(schema.additional_properties)
+                value_annotation = self._child_annotation(schema.additional_properties)
                 dict_annotation = dict[str, value_annotation]  # type: ignore[valid-type]
                 return annotate(dict_annotation, object_dict_metadata(schema))
 

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -818,17 +818,20 @@ class SchemaConverter:
 
         For the two child nodes that never become a field or a validated branch of their own — a
         homogeneous `items` element and a schema-valued `additionalProperties` value — plain
-        `_schema_to_annotation` is the whole conversion, so rules have nowhere else to attach. A
-        `Reference` child carries no schema of its own to match against, so it is returned as is
-        (same rule as `_constrained_annotation`).
+        `_schema_to_annotation` is the whole conversion, so `format` substitution and rules have
+        nowhere else to attach. Both run here in the same order as everywhere else (format first,
+        so a rule matches the substituted annotation). A `Reference` child carries no schema of
+        its own to match against, so it is returned as is (same rule as `_constrained_annotation`).
 
         :param schema: The child schema (or reference).
-        :returns: The child's annotation, wrapped by every matching rule.
+        :returns: The child's annotation, with its format substituted and every matching rule
+            wrapped around it.
         """
         annotation = self._schema_to_annotation(schema)
         if isinstance(schema, Reference):
             return annotation
 
+        annotation = self._apply_format(annotation, schema)
         return self._apply_rules(annotation, schema)
 
     @staticmethod

--- a/pydantic_jsonschema/converters/_refs.py
+++ b/pydantic_jsonschema/converters/_refs.py
@@ -11,6 +11,7 @@ circular, or dangling targets. They are stateless: alias resolution depends only
 # and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
+from dataclasses import dataclass
 from typing import Final
 
 from pydantic.experimental.missing_sentinel import MISSING
@@ -20,6 +21,7 @@ from pydantic_jsonschema.schema import Reference, Schema
 
 __all__ = [
     "DEFS_KEY",
+    "ResolvedDef",
     "escape_pointer_token",
     "get_inline_defs",
     "resolve_def_alias",
@@ -43,31 +45,43 @@ def escape_pointer_token(token: str, /) -> str:
     return token.replace("~", "~0").replace("/", "~1")
 
 
-def get_inline_defs(schema: Schema, /) -> dict[str, Schema]:
+@dataclass(frozen=True, slots=True)
+class ResolvedDef:
+    """A `$defs` entry resolved to its concrete schema and the name that declares that schema.
+
+    The two differ only for a def alias: `{"Author": {"$ref": "#/$defs/User"}}` resolves to
+    `User`'s body, declared under the name `User`.
+    """
+
+    name: str
+    schema: Schema
+
+
+def get_inline_defs(schema: Schema, /) -> dict[str, ResolvedDef]:
     """Extract inline schema defs from a schema's `$defs` field.
 
     `Reference` entries (def aliases) are resolved to their target schemas.
 
     :param schema: Schema to extract defs from.
-    :returns: Mapping of reference paths to schemas.
+    :returns: Mapping of reference paths to resolved definitions.
     :raises SchemaReferenceError: If a def alias cannot be resolved.
     """
     if schema.defs is MISSING:
         return {}
 
-    result_defs: dict[str, Schema] = {}
+    result_defs: dict[str, ResolvedDef] = {}
     for name in schema.defs:
         ref_path = f"#/{DEFS_KEY}/{name}"
         result_defs[ref_path] = resolve_def_alias(schema.defs, name=name)
     return result_defs
 
 
-def resolve_def_alias(defs: dict[str, Schema | Reference], /, *, name: str) -> Schema:
+def resolve_def_alias(defs: dict[str, Schema | Reference], /, *, name: str) -> ResolvedDef:
     """Resolve a `$defs` entry to a concrete schema, following alias chains.
 
     :param defs: Raw `$defs` mapping.
     :param name: Definition name to resolve.
-    :returns: Concrete schema for the definition.
+    :returns: Concrete schema for the definition, with the name that declares it.
     :raises SchemaReferenceError: If an alias chain is circular, points to a
         missing definition, or targets an external reference.
     """
@@ -79,7 +93,10 @@ def resolve_def_alias(defs: dict[str, Schema | Reference], /, *, name: str) -> S
         seen_names.append(target_name)
         current = defs[target_name]
 
-    return current
+    return ResolvedDef(
+        name=seen_names[-1],
+        schema=current,
+    )
 
 
 def _check_alias_target(

--- a/pydantic_jsonschema/converters/_refs.py
+++ b/pydantic_jsonschema/converters/_refs.py
@@ -20,6 +20,7 @@ from pydantic_jsonschema.schema import Reference, Schema
 
 __all__ = [
     "DEFS_KEY",
+    "escape_pointer_token",
     "get_inline_defs",
     "resolve_def_alias",
 ]
@@ -27,6 +28,19 @@ __all__ = [
 # JSON Schema 2020-12 definitions key
 # See: https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.4
 DEFS_KEY: Final[str] = "$defs"
+
+
+def escape_pointer_token(token: str, /) -> str:
+    """Escape a raw member name into a JSON Pointer reference token.
+
+    `~` and `/` are the two characters a pointer token cannot carry literally, since `/` separates
+    tokens. RFC 6901 section 3 escapes them as `~0` and `~1`; `~` must go first, or the `~` written
+    by the `/` -> `~1` step would be escaped again into `~01`.
+
+    :param token: Raw member name (a property name, a `$defs` name, an array index).
+    :returns: The escaped reference token.
+    """
+    return token.replace("~", "~0").replace("/", "~1")
 
 
 def get_inline_defs(schema: Schema, /) -> dict[str, Schema]:

--- a/pydantic_jsonschema/rules/__init__.py
+++ b/pydantic_jsonschema/rules/__init__.py
@@ -1,0 +1,53 @@
+"""Loading rules: per-node input coercion and output serialization, matched by type or path.
+
+A `Rule` attaches custom loading behavior to the model `to_model` generates, without hand-writing
+the model. Each rule has three parts, one object each:
+
+1. **when** — a matcher (`ByType`, `ByPath`, `ByFunc`);
+2. **what** — a callable, held by the action;
+3. **how** — the action kind (`Before`, `After`, `Override`, `Dump`).
+
+One rule performs exactly one action. A load-and-dump round-trip is two rules sharing a matcher.
+
+```python
+to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+```
+
+See `.ai/configurable-loading.md` for the design and the action -> Pydantic slot mapping.
+"""
+
+from pydantic_jsonschema.rules._actions import (
+    Action,
+    After,
+    Before,
+    Dump,
+    Loader,
+    Override,
+    Serializer,
+)
+from pydantic_jsonschema.rules._matchers import (
+    ByFunc,
+    ByPath,
+    ByType,
+    MatchContext,
+    Matcher,
+    SchemaPredicate,
+)
+from pydantic_jsonschema.rules._rule import Rule
+
+__all__ = [
+    "Action",
+    "After",
+    "Before",
+    "ByFunc",
+    "ByPath",
+    "ByType",
+    "Dump",
+    "Loader",
+    "MatchContext",
+    "Matcher",
+    "Override",
+    "Rule",
+    "SchemaPredicate",
+    "Serializer",
+]

--- a/pydantic_jsonschema/rules/_actions.py
+++ b/pydantic_jsonschema/rules/_actions.py
@@ -1,0 +1,102 @@
+"""Actions: the *what* and *how* of a loading rule.
+
+An action pairs a callable (the *what*) with a Pydantic slot (the *how*). Each concrete action
+maps to exactly one Pydantic wrapper, so a rule that holds one action performs exactly one thing:
+
+- `Before` -> `BeforeValidator` — coerce raw input before core parsing (e.g. `"a,b,c"` -> list);
+- `After` -> `AfterValidator` — normalize / validate the parsed value;
+- `Override` -> `PlainValidator` — replace core parsing entirely;
+- `Dump` -> `PlainSerializer` — transform the value on serialization (model -> output).
+
+Actions are frozen dataclasses: they compare, hash, and `repr` as data. Their only non-data field
+is the held callable.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Protocol, override
+
+from pydantic import AfterValidator, BeforeValidator, PlainSerializer, PlainValidator
+
+__all__ = [
+    "Action",
+    "After",
+    "Before",
+    "Dump",
+    "Loader",
+    "Override",
+    "Serializer",
+]
+
+# The Pydantic metadata object an action contributes to an `Annotated` annotation.
+type MetadataType = Any
+# A loaded / dumped value; genuinely unconstrained, so aliased to keep it out of `ANN401`.
+type ValueType = Any
+
+
+class Loader(Protocol):
+    """A callable that transforms a value during loading (input -> value)."""
+
+    def __call__(self, value: ValueType, /) -> ValueType: ...
+
+
+class Serializer(Protocol):
+    """A callable that transforms a value during dumping (value -> output)."""
+
+    def __call__(self, value: ValueType, /) -> ValueType: ...
+
+
+class Action(ABC):
+    """Base for the *what* + *how* of a rule: contributes one Pydantic metadata object."""
+
+    @abstractmethod
+    def metadata(self) -> MetadataType:
+        """Return the Pydantic wrapper to attach as `Annotated` metadata."""
+
+
+@dataclass(frozen=True, slots=True)
+class Before(Action):
+    """Run `func` before core parsing, on the raw input (`BeforeValidator`)."""
+
+    func: Loader
+
+    @override
+    def metadata(self) -> MetadataType:
+        """Wrap `func` as a `BeforeValidator`."""
+        return BeforeValidator(self.func)
+
+
+@dataclass(frozen=True, slots=True)
+class After(Action):
+    """Run `func` after core parsing, on the parsed value (`AfterValidator`)."""
+
+    func: Loader
+
+    @override
+    def metadata(self) -> MetadataType:
+        """Wrap `func` as an `AfterValidator`."""
+        return AfterValidator(self.func)
+
+
+@dataclass(frozen=True, slots=True)
+class Override(Action):
+    """Replace core parsing with `func` entirely (`PlainValidator`)."""
+
+    func: Loader
+
+    @override
+    def metadata(self) -> MetadataType:
+        """Wrap `func` as a `PlainValidator`."""
+        return PlainValidator(self.func)
+
+
+@dataclass(frozen=True, slots=True)
+class Dump(Action):
+    """Transform the value on serialization with `func` (`PlainSerializer`)."""
+
+    func: Serializer
+
+    @override
+    def metadata(self) -> MetadataType:
+        """Wrap `func` as a `PlainSerializer`."""
+        return PlainSerializer(self.func)

--- a/pydantic_jsonschema/rules/_matchers.py
+++ b/pydantic_jsonschema/rules/_matchers.py
@@ -1,0 +1,118 @@
+"""Matchers: the *when* of a loading rule.
+
+A matcher answers one question about a schema node the converter is about to turn into a field:
+"does this rule apply here?". The node is described by a `MatchContext` (schema, resolved
+annotation, JSON Pointer); the three concrete matchers cover the useful axes:
+
+- `ByType` — match on the resolved Python annotation (`list[str]`, `str`, `datetime`, ...);
+- `ByPath` — match on the node's JSON Pointer (`#/properties/created`);
+- `ByFunc` — escape hatch: an arbitrary predicate over the `MatchContext`.
+
+All matchers are frozen dataclasses, so they compare, hash, and `repr` as plain data. `ByType`
+and `ByPath` hold only data; `ByFunc` holds a callable and is therefore the one matcher that does
+not serialize to JSON.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Protocol, override
+
+from pydantic_jsonschema.schema import Schema
+
+__all__ = [
+    "ByFunc",
+    "ByPath",
+    "ByType",
+    "MatchContext",
+    "Matcher",
+    "SchemaPredicate",
+]
+
+# Any annotation Pydantic supports (`type`, `Annotated`, `Union`, `Literal`, ...).
+type AnnotationType = Any
+
+
+@dataclass(frozen=True, slots=True)
+class MatchContext:
+    """The node a matcher is asked about: its schema, resolved annotation, and JSON Pointer."""
+
+    schema: Schema
+    annotation: AnnotationType
+    path: str
+
+
+class SchemaPredicate(Protocol):
+    """A user predicate deciding whether a `ByFunc` matcher applies to a node."""
+
+    def __call__(self, context: MatchContext, /) -> bool: ...
+
+
+def _normalize_pointer(pointer: str, /) -> str:
+    """Normalize a user-supplied pointer to the converter's canonical `/a/b` form.
+
+    Accepts a JSON Pointer (`#/properties/created`), a leading-slash form
+    (`/properties/created`), or a bare form (`properties/created`); all normalize identically.
+
+    :param pointer: User-supplied path pointer.
+    :returns: Canonical pointer starting with `/`.
+    """
+    stripped: str = pointer.removeprefix("#")
+    return stripped if stripped.startswith("/") else f"/{stripped}"
+
+
+class Matcher(ABC):
+    """Base for the *when* of a rule: decides whether a rule applies to a schema node."""
+
+    @abstractmethod
+    def matches(self, context: MatchContext, /) -> bool:
+        """Return whether this matcher applies to the given node.
+
+        :param context: The node's schema, resolved core annotation, and canonical JSON Pointer.
+        :returns: `True` when the rule should apply here.
+        """
+
+
+@dataclass(frozen=True, slots=True)
+class ByType(Matcher):
+    """Match when the resolved core annotation equals `target`.
+
+    `target` is a Python type or typing form (`list[str]`, `str`, `datetime`). Comparison is
+    equality, so parameterized generics match exactly (`list[str]`, not `list[int]`). A node whose
+    annotation a `formats` entry already replaced (e.g. `Annotated[str, ...]`) will not match a
+    bare `ByType(str)`.
+    """
+
+    target: AnnotationType
+
+    @override
+    def matches(self, context: MatchContext, /) -> bool:
+        """Return whether the resolved annotation equals `target`."""
+        return bool(context.annotation == self.target)
+
+
+@dataclass(frozen=True, slots=True)
+class ByPath(Matcher):
+    """Match when the node's JSON Pointer equals `pointer`.
+
+    `pointer` accepts `#/properties/created`, `/properties/created`, or `properties/created` —
+    all normalize to the same canonical form before comparison.
+    """
+
+    pointer: str
+
+    @override
+    def matches(self, context: MatchContext, /) -> bool:
+        """Return whether the node's canonical pointer equals the normalized `pointer`."""
+        return context.path == _normalize_pointer(self.pointer)
+
+
+@dataclass(frozen=True, slots=True)
+class ByFunc(Matcher):
+    """Match when `predicate(context)` returns `True`."""
+
+    predicate: SchemaPredicate
+
+    @override
+    def matches(self, context: MatchContext, /) -> bool:
+        """Delegate the decision to the user predicate."""
+        return self.predicate(context)

--- a/pydantic_jsonschema/rules/_matchers.py
+++ b/pydantic_jsonschema/rules/_matchers.py
@@ -95,7 +95,10 @@ class ByPath(Matcher):
     """Match when the node's JSON Pointer equals `pointer`.
 
     `pointer` accepts `#/properties/created`, `/properties/created`, or `properties/created` —
-    all normalize to the same canonical form before comparison.
+    all normalize to the same canonical form before comparison. Node pointers are RFC 6901
+    proper: an index is its own level (`anyOf/0`), a definition is addressed where it is declared
+    (`#/$defs/User/...`), and `~` / `/` inside a name are escaped as `~0` / `~1`. See
+    `docs/rules.md` for the full list of addressable nodes.
     """
 
     pointer: str

--- a/pydantic_jsonschema/rules/_matchers.py
+++ b/pydantic_jsonschema/rules/_matchers.py
@@ -5,7 +5,7 @@ A matcher answers one question about a schema node the converter is about to tur
 annotation, JSON Pointer); the three concrete matchers cover the useful axes:
 
 - `ByType` — match on the resolved Python annotation (`list[str]`, `str`, `datetime`, ...);
-- `ByPath` — match on the node's JSON Pointer (`#/properties/created`);
+- `ByPath` — match on the node's JSON Pointer (`/properties/created`);
 - `ByFunc` — escape hatch: an arbitrary predicate over the `MatchContext`.
 
 All matchers are frozen dataclasses, so they compare, hash, and `repr` as plain data. `ByType`
@@ -45,19 +45,6 @@ class SchemaPredicate(Protocol):
     """A user predicate deciding whether a `ByFunc` matcher applies to a node."""
 
     def __call__(self, context: MatchContext, /) -> bool: ...
-
-
-def _normalize_pointer(pointer: str, /) -> str:
-    """Normalize a user-supplied pointer to the converter's canonical `/a/b` form.
-
-    Accepts a JSON Pointer (`#/properties/created`), a leading-slash form
-    (`/properties/created`), or a bare form (`properties/created`); all normalize identically.
-
-    :param pointer: User-supplied path pointer.
-    :returns: Canonical pointer starting with `/`.
-    """
-    stripped: str = pointer.removeprefix("#")
-    return stripped if stripped.startswith("/") else f"/{stripped}"
 
 
 class Matcher(ABC):
@@ -103,19 +90,46 @@ class ByType(Matcher):
 class ByPath(Matcher):
     """Match when the node's JSON Pointer equals `pointer`.
 
-    `pointer` accepts `#/properties/created`, `/properties/created`, or `properties/created` —
-    all normalize to the same canonical form before comparison. Node pointers are RFC 6901
-    proper: an index is its own level (`anyOf/0`), a definition is addressed where it is declared
-    (`#/$defs/User/...`), and `~` / `/` inside a name are escaped as `~0` / `~1`. See
+    `pointer` is a JSON Pointer in exactly the form `MatchContext.path` reports it: a leading `/`,
+    one token per level, no `#` prefix (`/properties/created`). Node pointers are RFC 6901 proper:
+    an index is its own level (`anyOf/0`), a definition is addressed where it is declared
+    (`/$defs/User/...`), and `~` / `/` inside a name are escaped as `~0` / `~1`. See
     `docs/rules.md` for the full list of addressable nodes.
+
+    :raises ValueError: If `pointer` does not start with `/`.
     """
 
     pointer: str
 
+    def __post_init__(self) -> None:
+        """Reject any spelling other than the one the converter itself produces.
+
+        The `#/a/b` fragment form is what a `$ref` looks like, so it is the natural thing to
+        paste. Normalizing it instead of rejecting it makes the pointer a user writes differ from
+        the one they can observe: the converter reports `/properties/code`, so a predicate
+        comparing against the pasted fragment silently never fires while the `ByPath` spelled the
+        same way does.
+
+            Rule(ByFunc(lambda context: context.path == "#/properties/code"), After(strip))
+            # -> never matches, unlike ByPath("#/properties/code") under normalization
+
+        One accepted spelling keeps the two consistent, and turns a mistyped pointer into an
+        error instead of a rule that quietly matches nothing.
+        """
+        if self.pointer.startswith("/"):
+            return
+
+        suggestion: str = f"/{self.pointer.removeprefix('#').lstrip('/')}"
+        msg = (
+            f"`ByPath` takes a JSON Pointer starting with `/`, got {self.pointer!r}. "
+            f"Did you mean {suggestion!r}? This is the form `MatchContext.path` reports."
+        )
+        raise ValueError(msg)
+
     @override
     def matches(self, context: MatchContext, /) -> bool:
-        """Return whether the node's canonical pointer equals the normalized `pointer`."""
-        return context.path == _normalize_pointer(self.pointer)
+        """Return whether the node's pointer equals `pointer`."""
+        return context.path == self.pointer
 
 
 @dataclass(frozen=True, slots=True)

--- a/pydantic_jsonschema/rules/_matchers.py
+++ b/pydantic_jsonschema/rules/_matchers.py
@@ -17,6 +17,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Protocol, get_origin, override
 
+from pydantic_jsonschema._utils import unwrap_type_alias
 from pydantic_jsonschema.schema import Schema
 
 __all__ = [
@@ -63,10 +64,13 @@ class Matcher(ABC):
 class ByType(Matcher):
     """Match when the resolved core annotation equals `target`, or parameterizes it.
 
-    `target` is a Python type or typing form (`list[str]`, `str`, `datetime`). A parameterized
-    target matches exactly (`list[str]`, not `list[int]`); an unparameterized generic (`list`,
-    `dict`, `set`) matches every parameterization of itself. A node whose annotation a `formats`
-    entry already replaced (e.g. `Annotated[str, ...]`) will not match a bare `ByType(str)`.
+    `target` is a Python type, typing form, or PEP 695 alias (`list[str]`, `str`, `datetime`,
+    `Email`). A parameterized target matches exactly (`list[str]`, not `list[int]`); an
+    unparameterized generic (`list`, `dict`, `set`) matches every parameterization of itself.
+
+    A node whose annotation a `formats` entry replaced carries the format type, so target it with
+    that same type — `ByType(Email)` reaches the email fields, while a bare `ByType(str)` reaches
+    only the strings no format touched.
     """
 
     target: AnnotationType
@@ -74,16 +78,26 @@ class ByType(Matcher):
     @override
     def matches(self, context: MatchContext, /) -> bool:
         """Return whether the resolved annotation equals `target` or is a parameterization of it."""
+        # NOTE: Every built-in format type is a PEP 695 alias, and a `TypeAliasType` compares by
+        # identity — so without unwrapping, aiming a rule at the very type passed to `formats`
+        # matches nothing at all:
+        #
+        #   to_model(schema, formats={"date-time": DateTime},
+        #            rules=[Rule(ByType(DateTime), After(to_utc))])
+        #   # -> rule never fires: the node is `datetime.datetime`, and
+        #   #    `DateTime == datetime.datetime` is False
+        target: AnnotationType = unwrap_type_alias(self.target)
+
         # NOTE: An unparameterized generic never equals what the converter produces — an array is
         # `list[str]` or `list[Any]`, a typed map is `dict[str, T]` — so under plain equality a
         # rule built as `Rule(ByType(list), After(dedupe))` would silently match nothing at all.
         # `Annotated` is safe here: `get_origin(Annotated[str, ...])` is `Annotated`, not `str`,
         # so a format-substituted node still does not match a bare `ByType(str)`.
         origin: AnnotationType = get_origin(context.annotation)
-        if isinstance(self.target, type) and origin is self.target:
+        if isinstance(target, type) and origin is target:
             return True
 
-        return bool(context.annotation == self.target)
+        return bool(context.annotation == target)
 
 
 @dataclass(frozen=True, slots=True)

--- a/pydantic_jsonschema/rules/_matchers.py
+++ b/pydantic_jsonschema/rules/_matchers.py
@@ -15,7 +15,7 @@ not serialize to JSON.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Protocol, override
+from typing import Any, Protocol, get_origin, override
 
 from pydantic_jsonschema.schema import Schema
 
@@ -74,19 +74,28 @@ class Matcher(ABC):
 
 @dataclass(frozen=True, slots=True)
 class ByType(Matcher):
-    """Match when the resolved core annotation equals `target`.
+    """Match when the resolved core annotation equals `target`, or parameterizes it.
 
-    `target` is a Python type or typing form (`list[str]`, `str`, `datetime`). Comparison is
-    equality, so parameterized generics match exactly (`list[str]`, not `list[int]`). A node whose
-    annotation a `formats` entry already replaced (e.g. `Annotated[str, ...]`) will not match a
-    bare `ByType(str)`.
+    `target` is a Python type or typing form (`list[str]`, `str`, `datetime`). A parameterized
+    target matches exactly (`list[str]`, not `list[int]`); an unparameterized generic (`list`,
+    `dict`, `set`) matches every parameterization of itself. A node whose annotation a `formats`
+    entry already replaced (e.g. `Annotated[str, ...]`) will not match a bare `ByType(str)`.
     """
 
     target: AnnotationType
 
     @override
     def matches(self, context: MatchContext, /) -> bool:
-        """Return whether the resolved annotation equals `target`."""
+        """Return whether the resolved annotation equals `target` or is a parameterization of it."""
+        # NOTE: An unparameterized generic never equals what the converter produces — an array is
+        # `list[str]` or `list[Any]`, a typed map is `dict[str, T]` — so under plain equality a
+        # rule built as `Rule(ByType(list), After(dedupe))` would silently match nothing at all.
+        # `Annotated` is safe here: `get_origin(Annotated[str, ...])` is `Annotated`, not `str`,
+        # so a format-substituted node still does not match a bare `ByType(str)`.
+        origin: AnnotationType = get_origin(context.annotation)
+        if isinstance(self.target, type) and origin is self.target:
+            return True
+
         return bool(context.annotation == self.target)
 
 

--- a/pydantic_jsonschema/rules/_rule.py
+++ b/pydantic_jsonschema/rules/_rule.py
@@ -1,0 +1,28 @@
+"""`Rule`: one matcher paired with one action.
+
+A rule is the whole unit the converter consumes: *when* (a `Matcher`) and *what/how* (an
+`Action`). The one-action-per-rule constraint is enforced structurally — a `Rule` holds a single
+`action`, and there is no multi-action form. A load-and-dump round-trip is expressed as two rules
+sharing a matcher.
+"""
+
+from dataclasses import dataclass
+
+from pydantic_jsonschema.rules._actions import Action
+from pydantic_jsonschema.rules._matchers import Matcher
+
+__all__ = [
+    "Rule",
+]
+
+
+# NOTE: `Rule(matcher, action)` intentionally takes two positional arguments, against the
+# project's "keyword-only after the first parameter" convention. `(matcher, action)` reads as one
+# natural pair, exactly like `Annotated[T, meta]`; every other public rule type takes a single
+# argument. Kept positional by design — see `.ai/configurable-loading.md`.
+@dataclass(frozen=True, slots=True)
+class Rule:
+    """A single loading rule: apply `action` wherever `matcher` matches."""
+
+    matcher: Matcher
+    action: Action

--- a/tests/benchmarks/test_conversion.py
+++ b/tests/benchmarks/test_conversion.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Final
 import pytest
 
 from pydantic_jsonschema import Schema, to_model
+from pydantic_jsonschema.rules import After, ByFunc, ByPath, ByType, MatchContext, Rule
 
 if TYPE_CHECKING:
     from pytest_codspeed import BenchmarkFixture
@@ -100,6 +101,26 @@ _NESTED_SCHEMA: Final[dict[str, Any]] = {
 }
 
 
+def _strip_upper(value: str) -> str:
+    """Normalize a string — the payload of the benchmarked rules, kept trivial on purpose."""
+    return value.strip().upper()
+
+
+def _annotation_is_int(context: MatchContext, /) -> bool:
+    """Predicate for the `ByFunc` benchmark rule."""
+    return context.annotation is int
+
+
+# One rule per matcher kind. Rules are matched against every node the converter walks, so the cost
+# scales with the rule count rather than with the number of nodes they actually hit — and a
+# non-empty rule list also switches the model cache to a pointer-scoped key.
+_RULES: Final[list[Rule]] = [
+    Rule(ByType(str), After(_strip_upper)),
+    Rule(ByPath("#/properties/name"), After(_strip_upper)),
+    Rule(ByFunc(_annotation_is_int), After(abs)),
+]
+
+
 class TestConversionBenchmarks:
     """Time the converter on representative wide / nested / end-to-end schemas."""
 
@@ -119,3 +140,15 @@ class TestConversionBenchmarks:
     def test_validate_and_convert(self, benchmark: "BenchmarkFixture") -> None:
         """Time the full public entry path: `Schema.model_validate` followed by `to_model`."""
         benchmark(lambda: to_model(Schema.model_validate(_NESTED_SCHEMA)))
+
+    @pytest.mark.benchmark
+    def test_to_model_wide_with_rules(self, benchmark: "BenchmarkFixture") -> None:
+        """Time `to_model` with one rule per matcher kind — the per-node matching cost."""
+        schema = Schema.model_validate(_WIDE_SCHEMA)
+        benchmark(lambda: to_model(schema, rules=_RULES))
+
+    @pytest.mark.benchmark
+    def test_to_model_nested_with_rules(self, benchmark: "BenchmarkFixture") -> None:
+        """Time `to_model` with rules on a `$ref`-heavy schema (pointer-scoped model cache)."""
+        schema = Schema.model_validate(_NESTED_SCHEMA)
+        benchmark(lambda: to_model(schema, rules=_RULES))

--- a/tests/benchmarks/test_conversion.py
+++ b/tests/benchmarks/test_conversion.py
@@ -116,7 +116,7 @@ def _annotation_is_int(context: MatchContext, /) -> bool:
 # non-empty rule list also switches the model cache to a pointer-scoped key.
 _RULES: Final[list[Rule]] = [
     Rule(ByType(str), After(_strip_upper)),
-    Rule(ByPath("#/properties/name"), After(_strip_upper)),
+    Rule(ByPath("/properties/name"), After(_strip_upper)),
     Rule(ByFunc(_annotation_is_int), After(abs)),
 ]
 

--- a/tests/converters/test_converter.py
+++ b/tests/converters/test_converter.py
@@ -628,7 +628,10 @@ class TestConverterCaching:
                 """Simulate scenario where ref exists in defs_cache but model not cached."""
                 test_schema = Schema(type="object", properties={"value": Schema(type="string")})
                 ref = "#/$defs/TestType"
+                # A def is registered with the name that declares its schema — that name is what
+                # its nodes are addressed by, so both halves are filled together.
                 self._defs_cache[ref] = test_schema
+                self._def_names[ref] = "TestType"
                 return self._get_model(ref)
 
         converter = TestableConverter()

--- a/tests/converters/test_formats.py
+++ b/tests/converters/test_formats.py
@@ -447,6 +447,56 @@ class TestFormats:
         )
 
 
+class TestFormatOnChildNodes:
+    """A `format` on an inline child schema is substituted like one on a field."""
+
+    @pytest.mark.parametrize(
+        ("raw_schema", "payload", "expected"),
+        [
+            pytest.param(
+                {
+                    "type": "object",
+                    "properties": {
+                        "tags": {"type": "array", "items": {"type": "string", "format": "custom"}}
+                    },
+                    "required": ["tags"],
+                },
+                {"tags": ["ab"]},
+                {"tags": ["AB"]},
+                id="array-items",
+            ),
+            pytest.param(
+                {
+                    "type": "object",
+                    "properties": {
+                        "meta": {
+                            "type": "object",
+                            "additionalProperties": {"type": "string", "format": "custom"},
+                        }
+                    },
+                    "required": ["meta"],
+                },
+                {"meta": {"key": "ab"}},
+                {"meta": {"key": "AB"}},
+                id="map-values",
+            ),
+        ],
+    )
+    def test_child_format_is_applied(
+        self,
+        raw_schema: "SchemaRaw",
+        payload: dict[str, Any],
+        expected: dict[str, Any],
+    ) -> None:
+        """The element / value type carries the format entry, not the bare JSON type."""
+        type Uppercased = Annotated[str, AfterValidator(str.upper)]
+
+        schema = Schema.model_validate(raw_schema)
+        model = to_model(schema, formats={"custom": Uppercased})
+
+        assert model(**payload).model_dump() == expected
+
+
 class TestFormatAcceptedForms:
     """A `formats` entry must be a type or `Annotated` type; any other form is rejected."""
 

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -1,12 +1,12 @@
 """Tests for the `rules` parameter: per-node loading via matchers and actions."""
 
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, Final
 
 import pytest
 from inline_snapshot import snapshot
 from pydantic import AfterValidator, ValidationError
 
-from pydantic_jsonschema import to_model
+from pydantic_jsonschema import formats, to_model
 from pydantic_jsonschema.rules import (
     After,
     Before,
@@ -28,6 +28,37 @@ __all__: list[str] = []
 
 # Mirrors `ByType.target`: any type or typing form a rule can be aimed at.
 type ByTypeTargetType = Any
+
+# The value of whatever field a rule happens to wrap, whichever format it carries.
+type FieldValueType = Any
+
+# User-declared aliases: `ByType` must resolve them to what they name, at any nesting depth.
+type Tags = list[str]
+type Timestamps = Tags
+
+# Every type exported from `pydantic_jsonschema.formats`, with the JSON Schema `format` keyword it
+# serves and a value that satisfies it. `test_every_exported_format_type_is_covered` keeps it whole.
+_FORMAT_CASES: Final[list[tuple[str, ByTypeTargetType, str]]] = [
+    ("date-time", formats.DateTime, "2024-01-15T10:30:00Z"),
+    ("time", formats.Time, "10:30:00"),
+    ("date", formats.Date, "2024-01-15"),
+    ("duration", formats.Duration, "P1D"),
+    ("email", formats.Email, "user@example.com"),
+    ("idn-email", formats.IdnEmail, "user@example.com"),
+    ("hostname", formats.Hostname, "example.com"),
+    ("idn-hostname", formats.IdnHostname, "example.com"),
+    ("uuid", formats.UUID, "00000000-0000-7000-8000-000000000000"),
+    ("regex", formats.Regex, "^a+$"),
+    ("ipv4", formats.IPv4, "192.0.2.1"),
+    ("ipv6", formats.IPv6, "2001:db8::1"),
+    ("uri", formats.Uri, "https://example.com"),
+    ("uri-reference", formats.UriReference, "/path"),
+    ("iri", formats.Iri, "https://example.com"),
+    ("iri-reference", formats.IriReference, "/path"),
+    ("uri-template", formats.UriTemplate, "https://example.com/{id}"),
+    ("json-pointer", formats.JsonPointer, "/a/b"),
+    ("relative-json-pointer", formats.RelativeJsonPointer, "1/a"),
+]
 
 _TAGS_SCHEMA: "SchemaRaw" = {
     "type": "object",
@@ -301,6 +332,87 @@ class TestByTypeParameterization:
 
         instance = model(meta={"b": "2", "a": "1"})
         assert instance.model_dump() == snapshot({"meta": {"a": "1", "b": "2"}})
+
+
+class TestByTypeFormatTypes:
+    """The type passed to `formats` is also the type that targets the nodes it substituted."""
+
+    @pytest.mark.parametrize(
+        ("format_name", "format_type", "value"),
+        _FORMAT_CASES,
+        ids=[format_name for format_name, _, _ in _FORMAT_CASES],
+    )
+    def test_format_type_targets_its_own_nodes(
+        self,
+        format_name: str,
+        format_type: ByTypeTargetType,
+        value: str,
+    ) -> None:
+        """`ByType(<format type>)` reaches the field that same type was substituted into."""
+        matched: list[FieldValueType] = []
+
+        def mark(field_value: FieldValueType) -> FieldValueType:
+            matched.append(field_value)
+            return field_value
+
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"value": {"type": "string", "format": format_name}},
+                "required": ["value"],
+            }
+        )
+        model = to_model(
+            schema,
+            formats={format_name: format_type},
+            rules=[
+                Rule(ByType(format_type), After(mark)),
+            ],
+        )
+
+        model(value=value)
+        assert len(matched) == 1
+
+    def test_every_exported_format_type_is_covered(self) -> None:
+        """The case table above spans the whole `formats` export list.
+
+        Without this guard a newly exported format type would be absent from the table rather
+        than failing it, and would silently keep the alias bug it was added with.
+        """
+        covered = {format_type for _, format_type, _ in _FORMAT_CASES}
+        exported = {getattr(formats, name) for name in formats.__all__}
+
+        assert covered == exported
+
+    @pytest.mark.parametrize(
+        ("target", "expected"),
+        [
+            (Tags, ["b", "a"]),
+            (Timestamps, ["b", "a"]),
+        ],
+        ids=["alias", "alias-of-alias"],
+    )
+    def test_user_alias_resolves_to_what_it_names(
+        self,
+        target: ByTypeTargetType,
+        expected: list[str],
+    ) -> None:
+        """A PEP 695 alias targets whatever it names, however many aliases deep."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+                "required": ["tags"],
+            }
+        )
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(target), After(reverse_items)),
+            ],
+        )
+
+        assert model(tags=["a", "b"]).model_dump() == {"tags": expected}
 
 
 class TestByPathPointers:

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -1,6 +1,6 @@
 """Tests for the `rules` parameter: per-node loading via matchers and actions."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from inline_snapshot import snapshot
@@ -171,6 +171,175 @@ class TestMatchers:
 
         instance = model(tags=[], created="  hi ")
         assert instance.model_dump() == snapshot({"tags": [], "created": "HI"})
+
+
+class TestByPathPointers:
+    """`ByPath` addresses nodes by their true JSON Pointer.
+
+    The pointer is built from one token per level, so a union branch index is its own token, a
+    definition sits under `$defs`, and a property name keeps whatever characters it has (escaped
+    per RFC 6901).
+    """
+
+    def test_root_value_is_the_root_pointer(self) -> None:
+        """A root scalar has no tokens above it, so its pointer is `/`."""
+        schema = Schema.model_validate({"type": "string"})
+        model = to_model(schema, rules=[Rule(ByPath("/"), After(strip_upper))])
+
+        assert model(" ab ").model_dump() == snapshot("AB")  # type: ignore[call-arg]
+
+    def test_union_branch_index_is_its_own_token(self) -> None:
+        """A branch is `anyOf/0`, not `anyOf[0]` — only the string branch is normalized."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"value": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
+                "required": ["value"],
+            }
+        )
+        model = to_model(
+            schema, rules=[Rule(ByPath("#/properties/value/anyOf/0"), After(strip_upper))]
+        )
+
+        assert model(value=" ab ").model_dump() == snapshot({"value": "AB"})
+        assert model(value=7).model_dump() == snapshot({"value": 7})
+
+    def test_definition_node_does_not_claim_the_root_pointer(self) -> None:
+        """A def's nodes live under `$defs/<name>`, so they never collide with root properties."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "$defs": {
+                    "User": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    }
+                },
+                "properties": {"user": {"$ref": "#/$defs/User"}, "name": {"type": "string"}},
+                "required": ["user", "name"],
+            }
+        )
+        model = to_model(
+            schema, rules=[Rule(ByPath("#/$defs/User/properties/name"), After(strip_upper))]
+        )
+
+        instance = model(user={"name": " nested "}, name=" root ")
+        # Only the def's `name` is normalized; the same-named root property is untouched.
+        assert instance.model_dump() == snapshot({"user": {"name": "NESTED"}, "name": " root "})
+
+    @pytest.mark.parametrize(
+        ("property_name", "pointer"),
+        [
+            ("a.b", "#/properties/a.b"),
+            ("a/b", "#/properties/a~1b"),
+            ("a~b", "#/properties/a~0b"),
+        ],
+        ids=["dotted", "slash-escaped", "tilde-escaped"],
+    )
+    def test_special_characters_in_property_name(
+        self,
+        property_name: str,
+        pointer: str,
+    ) -> None:
+        """A dot stays part of the name; `/` and `~` are escaped as `~1` / `~0`."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {property_name: {"type": "string"}},
+                "required": [property_name],
+            }
+        )
+        model = to_model(schema, rules=[Rule(ByPath(pointer), After(strip_upper))])
+
+        instance = model(**{property_name: " ab "})
+        assert instance.model_dump() == {property_name: "AB"}
+
+
+class TestChildNodes:
+    """Rules reach inline child schemas that never become a field of their own."""
+
+    def test_array_items(self) -> None:
+        """A rule matching the element type applies to every item of an inline `items`."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+                "required": ["tags"],
+            }
+        )
+        model = to_model(schema, rules=[Rule(ByType(str), After(strip_upper))])
+
+        assert model(tags=[" a ", "b"]).model_dump() == snapshot({"tags": ["A", "B"]})
+
+    def test_map_values(self) -> None:
+        """A rule matching the value type applies to every value of a typed map."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {
+                    "meta": {"type": "object", "additionalProperties": {"type": "string"}}
+                },
+                "required": ["meta"],
+            }
+        )
+        model = to_model(schema, rules=[Rule(ByType(str), After(strip_upper))])
+
+        assert model(meta={"k": " v "}).model_dump() == snapshot({"meta": {"k": "V"}})
+
+    @pytest.mark.parametrize(
+        ("raw_schema", "pointer", "payload", "expected"),
+        [
+            (
+                {
+                    "type": "object",
+                    "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+                    "required": ["tags"],
+                },
+                "#/properties/tags/items",
+                {"tags": [" a "]},
+                {"tags": ["A"]},
+            ),
+            (
+                {
+                    "type": "object",
+                    "properties": {
+                        "meta": {"type": "object", "additionalProperties": {"type": "string"}}
+                    },
+                    "required": ["meta"],
+                },
+                "#/properties/meta/additionalProperties",
+                {"meta": {"k": " v "}},
+                {"meta": {"k": "V"}},
+            ),
+        ],
+        ids=["items", "additionalProperties"],
+    )
+    def test_child_is_addressable_by_path(
+        self,
+        raw_schema: "SchemaRaw",
+        pointer: str,
+        payload: dict[str, Any],
+        expected: dict[str, Any],
+    ) -> None:
+        """A child node carries its own pointer, so `ByPath` can target it directly."""
+        schema = Schema.model_validate(raw_schema)
+        model = to_model(schema, rules=[Rule(ByPath(pointer), After(strip_upper))])
+
+        assert model(**payload).model_dump() == expected
+
+    def test_dump_on_items(self) -> None:
+        """`Dump` on the element type serializes each item."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+                "required": ["tags"],
+            }
+        )
+        model = to_model(schema, rules=[Rule(ByType(str), Dump(str.upper))])
+
+        assert model(tags=["a", "b"]).model_dump() == snapshot({"tags": ["A", "B"]})
 
 
 class TestRoundTrip:

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -1,0 +1,227 @@
+"""Tests for the `rules` parameter: per-node loading via matchers and actions."""
+
+from typing import TYPE_CHECKING
+
+import pytest
+from inline_snapshot import snapshot
+from pydantic import ValidationError
+
+from pydantic_jsonschema import (
+    After,
+    Before,
+    ByFunc,
+    ByPath,
+    ByType,
+    Dump,
+    MatchContext,
+    Override,
+    Rule,
+    to_model,
+)
+from pydantic_jsonschema.schema import Schema
+from tests.conftest import dump_errors
+
+if TYPE_CHECKING:
+    from tests.conftest import SchemaRaw
+
+__all__: list[str] = []
+
+_TAGS_SCHEMA: "SchemaRaw" = {
+    "type": "object",
+    "properties": {
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "created": {"type": "string"},
+    },
+    "required": ["tags", "created"],
+}
+
+
+def csv_to_list(value: str | list[str]) -> list[str]:
+    """Split a comma-separated string into a list, passing lists through unchanged."""
+    return value.split(",") if isinstance(value, str) else value
+
+
+def strip_upper(value: str) -> str:
+    """Normalize a string by stripping whitespace and upper-casing."""
+    return value.strip().upper()
+
+
+def reject_empty(value: list[str]) -> list[str]:
+    """Reject an empty list, else return it unchanged."""
+    if not value:
+        msg = "must not be empty"
+        raise ValueError(msg)
+    return value
+
+
+def annotation_is_str(context: MatchContext, /) -> bool:
+    """Predicate: match when the resolved annotation is exactly `str`."""
+    return context.annotation is str
+
+
+class TestBefore:
+    """`Before` -> `BeforeValidator`: coerce raw input before core parsing."""
+
+    def test_csv_string_to_list(self) -> None:
+        """A comma-separated string is split into a list before list parsing."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+
+        instance = model(tags="a,b,c", created="x")
+        assert instance.model_dump() == snapshot({"tags": ["a", "b", "c"], "created": "x"})
+
+    def test_list_input_passes_through(self) -> None:
+        """A list input is left unchanged (the coercion is idempotent)."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+
+        instance = model(tags=["a", "b"], created="x")
+        assert instance.model_dump() == snapshot({"tags": ["a", "b"], "created": "x"})
+
+
+class TestAfter:
+    """`After` -> `AfterValidator`: normalize / validate the parsed value."""
+
+    def test_normalizes_value(self) -> None:
+        """The parsed string is normalized after core parsing."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByPath("#/properties/created"), After(strip_upper))])
+
+        instance = model(tags=[], created="  hi  ")
+        assert instance.model_dump() == snapshot({"tags": [], "created": "HI"})
+
+    def test_rejects_invalid_value(self) -> None:
+        """An `After` validator that raises surfaces as a `ValidationError`."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByType(list[str]), After(reject_empty))])
+
+        with pytest.raises(ValidationError) as exc_info:
+            model(tags=[], created="x")
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("tags",),
+                    "msg": "Value error, must not be empty",
+                    "input": [],
+                }
+            ]
+        )
+
+
+class TestOverride:
+    """`Override` -> `PlainValidator`: replace core parsing entirely."""
+
+    def test_replaces_parsing(self) -> None:
+        """`Override` bypasses list parsing and produces the value directly."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByType(list[str]), Override(csv_to_list))])
+
+        instance = model(tags="a,b", created="x")
+        assert instance.model_dump() == snapshot({"tags": ["a", "b"], "created": "x"})
+
+
+class TestDump:
+    """`Dump` -> `PlainSerializer`: transform the value on serialization."""
+
+    def test_serializes_value(self) -> None:
+        """The list is joined into a string on `model_dump`."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByType(list[str]), Dump(",".join))])
+
+        instance = model(tags=["x", "y"], created="z")
+        assert instance.model_dump() == snapshot({"tags": "x,y", "created": "z"})
+
+
+class TestMatchers:
+    """Matcher selection: `ByType`, `ByPath`, `ByFunc`."""
+
+    def test_by_type_no_match_leaves_field_untouched(self) -> None:
+        """A `ByType` mismatch does not wrap the field, so raw input fails validation."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByType(list[int]), Before(csv_to_list))])
+
+        with pytest.raises(ValidationError) as exc_info:
+            model(tags="a,b,c", created="x")
+
+        assert dump_errors(exc_info.value) == snapshot(
+            [
+                {
+                    "type": "list_type",
+                    "loc": ("tags",),
+                    "msg": "Input should be a valid list",
+                    "input": "a,b,c",
+                }
+            ]
+        )
+
+    def test_by_path_matches_pointer(self) -> None:
+        """`ByPath` targets a single node by its JSON Pointer."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByPath("#/properties/created"), After(strip_upper))])
+
+        instance = model(tags=[], created="hi")
+        assert instance.model_dump() == snapshot({"tags": [], "created": "HI"})
+
+    def test_by_func_predicate(self) -> None:
+        """`ByFunc` matches every node whose predicate returns `True`."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema, rules=[Rule(ByFunc(annotation_is_str), After(strip_upper))])
+
+        instance = model(tags=[], created="  hi ")
+        assert instance.model_dump() == snapshot({"tags": [], "created": "HI"})
+
+
+class TestRoundTrip:
+    """Two rules sharing a matcher express a load-and-dump round-trip."""
+
+    def test_before_and_dump(self) -> None:
+        """`Before` coerces on input and `Dump` serializes on output for one type."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(list[str]), Before(csv_to_list)),
+                Rule(ByType(list[str]), Dump(",".join)),
+            ],
+        )
+
+        instance = model(tags="x,y", created="z")
+        # `Before` coerced the CSV string into a list internally; `Dump` re-joins it on output.
+        # `getattr` sidesteps the dynamic model's untyped attribute access.
+        assert getattr(instance, "tags") == snapshot(["x", "y"])  # noqa: B009
+        assert instance.model_dump() == snapshot({"tags": "x,y", "created": "z"})
+
+
+class TestNoRules:
+    """Absence of rules is a no-op."""
+
+    def test_empty_rules_unchanged(self) -> None:
+        """Passing no rules leaves conversion unchanged."""
+        schema = Schema.model_validate(_TAGS_SCHEMA)
+        model = to_model(schema)
+
+        instance = model(tags=["a"], created="c")
+        assert instance.model_dump() == snapshot({"tags": ["a"], "created": "c"})
+
+
+class TestRuleObjects:
+    """Rules are frozen data: they compare, hash, and `repr` predictably."""
+
+    def test_equal_rules_compare_equal(self) -> None:
+        """Two rules built from the same parts are equal and hash equal."""
+        first = Rule(ByType(list[str]), Before(csv_to_list))
+        second = Rule(ByType(list[str]), Before(csv_to_list))
+
+        assert first == second
+        assert hash(first) == hash(second)
+
+    def test_repr_is_data(self) -> None:
+        """A rule's `repr` shows its matcher and action as data (function address elided)."""
+        rule = Rule(ByPath("#/properties/created"), After(strip_upper))
+        # NOTE: A function's `repr` carries its non-deterministic memory address, so match only
+        # the stable prefix (`repr(rule) == "..."` would flap across runs).
+        assert repr(rule).startswith(
+            "Rule(matcher=ByPath(pointer='#/properties/created'), action=After(func=<function "
+        )

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -70,7 +70,12 @@ class TestBefore:
     def test_csv_string_to_list(self) -> None:
         """A comma-separated string is split into a list before list parsing."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(list[str]), Before(csv_to_list)),
+            ],
+        )
 
         instance = model(tags="a,b,c", created="x")
         assert instance.model_dump() == snapshot({"tags": ["a", "b", "c"], "created": "x"})
@@ -78,7 +83,12 @@ class TestBefore:
     def test_list_input_passes_through(self) -> None:
         """A list input is left unchanged (the coercion is idempotent)."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByType(list[str]), Before(csv_to_list))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(list[str]), Before(csv_to_list)),
+            ],
+        )
 
         instance = model(tags=["a", "b"], created="x")
         assert instance.model_dump() == snapshot({"tags": ["a", "b"], "created": "x"})
@@ -90,7 +100,12 @@ class TestAfter:
     def test_normalizes_value(self) -> None:
         """The parsed string is normalized after core parsing."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByPath("#/properties/created"), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByPath("#/properties/created"), After(strip_upper)),
+            ],
+        )
 
         instance = model(tags=[], created="  hi  ")
         assert instance.model_dump() == snapshot({"tags": [], "created": "HI"})
@@ -98,7 +113,12 @@ class TestAfter:
     def test_rejects_invalid_value(self) -> None:
         """An `After` validator that raises surfaces as a `ValidationError`."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByType(list[str]), After(reject_empty))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(list[str]), After(reject_empty)),
+            ],
+        )
 
         with pytest.raises(ValidationError) as exc_info:
             model(tags=[], created="x")
@@ -121,7 +141,12 @@ class TestOverride:
     def test_replaces_parsing(self) -> None:
         """`Override` bypasses list parsing and produces the value directly."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByType(list[str]), Override(csv_to_list))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(list[str]), Override(csv_to_list)),
+            ],
+        )
 
         instance = model(tags="a,b", created="x")
         assert instance.model_dump() == snapshot({"tags": ["a", "b"], "created": "x"})
@@ -133,7 +158,12 @@ class TestDump:
     def test_serializes_value(self) -> None:
         """The list is joined into a string on `model_dump`."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByType(list[str]), Dump(",".join))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(list[str]), Dump(",".join)),
+            ],
+        )
 
         instance = model(tags=["x", "y"], created="z")
         assert instance.model_dump() == snapshot({"tags": "x,y", "created": "z"})
@@ -145,7 +175,12 @@ class TestMatchers:
     def test_by_type_no_match_leaves_field_untouched(self) -> None:
         """A `ByType` mismatch does not wrap the field, so raw input fails validation."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByType(list[int]), Before(csv_to_list))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(list[int]), Before(csv_to_list)),
+            ],
+        )
 
         with pytest.raises(ValidationError) as exc_info:
             model(tags="a,b,c", created="x")
@@ -164,7 +199,12 @@ class TestMatchers:
     def test_by_path_matches_pointer(self) -> None:
         """`ByPath` targets a single node by its JSON Pointer."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByPath("#/properties/created"), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByPath("#/properties/created"), After(strip_upper)),
+            ],
+        )
 
         instance = model(tags=[], created="hi")
         assert instance.model_dump() == snapshot({"tags": [], "created": "HI"})
@@ -172,7 +212,12 @@ class TestMatchers:
     def test_by_func_predicate(self) -> None:
         """`ByFunc` matches every node whose predicate returns `True`."""
         schema = Schema.model_validate(_TAGS_SCHEMA)
-        model = to_model(schema, rules=[Rule(ByFunc(annotation_is_str), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByFunc(annotation_is_str), After(strip_upper)),
+            ],
+        )
 
         instance = model(tags=[], created="  hi ")
         assert instance.model_dump() == snapshot({"tags": [], "created": "HI"})
@@ -189,7 +234,12 @@ class TestByPathPointers:
     def test_root_value_is_the_root_pointer(self) -> None:
         """A root scalar has no tokens above it, so its pointer is `/`."""
         schema = Schema.model_validate({"type": "string"})
-        model = to_model(schema, rules=[Rule(ByPath("/"), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByPath("/"), After(strip_upper)),
+            ],
+        )
 
         assert model(" ab ").model_dump() == snapshot("AB")  # type: ignore[call-arg]
 
@@ -207,7 +257,12 @@ class TestByPathPointers:
                 "required": ["name"],
             }
         )
-        model = to_model(schema, rules=[Rule(ByPath("/"), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByPath("/"), After(strip_upper)),
+            ],
+        )
 
         assert model(name=" ab ").model_dump() == snapshot({"name": " ab "})
 
@@ -273,7 +328,12 @@ class TestByPathPointers:
                 "required": [property_name],
             }
         )
-        model = to_model(schema, rules=[Rule(ByPath(pointer), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByPath(pointer), After(strip_upper)),
+            ],
+        )
 
         instance = model(**{property_name: " ab "})
         assert instance.model_dump() == {property_name: "AB"}
@@ -320,7 +380,12 @@ class TestModelCache:
                 "required": ["first", "second"],
             }
         )
-        model = to_model(schema, rules=[Rule(ByPath(pointer), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByPath(pointer), After(strip_upper)),
+            ],
+        )
 
         instance = model(first={"code": " a "}, second={"code": " b "})
         assert instance.model_dump() == expected
@@ -424,7 +489,12 @@ class TestChildNodes:
                 "required": ["tags"],
             }
         )
-        model = to_model(schema, rules=[Rule(ByType(str), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(str), After(strip_upper)),
+            ],
+        )
 
         assert model(tags=[" a ", "b"]).model_dump() == snapshot({"tags": ["A", "B"]})
 
@@ -439,7 +509,12 @@ class TestChildNodes:
                 "required": ["meta"],
             }
         )
-        model = to_model(schema, rules=[Rule(ByType(str), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(str), After(strip_upper)),
+            ],
+        )
 
         assert model(meta={"k": " v "}).model_dump() == snapshot({"meta": {"k": "V"}})
 
@@ -480,7 +555,12 @@ class TestChildNodes:
     ) -> None:
         """A child node carries its own pointer, so `ByPath` can target it directly."""
         schema = Schema.model_validate(raw_schema)
-        model = to_model(schema, rules=[Rule(ByPath(pointer), After(strip_upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByPath(pointer), After(strip_upper)),
+            ],
+        )
 
         assert model(**payload).model_dump() == expected
 
@@ -499,14 +579,22 @@ class TestChildNodes:
 
         # `ByType(str)` sees the substituted `Annotated[...]`, so it no longer matches — only the
         # format runs. Same rule as for a formatted field.
-        by_type = to_model(schema, formats=formats, rules=[Rule(ByType(str), After(exclaim))])
+        by_type = to_model(
+            schema,
+            formats=formats,
+            rules=[
+                Rule(ByType(str), After(exclaim)),
+            ],
+        )
         assert by_type(tags=["ab"]).model_dump() == snapshot({"tags": ["AB"]})
 
         # `ByPath` is annotation-independent, so it still matches and layers on top of the format.
         by_path = to_model(
             schema,
             formats=formats,
-            rules=[Rule(ByPath("#/properties/tags/items"), After(exclaim))],
+            rules=[
+                Rule(ByPath("#/properties/tags/items"), After(exclaim)),
+            ],
         )
         assert by_path(tags=["ab"]).model_dump() == snapshot({"tags": ["AB!"]})
 
@@ -519,7 +607,12 @@ class TestChildNodes:
                 "required": ["tags"],
             }
         )
-        model = to_model(schema, rules=[Rule(ByType(str), Dump(str.upper))])
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(str), Dump(str.upper)),
+            ],
+        )
 
         assert model(tags=["a", "b"]).model_dump() == snapshot({"tags": ["A", "B"]})
 

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -468,7 +468,10 @@ class TestByPathPointers:
             }
         )
         model = to_model(
-            schema, rules=[Rule(ByPath("/properties/value/anyOf/0"), After(strip_upper))]
+            schema,
+            rules=[
+                Rule(ByPath("/properties/value/anyOf/0"), After(strip_upper)),
+            ],
         )
 
         assert model(value=" ab ").model_dump() == snapshot({"value": "AB"})
@@ -491,7 +494,10 @@ class TestByPathPointers:
             }
         )
         model = to_model(
-            schema, rules=[Rule(ByPath("/$defs/User/properties/name"), After(strip_upper))]
+            schema,
+            rules=[
+                Rule(ByPath("/$defs/User/properties/name"), After(strip_upper)),
+            ],
         )
 
         instance = model(user={"name": " nested "}, name=" root ")
@@ -690,7 +696,10 @@ class TestModelCache:
             }
         )
         model = to_model(
-            schema, rules=[Rule(ByPath("/$defs/User/properties/name"), After(strip_upper))]
+            schema,
+            rules=[
+                Rule(ByPath("/$defs/User/properties/name"), After(strip_upper)),
+            ],
         )
 
         author = model.model_fields["author"].annotation
@@ -722,7 +731,10 @@ class TestModelCache:
             }
         )
         model = to_model(
-            schema, rules=[Rule(ByPath("/$defs/User/properties/name"), After(strip_upper))]
+            schema,
+            rules=[
+                Rule(ByPath("/$defs/User/properties/name"), After(strip_upper)),
+            ],
         )
 
         user = model.model_fields["user"].annotation
@@ -730,6 +742,44 @@ class TestModelCache:
 
         instance = model(user={"name": " a "}, author={"name": " b "})
         assert instance.model_dump() == snapshot({"user": {"name": "A"}, "author": {"name": "B"}})
+
+    def test_alias_name_is_not_an_addressable_pointer(self) -> None:
+        """An alias has no pointer of its own: only the name declaring the schema addresses it.
+
+        The flip side of the test above. `Author` resolves to `User`'s schema, so the converter
+        walks it once under `/$defs/User` and never emits `/$defs/Author`. Aiming a rule at the
+        alias name is therefore a no-op — asserted here so the choice of pointer cannot change
+        unnoticed.
+        """
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "$defs": {
+                    "User": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    },
+                    "Author": {"$ref": "#/$defs/User"},
+                },
+                "properties": {
+                    "user": {"$ref": "#/$defs/User"},
+                    "author": {"$ref": "#/$defs/Author"},
+                },
+                "required": ["user", "author"],
+            }
+        )
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByPath("/$defs/Author/properties/name"), After(strip_upper)),
+            ],
+        )
+
+        instance = model(user={"name": " a "}, author={"name": " b "})
+        assert instance.model_dump() == snapshot(
+            {"user": {"name": " a "}, "author": {"name": " b "}}
+        )
 
 
 class TestChildNodes:

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
 
 __all__: list[str] = []
 
+# Mirrors `ByType.target`: any type or typing form a rule can be aimed at.
+type ByTypeTargetType = Any
+
 _TAGS_SCHEMA: "SchemaRaw" = {
     "type": "object",
     "properties": {
@@ -57,6 +60,16 @@ def reject_empty(value: list[str]) -> list[str]:
 def exclaim(value: str) -> str:
     """Append an exclamation mark, marking that a rule ran after the format substitution."""
     return f"{value}!"
+
+
+def reverse_items[ItemType](value: list[ItemType]) -> list[ItemType]:
+    """Reverse a list, marking which arrays a `ByType` target reached."""
+    return list(reversed(value))
+
+
+def sorted_keys[ValueType](value: dict[str, ValueType]) -> dict[str, ValueType]:
+    """Sort a map by key, marking that a `ByType` target reached the map itself."""
+    return dict(sorted(value.items()))
 
 
 def annotation_is_str(context: MatchContext, /) -> bool:
@@ -221,6 +234,73 @@ class TestMatchers:
 
         instance = model(tags=[], created="  hi ")
         assert instance.model_dump() == snapshot({"tags": [], "created": "HI"})
+
+
+class TestByTypeParameterization:
+    """`ByType` compares annotations exactly, except that a bare generic covers every parameter.
+
+    The converter never produces an unparameterized annotation — an array is `list[str]` or
+    `list[Any]`, a typed map is `dict[str, T]` — so a bare target that compared by equality would
+    match nothing at all.
+    """
+
+    @pytest.mark.parametrize(
+        ("target", "expected"),
+        [
+            (list, {"names": ["B", "A"], "counts": [2, 1], "loose": [False, True]}),
+            (list[str], {"names": ["B", "A"], "counts": [1, 2], "loose": [True, False]}),
+            (list[int], {"names": ["A", "B"], "counts": [2, 1], "loose": [True, False]}),
+            (list[Any], {"names": ["A", "B"], "counts": [1, 2], "loose": [False, True]}),
+        ],
+        ids=["bare", "of-str", "of-int", "of-any"],
+    )
+    def test_bare_generic_covers_every_parameterization(
+        self,
+        target: ByTypeTargetType,
+        expected: dict[str, Any],
+    ) -> None:
+        """A bare `list` matches all three arrays; a parameterized target matches only its own."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {
+                    "names": {"type": "array", "items": {"type": "string"}},
+                    "counts": {"type": "array", "items": {"type": "integer"}},
+                    "loose": {"type": "array"},
+                },
+                "required": ["names", "counts", "loose"],
+            }
+        )
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(target), After(reverse_items)),
+            ],
+        )
+
+        instance = model(names=["A", "B"], counts=[1, 2], loose=[True, False])
+        assert instance.model_dump() == expected
+
+    def test_bare_dict_matches_a_typed_map(self) -> None:
+        """The same holds for a map: the converter emits `dict[str, T]`, never a bare `dict`."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {
+                    "meta": {"type": "object", "additionalProperties": {"type": "string"}}
+                },
+                "required": ["meta"],
+            }
+        )
+        model = to_model(
+            schema,
+            rules=[
+                Rule(ByType(dict), After(sorted_keys)),
+            ],
+        )
+
+        instance = model(meta={"b": "2", "a": "1"})
+        assert instance.model_dump() == snapshot({"meta": {"a": "1", "b": "2"}})
 
 
 class TestByPathPointers:

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -116,7 +116,7 @@ class TestAfter:
         model = to_model(
             schema,
             rules=[
-                Rule(ByPath("#/properties/created"), After(strip_upper)),
+                Rule(ByPath("/properties/created"), After(strip_upper)),
             ],
         )
 
@@ -215,7 +215,7 @@ class TestMatchers:
         model = to_model(
             schema,
             rules=[
-                Rule(ByPath("#/properties/created"), After(strip_upper)),
+                Rule(ByPath("/properties/created"), After(strip_upper)),
             ],
         )
 
@@ -356,7 +356,7 @@ class TestByPathPointers:
             }
         )
         model = to_model(
-            schema, rules=[Rule(ByPath("#/properties/value/anyOf/0"), After(strip_upper))]
+            schema, rules=[Rule(ByPath("/properties/value/anyOf/0"), After(strip_upper))]
         )
 
         assert model(value=" ab ").model_dump() == snapshot({"value": "AB"})
@@ -379,7 +379,7 @@ class TestByPathPointers:
             }
         )
         model = to_model(
-            schema, rules=[Rule(ByPath("#/$defs/User/properties/name"), After(strip_upper))]
+            schema, rules=[Rule(ByPath("/$defs/User/properties/name"), After(strip_upper))]
         )
 
         instance = model(user={"name": " nested "}, name=" root ")
@@ -389,9 +389,9 @@ class TestByPathPointers:
     @pytest.mark.parametrize(
         ("property_name", "pointer"),
         [
-            ("a.b", "#/properties/a.b"),
-            ("a/b", "#/properties/a~1b"),
-            ("a~b", "#/properties/a~0b"),
+            ("a.b", "/properties/a.b"),
+            ("a/b", "/properties/a~1b"),
+            ("a~b", "/properties/a~0b"),
         ],
         ids=["dotted", "slash-escaped", "tilde-escaped"],
     )
@@ -419,6 +419,69 @@ class TestByPathPointers:
         assert instance.model_dump() == {property_name: "AB"}
 
 
+class TestByPathPointerForm:
+    """`ByPath` takes one pointer spelling: the one `MatchContext.path` reports."""
+
+    @pytest.mark.parametrize(
+        ("pointer", "suggestion"),
+        [
+            ("#/properties/code", "/properties/code"),
+            ("#/$defs/User/properties/name", "/$defs/User/properties/name"),
+            ("properties/code", "/properties/code"),
+            ("", "/"),
+        ],
+        ids=["fragment", "ref-fragment", "bare", "empty"],
+    )
+    def test_rejects_other_spellings(self, pointer: str, suggestion: str) -> None:
+        """A pointer that does not start with `/` raises, naming the one to use instead."""
+        with pytest.raises(ValueError, match="takes a JSON Pointer starting with") as error_info:
+            ByPath(pointer)
+
+        assert repr(suggestion) in str(error_info.value)
+
+    def test_reported_paths_are_accepted_verbatim(self) -> None:
+        """Every path a matcher observes is a valid `ByPath` pointer, with no rewriting."""
+        seen: list[str] = []
+
+        def collect(context: MatchContext) -> bool:
+            seen.append(context.path)
+            return False
+
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "$defs": {
+                    "User": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    }
+                },
+                "properties": {
+                    "user": {"$ref": "#/$defs/User"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["user", "tags"],
+            }
+        )
+        to_model(
+            schema,
+            rules=[
+                Rule(ByFunc(collect), After(strip_upper)),
+            ],
+        )
+
+        assert seen == snapshot(
+            [
+                "/$defs/User/properties/name",
+                "/properties/user",
+                "/properties/tags/items",
+                "/properties/tags",
+            ]
+        )
+        assert [ByPath(path).pointer for path in seen] == seen
+
+
 class TestModelCache:
     """Generated models are cached, and rules make that cache path-aware."""
 
@@ -426,11 +489,11 @@ class TestModelCache:
         ("pointer", "expected"),
         [
             (
-                "#/properties/first/properties/code",
+                "/properties/first/properties/code",
                 {"first": {"code": "A"}, "second": {"code": " b "}},
             ),
             (
-                "#/properties/second/properties/code",
+                "/properties/second/properties/code",
                 {"first": {"code": " a "}, "second": {"code": "B"}},
             ),
         ],
@@ -515,7 +578,7 @@ class TestModelCache:
             }
         )
         model = to_model(
-            schema, rules=[Rule(ByPath("#/$defs/User/properties/name"), After(strip_upper))]
+            schema, rules=[Rule(ByPath("/$defs/User/properties/name"), After(strip_upper))]
         )
 
         author = model.model_fields["author"].annotation
@@ -547,7 +610,7 @@ class TestModelCache:
             }
         )
         model = to_model(
-            schema, rules=[Rule(ByPath("#/$defs/User/properties/name"), After(strip_upper))]
+            schema, rules=[Rule(ByPath("/$defs/User/properties/name"), After(strip_upper))]
         )
 
         user = model.model_fields["user"].annotation
@@ -607,7 +670,7 @@ class TestChildNodes:
                     "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
                     "required": ["tags"],
                 },
-                "#/properties/tags/items",
+                "/properties/tags/items",
                 {"tags": [" a "]},
                 {"tags": ["A"]},
             ),
@@ -619,7 +682,7 @@ class TestChildNodes:
                     },
                     "required": ["meta"],
                 },
-                "#/properties/meta/additionalProperties",
+                "/properties/meta/additionalProperties",
                 {"meta": {"k": " v "}},
                 {"meta": {"k": "V"}},
             ),
@@ -673,7 +736,7 @@ class TestChildNodes:
             schema,
             formats=formats,
             rules=[
-                Rule(ByPath("#/properties/tags/items"), After(exclaim)),
+                Rule(ByPath("/properties/tags/items"), After(exclaim)),
             ],
         )
         assert by_path(tags=["ab"]).model_dump() == snapshot({"tags": ["AB!"]})
@@ -743,9 +806,9 @@ class TestRuleObjects:
 
     def test_repr_is_data(self) -> None:
         """A rule's `repr` shows its matcher and action as data (function address elided)."""
-        rule = Rule(ByPath("#/properties/created"), After(strip_upper))
+        rule = Rule(ByPath("/properties/created"), After(strip_upper))
         # NOTE: A function's `repr` carries its non-deterministic memory address, so match only
         # the stable prefix (`repr(rule) == "..."` would flap across runs).
         assert repr(rule).startswith(
-            "Rule(matcher=ByPath(pointer='#/properties/created'), action=After(func=<function "
+            "Rule(matcher=ByPath(pointer='/properties/created'), action=After(func=<function "
         )

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -193,6 +193,24 @@ class TestByPathPointers:
 
         assert model(" ab ").model_dump() == snapshot("AB")  # type: ignore[call-arg]
 
+    def test_object_root_has_no_annotation_at_the_root_pointer(self) -> None:
+        """An object root becomes the model class, so `/` has no annotation to wrap.
+
+        Rules attach where a node turns into an annotation — a field, a validated branch, or an
+        inline child. A `RootModel` value is a field (`field_kind="root"`), but an object root is
+        not: its properties are the fields. Target those instead.
+        """
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            }
+        )
+        model = to_model(schema, rules=[Rule(ByPath("/"), After(strip_upper))])
+
+        assert model(name=" ab ").model_dump() == snapshot({"name": " ab "})
+
     def test_union_branch_index_is_its_own_token(self) -> None:
         """A branch is `anyOf/0`, not `anyOf[0]` — only the string branch is normalized."""
         schema = Schema.model_validate(

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -6,7 +6,8 @@ import pytest
 from inline_snapshot import snapshot
 from pydantic import ValidationError
 
-from pydantic_jsonschema import (
+from pydantic_jsonschema import to_model
+from pydantic_jsonschema.rules import (
     After,
     Before,
     ByFunc,
@@ -16,7 +17,6 @@ from pydantic_jsonschema import (
     MatchContext,
     Override,
     Rule,
-    to_model,
 )
 from pydantic_jsonschema.schema import Schema
 from tests.conftest import dump_errors

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -1,10 +1,10 @@
 """Tests for the `rules` parameter: per-node loading via matchers and actions."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import pytest
 from inline_snapshot import snapshot
-from pydantic import ValidationError
+from pydantic import AfterValidator, ValidationError
 
 from pydantic_jsonschema import to_model
 from pydantic_jsonschema.rules import (
@@ -52,6 +52,11 @@ def reject_empty(value: list[str]) -> list[str]:
         msg = "must not be empty"
         raise ValueError(msg)
     return value
+
+
+def exclaim(value: str) -> str:
+    """Append an exclamation mark, marking that a rule ran after the format substitution."""
+    return f"{value}!"
 
 
 def annotation_is_str(context: MatchContext, /) -> bool:
@@ -327,6 +332,32 @@ class TestChildNodes:
         model = to_model(schema, rules=[Rule(ByPath(pointer), After(strip_upper))])
 
         assert model(**payload).model_dump() == expected
+
+    def test_format_substitution_runs_before_rules(self) -> None:
+        """A formatted child is matched on the substituted annotation, and rules wrap it after."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {
+                    "tags": {"type": "array", "items": {"type": "string", "format": "custom"}}
+                },
+                "required": ["tags"],
+            }
+        )
+        formats: dict[str, Any] = {"custom": Annotated[str, AfterValidator(str.upper)]}
+
+        # `ByType(str)` sees the substituted `Annotated[...]`, so it no longer matches — only the
+        # format runs. Same rule as for a formatted field.
+        by_type = to_model(schema, formats=formats, rules=[Rule(ByType(str), After(exclaim))])
+        assert by_type(tags=["ab"]).model_dump() == snapshot({"tags": ["AB"]})
+
+        # `ByPath` is annotation-independent, so it still matches and layers on top of the format.
+        by_path = to_model(
+            schema,
+            formats=formats,
+            rules=[Rule(ByPath("#/properties/tags/items"), After(exclaim))],
+        )
+        assert by_path(tags=["ab"]).model_dump() == snapshot({"tags": ["AB!"]})
 
     def test_dump_on_items(self) -> None:
         """`Dump` on the element type serializes each item."""

--- a/tests/converters/test_rules.py
+++ b/tests/converters/test_rules.py
@@ -279,6 +279,139 @@ class TestByPathPointers:
         assert instance.model_dump() == {property_name: "AB"}
 
 
+class TestModelCache:
+    """Generated models are cached, and rules make that cache path-aware."""
+
+    @pytest.mark.parametrize(
+        ("pointer", "expected"),
+        [
+            (
+                "#/properties/first/properties/code",
+                {"first": {"code": "A"}, "second": {"code": " b "}},
+            ),
+            (
+                "#/properties/second/properties/code",
+                {"first": {"code": " a "}, "second": {"code": "B"}},
+            ),
+        ],
+        ids=["first", "second"],
+    )
+    def test_equal_inline_objects_convert_per_path(
+        self,
+        pointer: str,
+        expected: dict[str, Any],
+    ) -> None:
+        """Two structurally equal inline objects each get their own class, so `ByPath` hits one."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {
+                    "first": {
+                        "type": "object",
+                        "properties": {"code": {"type": "string"}},
+                        "required": ["code"],
+                    },
+                    "second": {
+                        "type": "object",
+                        "properties": {"code": {"type": "string"}},
+                        "required": ["code"],
+                    },
+                },
+                "required": ["first", "second"],
+            }
+        )
+        model = to_model(schema, rules=[Rule(ByPath(pointer), After(strip_upper))])
+
+        instance = model(first={"code": " a "}, second={"code": " b "})
+        assert instance.model_dump() == expected
+
+    def test_equal_inline_objects_share_a_class_without_rules(self) -> None:
+        """Without rules the pointer is irrelevant, so the cache still collapses equal schemas."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "properties": {
+                    "first": {
+                        "type": "object",
+                        "properties": {"code": {"type": "string"}},
+                        "required": ["code"],
+                    },
+                    "second": {
+                        "type": "object",
+                        "properties": {"code": {"type": "string"}},
+                        "required": ["code"],
+                    },
+                },
+                "required": ["first", "second"],
+            }
+        )
+        model = to_model(schema)
+
+        first = model.model_fields["first"].annotation
+        assert first is model.model_fields["second"].annotation
+
+    def test_shared_definition_stays_one_class(self) -> None:
+        """A def converts once under its own pointer, however many `$ref`s reach it."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "$defs": {
+                    "User": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    }
+                },
+                "properties": {
+                    "author": {"$ref": "#/$defs/User"},
+                    "reviewer": {"$ref": "#/$defs/User"},
+                },
+                "required": ["author", "reviewer"],
+            }
+        )
+        model = to_model(
+            schema, rules=[Rule(ByPath("#/$defs/User/properties/name"), After(strip_upper))]
+        )
+
+        author = model.model_fields["author"].annotation
+        assert author is model.model_fields["reviewer"].annotation
+
+        instance = model(author={"name": " a "}, reviewer={"name": " b "})
+        assert instance.model_dump() == snapshot(
+            {"author": {"name": "A"}, "reviewer": {"name": "B"}}
+        )
+
+    def test_definition_alias_reuses_the_target_class(self) -> None:
+        """An alias is another name for the target, so a rule on the target covers it too."""
+        schema = Schema.model_validate(
+            {
+                "type": "object",
+                "$defs": {
+                    "User": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    },
+                    "Author": {"$ref": "#/$defs/User"},
+                },
+                "properties": {
+                    "user": {"$ref": "#/$defs/User"},
+                    "author": {"$ref": "#/$defs/Author"},
+                },
+                "required": ["user", "author"],
+            }
+        )
+        model = to_model(
+            schema, rules=[Rule(ByPath("#/$defs/User/properties/name"), After(strip_upper))]
+        )
+
+        user = model.model_fields["user"].annotation
+        assert user is model.model_fields["author"].annotation
+
+        instance = model(user={"name": " a "}, author={"name": " b "})
+        assert instance.model_dump() == snapshot({"user": {"name": "A"}, "author": {"name": "B"}})
+
+
 class TestChildNodes:
     """Rules reach inline child schemas that never become a field of their own."""
 


### PR DESCRIPTION
Adds a `rules=` parameter to `to_model` / `SchemaConverter` for per-node input coercion and output serialization, matched **by Python type, by JSON Pointer, or by an arbitrary predicate** — inspired by [adaptix](https://github.com/reagento/adaptix).

## API

A `Rule` pairs one matcher with one action (strictly one action per rule, enforced by types):

```python
from pydantic_jsonschema.rules import After, Before, ByPath, ByType, Dump, Rule

to_model(schema, rules=[
    Rule(ByType(list[str]), Before(csv_to_list)),          # "a,b,c" -> ["a", "b", "c"]
    Rule(ByType(str), After(validate_sku)),
    Rule(ByPath("#/properties/created"), Override(parse_dt)),
    Rule(ByType(list[str]), Dump(",".join)),               # round-trip = two rules, one matcher
])
```

- **Matchers**: `ByType` (resolved annotation), `ByPath` (JSON Pointer), `ByFunc` (predicate over a `MatchContext`).
- **Actions** map to one Pydantic slot each: `Before` -> `BeforeValidator`, `After` -> `AfterValidator`, `Override` -> `PlainValidator`, `Dump` -> `PlainSerializer`.
- Matchers, actions, and `Rule` are frozen dataclasses -> compare / hash / `repr` as data.
- The API lives in `pydantic_jsonschema.rules`, mirroring `pydantic_jsonschema.formats`. Nothing is re-exported from the package root.

## Mechanism

Rules wrap the field annotation (`Annotated[T, ...]`) at the points where the converter turns a schema node into an annotation, which is also where `formats` substitution happens — format first, then rules, so the two compose.

Node addressing is a real RFC 6901 JSON Pointer built from one token per level, so every node the converter walks is addressable, not just top-level properties:

| Node                            | Pointer                                  |
|---------------------------------|------------------------------------------|
| root value of a non-object root | `/`                                      |
| property `code`                 | `#/properties/code`                      |
| element of an array property    | `#/properties/tags/items`                |
| value of a typed map            | `#/properties/meta/additionalProperties` |
| second `anyOf` branch           | `#/properties/value/anyOf/1`             |
| property inside a `$defs` entry | `#/$defs/User/properties/name`           |

A definition is addressed where it is declared, not through the `$ref`s pointing at it, so one rule covers every use of it — including uses through a def alias (`"Author": {"$ref": "#/$defs/User"}`).

Two consequences worth calling out for review:

- **Object roots are out of reach.** A non-object root becomes a `RootModel` whose value has an annotation, so `/` works there. An object root becomes the model class itself, and a class carries no annotation to wrap — a rule at `/` has nothing to attach to and does not fire. Documented, with a runnable example, in `docs/rules.md`.
- **Model caching is pointer-scoped when rules are set.** Generated models are cached by schema shape, so two structurally identical inline objects used to share one class — a `ByPath` rule aimed at one of them would either never run or leak into both. With rules the cache key gains the node's pointer; without rules the key is unchanged and equal shapes still share a class. `$defs` entries keep a single identity regardless, since they always convert under their own `/$defs/<name>` pointer.

## Notes

- `Rule(matcher, action)` is intentionally two-positional (reads as a pair, like `Annotated[T, meta]`).
- Full JSON round-trip of callables (a registry by name) is left as a documented future extension.

## Tests & docs

- `tests/converters/test_rules.py` — matchers, actions, pointer addressing (union branches, `$defs`, escaped property names), inline child nodes, model-cache scoping, round-trip, no-op, and data-equality cases.
- `docs/rules.md` guide + `docs/api/rules.md`, `mkdocs.yml` nav, a README section, `rules` on the converters page, and a runnable `examples/loading_rules.py` wired into `docs/examples.md`.
- `tests/benchmarks/test_conversion.py` — two CodSpeed benchmarks covering conversion with one rule per matcher kind, on both a wide and a `$ref`-heavy schema.
- Full suite green (803 passed), coverage 100%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable loading and dumping rules for schema conversion.
  - Support matching fields by type, path, or custom predicates.
  - Added actions for preprocessing, postprocessing, overriding validation, and custom serialization.
  - Rules apply to nested objects, arrays, maps, definitions, and escaped JSON Pointer paths.
  - Added an example converting comma-separated values to lists and normalizing output.

- **Documentation**
  - Added comprehensive Rules documentation, API references, examples, and configuration guidance.
  - Documented format handling for nested values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->