### PR TITLE
feat(security): add weekly floating CVE rescan against the latest `trivy` DB

### DIFF
--- a/.github/workflows/cve-rescan.yml
+++ b/.github/workflows/cve-rescan.yml
@@ -1,0 +1,52 @@
+name: CVE rescan
+
+# Layer 2 of the CVE gate — a signal, NOT a PR gate. The blocking gate (CI's `Audit`
+# job) scans against a digest-pinned, frozen vulnerability DB for reproducibility; this
+# job re-runs the same scan against the UNPINNED, latest DB to surface advisories
+# published since the pinned digest was last bumped.
+#
+# When this fails, a new CVE affects the locked dependency graph. Resolve it by bumping
+# the dependency, or — if it cannot be fixed yet — add a scoped `.trivyignore.yaml`
+# entry; then bump the pinned DB digest in `scripts/trivy_scan.sh` so the blocking gate
+# picks the advisory up too. A failed scheduled run notifies via GitHub's standard
+# scheduled-workflow-failure email; no code change is needed to keep it running.
+#
+# Depends on `scripts/trivy_scan.sh` (added alongside the blocking gate).
+
+on:
+  schedule:
+    # Mondays 05:00 UTC — matches the existing weekly dependency-update cadence.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  rescan:
+    name: Rescan against the latest CVE DB
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up `uv` + `just`
+        uses: ./.github/actions/setup
+
+      # `TRIVY_DB_REPOSITORY` overrides the digest pin in `scripts/trivy_scan.sh` with
+      # the floating `:2` tag, so `trivy` pulls the latest DB — the whole point of this
+      # layer. The script's cache-provenance guard drops any DB cached under the pinned
+      # digest before scanning, so the floating result cannot be served from a stale
+      # frozen cache.
+      - name: Rescan dependencies against the latest CVE DB
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2
+        run: just scan-deps


### PR DESCRIPTION
Adds **layer 2** of the CVE gate: a weekly scheduled workflow that re-runs the dependency scan against the **unpinned, latest** Trivy DB, surfacing advisories published since the pinned digest was last bumped. This is a **signal, not a PR gate** — it never blocks normal work.

> [!NOTE]
> **Depends on #107**, which adds `scripts/trivy_scan.sh` (the shared scanner) and the frozen blocking gate. Merge #107 first. The workflow is inert until then — it only *calls* the script, which lands on `main` with #107.

### How it works
- Runs Mondays 05:00 UTC (matches the existing weekly dependency-update cadence) + `workflow_dispatch`.
- Reuses the exact same `just scan-deps` / `scripts/trivy_scan.sh fs` as the blocking gate, with one override: `TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db:2` (the floating `:2` tag instead of the pinned digest). The script's cache-provenance guard drops any DB cached under the pinned digest first, so the floating result can't be served from a stale frozen cache.
- Least-privilege (`contents: read`); not part of the `CI ok` gate, so it cannot block PRs.

### The operational loop this closes
1. Everyday PRs → blocking gate, frozen DB, reproducible (#107).
2. This job, weekly → flags anything new in the floating DB.
3. On failure: bump the offending dependency, or add a scoped `.trivyignore.yaml` entry if it's unfixable — then bump the pinned DB digest in `scripts/trivy_scan.sh` so the blocking gate catches it too.

A failed scheduled run notifies via GitHub's standard scheduled-workflow-failure email; no code change is needed to keep it running.

### Verified
`check-github-workflows` + `actionlint` + `zizmor` all clean.

Item **#5** / the CVE-freeze goal of the `rpo-app` supply-chain comparison — the floating-rescan half of the two-layer design.
