### PR TITLE
ci(audit): run the `Audit` job independently of `lint`/`test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,9 @@ jobs:
 
   audit:
     name: Audit
-    needs: [lint, test]
+    # No `needs`: the security audit is independent of lint/test, so it starts immediately and in
+    # parallel instead of waiting for them. A CVE surfaces as its own signal even when a test fails,
+    # rather than being masked behind an unrelated failure. It is still gated by the `check` job.
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
The `Audit` job currently declares `needs: [lint, test]`, so it only starts after both pass — and never runs at all if a test fails. That serializes the security signal behind unrelated work: a fresh CVE (like `GHSA-9xwg-3r6f-jcx2` last week) stays invisible until lint and the full test matrix are green.

This drops the `needs`, so `Audit` starts immediately and runs in parallel. It is still part of the required `check` (`CI ok`) gate, so nothing merges on a failed audit — the change only affects *when* it runs, not whether it blocks.

Item **#5** of the `rpo-app` supply-chain comparison (mirrors their `scan`-stage jobs that use `needs: []`). Independent of the other PRs in this series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow efficiency by allowing security audits to run in parallel with linting and tests.
  * Security audit results remain included in the overall validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->