### PR TITLE
feat(security): freeze CVE scanning on a digest-pinned `trivy` DB, drop `uv audit`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # No `just install-all`: `trivy` reads `uv.lock` via docker, `zizmor` runs via `uvx`.
       - name: Set up `uv` + `just`
         uses: ./.github/actions/setup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,14 +152,14 @@ jobs:
         with:
           persist-credentials: false
 
+      # No `just install-all` here: the CVE scan reads `uv.lock` directly through a
+      # pinned `trivy` docker image, and `just audit-workflows` runs `zizmor` via
+      # `uvx` — neither needs the project environment synced.
       - name: Set up `uv` + `just`
         uses: ./.github/actions/setup
 
-      - name: Install dependencies
-        run: just install-all
-
-      - name: Audit dependencies
-        run: just audit
+      - name: Scan dependencies for known CVEs
+        run: just scan-deps
 
       - name: Audit GitHub Actions workflows
         run: just audit-workflows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # No `just install-all` here: the CVE scan reads `uv.lock` directly through a
-      # pinned `trivy` docker image, and `just audit-workflows` runs `zizmor` via
-      # `uvx` — neither needs the project environment synced.
+      # No `just install-all`: `trivy` reads `uv.lock` via docker, `zizmor` runs via `uvx`.
       - name: Set up `uv` + `just`
         uses: ./.github/actions/setup
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,14 +91,10 @@ repos:
         always_run: true
         pass_filenames: false
 
-      - id: audit
-        name: Audit dependencies
-        entry: just
-        args: [audit]
-        language: system
-        always_run: true
-        pass_filenames: false
-
+      # NOTE: No dependency-CVE hook here on purpose. `just scan-deps` runs `trivy`
+      # via docker (image + DB pull), which is far too heavy for every commit; the
+      # frozen CVE gate lives in CI's `Audit` job and is available on demand as
+      # `just scan-deps`. The workflow audit below (`zizmor`) is cheap, so it stays.
       - id: audit-workflows
         name: Audit workflows
         entry: just

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,17 +1,21 @@
 # Accepted-finding ledger for the frozen CVE gate (`scripts/trivy_scan.sh`).
 #
-# Empty by default: we fix advisories rather than hide them. Add an entry ONLY for
-# a finding that genuinely cannot be fixed yet — no upstream release, or provably
-# not exploitable here. Every entry MUST carry `expired_at`, so a suppression
-# cannot outlive its justification: trivy re-raises the finding past that date and
-# forces a review.
+# Empty by default: we fix advisories rather than suppress them. The scan runs with
+# `--ignore-unfixed`, so a finding only reaches this gate once a FIX exists upstream.
+# Add an entry ONLY when that fix cannot be adopted yet (e.g. it is a breaking major
+# bump we need time to absorb) or the finding is provably not exploitable here.
+#
+# Policy: every entry MUST carry a future `expired_at`. trivy re-raises a finding once
+# that date passes, so a dated suppression cannot outlive its justification. An entry
+# WITHOUT the field never expires — trivy does not require it, so this rule is enforced
+# by review, not tooling: do not approve an entry that omits `expired_at`.
 #
 # Schema (trivy structured YAML ignorefile):
 #   vulnerabilities:
 #     - id: CVE-2026-xxxxx             # or GHSA-xxxx-xxxx-xxxx
 #       purls: ["pkg:pypi/<package>"]  # scope the suppression to the package
 #       statement: why this is accepted (one line)
-#       expired_at: 2026-10-01         # revisit-by date (required)
+#       expired_at: 2026-10-01         # revisit-by date — always a future date
 #
 # Docs: https://trivy.dev/latest/docs/configuration/filtering/#trivyignoreyaml
 vulnerabilities: []

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,17 @@
+# Accepted-finding ledger for the frozen CVE gate (`scripts/trivy_scan.sh`).
+#
+# Empty by default: we fix advisories rather than hide them. Add an entry ONLY for
+# a finding that genuinely cannot be fixed yet — no upstream release, or provably
+# not exploitable here. Every entry MUST carry `expired_at`, so a suppression
+# cannot outlive its justification: trivy re-raises the finding past that date and
+# forces a review.
+#
+# Schema (trivy structured YAML ignorefile):
+#   vulnerabilities:
+#     - id: CVE-2026-xxxxx             # or GHSA-xxxx-xxxx-xxxx
+#       purls: ["pkg:pypi/<package>"]  # scope the suppression to the package
+#       statement: why this is accepted (one line)
+#       expired_at: 2026-10-01         # revisit-by date (required)
+#
+# Docs: https://trivy.dev/latest/docs/configuration/filtering/#trivyignoreyaml
+vulnerabilities: []

--- a/justfile
+++ b/justfile
@@ -95,9 +95,12 @@ lint:
     uv run codespell
     npx --yes markdownlint-cli2
 
-# Audit dependencies for known vulnerabilities and abandoned packages (OSV-backed `uv audit`)
-audit:
-    uv audit --preview-features audit-command
+# Scan the locked dependency graph for known CVEs against a digest-pinned vulnerability DB
+# (frozen for reproducibility). All flags and the DB pin live in `scripts/trivy_scan.sh`,
+# shared verbatim with the CI `Audit` job. Runs `trivy` via docker — no local install needed.
+[doc("Scan uv.lock for known CVEs (frozen, digest-pinned DB)")]
+scan-deps:
+    scripts/trivy_scan.sh fs
 
 # Audit GitHub Actions workflows for security issues (`zizmor`)
 audit-workflows:
@@ -105,7 +108,7 @@ audit-workflows:
 
 # Generate a CycloneDX SBOM of the runtime dependency tree into `sbom/`. On-demand convenience only —
 # deliberately NOT wired into releases: the published wheel's `Requires-Dist` already declares deps,
-# and `uv audit` covers active CVE scanning, so this is just a standardized bill-of-materials for
+# and `just scan-deps` (Trivy) covers active CVE scanning, so this is just a standardized bill-of-materials for
 # anyone who explicitly needs one. `--no-default-groups` restricts it to runtime deps; `uv export`
 # carries hashes for component integrity. `cyclonedx-py` has no native `uv` lockfile support, hence
 # the `requirements` bridge. See https://github.com/CycloneDX/cyclonedx-python/issues/857
@@ -138,7 +141,7 @@ precommit:
     uv run pre-commit run --all-files
 
 # Run all checks
-all: format lint audit audit-workflows test docs-build
+all: format lint scan-deps audit-workflows test docs-build
 
 # --- Tests ---
 

--- a/scripts/trivy_scan.sh
+++ b/scripts/trivy_scan.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Frozen CVE gate over the locked dependency graph (`uv.lock`) — the single home
+# of the scan flags and the pinned vulnerability DB, invoked by BOTH the CI
+# `Audit` job and the local `just scan-deps` recipe, so local and CI runs execute
+# the identical scan and can never disagree just because they ran on different
+# days.
+#
+# Usage: scripts/trivy_scan.sh fs
+#
+# Reproducibility is the whole point: `TRIVY_DB_REPOSITORY` pins the vulnerability
+# DB by digest, so a freshly published advisory can no longer turn a green commit
+# red with no code change. The weekly floating rescan re-invokes this same script
+# with `TRIVY_DB_REPOSITORY` overridden to the unpinned `:2` tag, surfacing new
+# advisories on a controlled cadence instead of at random.
+#
+# Accepted findings that cannot be fixed yet live in `.trivyignore.yaml`, each
+# scoped to its package and carrying an `expired_at` date so a suppression cannot
+# rot silently.
+set -eu
+
+MODE="${1:?usage: trivy_scan.sh fs}"
+if [ "$MODE" != "fs" ]; then
+    echo "usage: trivy_scan.sh fs" >&2
+    exit 2
+fi
+
+# The pinned vulnerability DB. A digest — not a floating tag — is what makes the
+# gate reproducible; bumping it is a deliberate, reviewable change. Overridable
+# via the environment so the weekly floating rescan can point at the unpinned
+# `:2` tag. Kept here rather than in the workflow so CI and `just scan-deps` share
+# one source of truth for the pin.
+TRIVY_DB_REPOSITORY="${TRIVY_DB_REPOSITORY:-ghcr.io/aquasecurity/trivy-db:2@sha256:620c338424c30aa0141ccec1b5791aec4e1cc2559b26d9bfe8af6238aa1ab5c0}"
+
+# Pinned trivy image for the local/CI docker fallback below. Digest-pinned for
+# the same reproducibility reason as the DB.
+TRIVY_IMAGE="aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f"
+
+# MEDIUM included deliberately: `--ignore-unfixed` already bounds the gate to
+# findings we can act on, and the `.trivyignore.yaml` ledger absorbs any
+# wait-for-upstream tail.
+TRIVY_SEVERITY="${TRIVY_SEVERITY:-MEDIUM,HIGH,CRITICAL}"
+
+# trivy auto-discovers only the legacy plain `.trivyignore`, never the structured
+# YAML form, so the ledger has to be named explicitly. Left unnamed it does not
+# error — it simply stops suppressing, turning every accepted finding back into a
+# gate failure.
+TRIVY_IGNOREFILE="${TRIVY_IGNOREFILE:-.trivyignore.yaml}"
+
+export TRIVY_DB_REPOSITORY TRIVY_SEVERITY TRIVY_IGNOREFILE
+
+# Everything below assumes the repo root as cwd (`uv.lock` and `.trivyignore.yaml`
+# lookup). The script `cd`s here on both the host and the container re-exec.
+cd "$(dirname "$0")/.."
+
+# CI runners and local machines have no `trivy` binary — re-exec inside the pinned
+# image. The exported `TRIVY_*` vars cross the boundary so the in-container run
+# uses the identical flags, DB pin and ignorefile. Inside the container `trivy` is
+# on `PATH`, so this branch is not re-entered.
+if ! command -v trivy >/dev/null 2>&1; then
+    exec docker run --rm \
+        -v "$PWD:/repo" \
+        -v pydantic_jsonschema_trivy_cache:/root/.cache/trivy \
+        -w /repo \
+        -e TRIVY_DB_REPOSITORY \
+        -e TRIVY_SEVERITY \
+        -e TRIVY_IGNOREFILE \
+        --entrypoint sh \
+        "$TRIVY_IMAGE" \
+        scripts/trivy_scan.sh "$MODE"
+fi
+
+# NOTE: trivy reuses a cached DB purely on age — it records no provenance
+# (`db/metadata.json` holds only `Version`/`UpdatedAt`/`NextUpdate`/
+# `DownloadedAt`), so a cache populated under a DIFFERENT `TRIVY_DB_REPOSITORY`
+# (e.g. the weekly floating rescan's unpinned DB) is served without complaint,
+# silently defeating the pin. Guard with a marker file: when the requested
+# repository changes, drop the DB (`--vuln-db` removes `db/` only; the scan cache
+# survives) and record the new one.
+#
+# Reproduce (warm cache + a nonexistent digest -> exits 0, downloads nothing; the
+# same command on a cold cache dies with MANIFEST_UNKNOWN):
+#   docker run --rm -v pydantic_jsonschema_trivy_cache:/root/.cache/trivy \
+#     --entrypoint trivy aquasec/trivy:0.72.0 image --download-db-only \
+#     --db-repository ghcr.io/aquasecurity/trivy-db:2@sha256:$(printf '0%.0s' $(seq 64))
+trivy_cache_dir="${TRIVY_CACHE_DIR:-${HOME:-/root}/.cache/trivy}"
+db_ref_marker="$trivy_cache_dir/.db-repository"
+if [ "$(cat "$db_ref_marker" 2>/dev/null || true)" != "$TRIVY_DB_REPOSITORY" ]; then
+    trivy clean --vuln-db >/dev/null 2>&1 || true
+    mkdir -p "$trivy_cache_dir"
+    printf '%s\n' "$TRIVY_DB_REPOSITORY" >"$db_ref_marker"
+fi
+
+# `--include-dev-deps`: match the coverage of the `uv audit` this replaces — gate
+# dev/test/docs dependencies too, not just runtime. The advisory that motivated
+# freezing the DB (`pymdown-extensions`, GHSA-9xwg-3r6f-jcx2) was a docs-group
+# dep, which trivy suppresses by default.
+trivy fs \
+    --scanners vuln \
+    --severity "$TRIVY_SEVERITY" \
+    --ignore-unfixed \
+    --include-dev-deps \
+    --exit-code 1 \
+    uv.lock

--- a/scripts/trivy_scan.sh
+++ b/scripts/trivy_scan.sh
@@ -35,9 +35,10 @@ TRIVY_DB_REPOSITORY="${TRIVY_DB_REPOSITORY:-ghcr.io/aquasecurity/trivy-db:2@sha2
 # the same reproducibility reason as the DB.
 TRIVY_IMAGE="aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f"
 
-# MEDIUM included deliberately: `--ignore-unfixed` already bounds the gate to
-# findings we can act on, and the `.trivyignore.yaml` ledger absorbs any
-# wait-for-upstream tail.
+# MEDIUM included deliberately: the scan runs `--ignore-unfixed`, so the gate is
+# already bounded to findings that HAVE a fix (i.e. ones we can act on by bumping
+# the dependency), and the `.trivyignore.yaml` ledger absorbs the few whose fix
+# cannot be adopted immediately.
 TRIVY_SEVERITY="${TRIVY_SEVERITY:-MEDIUM,HIGH,CRITICAL}"
 
 # trivy auto-discovers only the legacy plain `.trivyignore`, never the structured
@@ -85,7 +86,14 @@ fi
 trivy_cache_dir="${TRIVY_CACHE_DIR:-${HOME:-/root}/.cache/trivy}"
 db_ref_marker="$trivy_cache_dir/.db-repository"
 if [ "$(cat "$db_ref_marker" 2>/dev/null || true)" != "$TRIVY_DB_REPOSITORY" ]; then
-    trivy clean --vuln-db >/dev/null 2>&1 || true
+    # Fail closed: the marker is written ONLY after a successful purge. If `trivy clean`
+    # is swallowed (e.g. `|| true`) and the marker is written anyway, the next run sees
+    # marker == requested repo, skips the purge, and serves the STALE DB under the new
+    # pin — silently defeating the reproducibility the pin exists to guarantee. `set -e`
+    # aborts the run on a nonzero `trivy clean`, leaving the marker unchanged so the
+    # purge is retried next time. `trivy clean --vuln-db` exits 0 on an empty cache, so
+    # the first run is unaffected.
+    trivy clean --vuln-db >/dev/null
     mkdir -p "$trivy_cache_dir"
     printf '%s\n' "$TRIVY_DB_REPOSITORY" >"$db_ref_marker"
 fi


### PR DESCRIPTION
Freezes dependency CVE scanning on a **digest-pinned Trivy database**, so a freshly published advisory can no longer turn a green commit red with no code change — the failure mode that reddened `main` via `pymdown-extensions` (`GHSA-9xwg-3r6f-jcx2`, #99). This is **layer 1 (the blocking, frozen gate)**; the weekly floating rescan that surfaces new advisories on a controlled cadence follows in a separate PR.

### What changes
- **New `scripts/trivy_scan.sh`** — the single home of the scan flags and the pinned DB, invoked by *both* the CI `Audit` job and `just scan-deps`, so local and CI runs execute the identical scan. Runs `trivy` via a pinned docker image (no local install needed); no `trivy` binary on the host → it re-execs inside the image.
- **New `.trivyignore.yaml`** — empty accepted-finding ledger. We fix advisories, not hide them; an entry is added only when a finding genuinely cannot be fixed yet, and every entry **must** carry `expired_at` so a suppression cannot rot silently (Trivy re-raises it past that date).
- **CI `Audit` job** now runs `just scan-deps` instead of `just audit`, and no longer syncs the project env (`just install-all` dropped — the scan reads `uv.lock` directly and `zizmor` runs via `uvx`). Still gated by the `CI ok` check.
- **`uv audit` removed** from the `justfile`, CI, and pre-commit.
- **No dependency-CVE pre-commit hook** — `trivy` via docker is too heavy for every commit; the gate lives in CI and on demand as `just scan-deps`. The cheap `zizmor` workflow audit stays.

### Why drop `uv audit` entirely (not keep it alongside)
`uv audit` sources vulnerabilities from a **live OSV query** — there is no local DB to pin, so it is inherently non-deterministic and cannot be frozen. Keeping it would also mean maintaining **two** suppression ledgers (`.trivyignore.yaml` for Trivy + `uv audit`'s `--ignore`), which drift apart. One tool, one ledger. The only thing lost is `uv audit`'s abandoned-package detection — an acceptable trade for reproducibility.

### Coverage parity
`--include-dev-deps` is set deliberately: Trivy suppresses dev/test/docs dependencies by default, but the advisory that motivated this (`pymdown-extensions`) is a **docs-group** dep. Matching `uv audit`'s all-groups coverage keeps the gate from regressing.

### Pins (updating = a deliberate, reviewable PR)
- DB: `ghcr.io/aquasecurity/trivy-db:2@sha256:620c338424c30aa0141ccec1b5791aec4e1cc2559b26d9bfe8af6238aa1ab5c0`
- Image: `aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f`

New CVEs enter only when the DB digest is bumped (or via the upcoming weekly floating rescan), never at random.

### Verified locally
- `scripts/trivy_scan.sh fs` (docker-fallback path) → `uv.lock` detected, **0 findings**, exit 0.
- Second run reuses the cached DB (no re-download); the cache-provenance marker holds the pinned repo, so the pin cannot be silently defeated by a stale cache.
- Empty `.trivyignore.yaml` parses; `--include-dev-deps` still clean.
- `shellcheck -s sh` clean; `check-github-workflows` + `actionlint` + `zizmor` clean; full pre-commit (lint/test/docs) green.

Item **#5** / the CVE-freeze goal of the `rpo-app` supply-chain comparison. **Layer 2 (weekly floating rescan) is a separate follow-up PR.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reproducible vulnerability scanning for locked project dependencies.
  * Added an accepted-findings ledger for managing documented security scan exceptions.

* **Bug Fixes**
  * Improved CI dependency scanning by avoiding unnecessary environment installation.

* **Chores**
  * Updated the aggregate checks to use the new dependency scan.
  * Removed dependency auditing from pre-commit checks while retaining workflow auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->