### PR TITLE
ci(deps): close three gaps in the automated dependency updates

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,12 @@
 name: Set up uv and just
-description: Install the pinned uv and just toolchain (single source for both action SHAs).
+description: Install the pinned uv and just toolchain (single source for both action SHAs; the
+  release workflow pins its own uncached copies).
 
 runs:
   using: composite
   steps:
     - name: Install `uv`
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
     - name: Install `just`
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,13 @@ updates:
           - "*"
 
   - package-ecosystem: github-actions
-    directory: /
+    # `/` scans `.github/workflows/` and a ROOT `action.yml` only, so the composite action at
+    #  `.github/actions/setup/action.yml` was never seen: its `setup-uv` pin sat at `v8.2.0` from
+    #  the commit that added it while `release.yml`'s duplicate of the same pin was bumped twice.
+    #  https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+    directories:
+      - /
+      - /.github/actions/setup
     schedule:
       interval: weekly
     # `exclude-newer` is a `uv`-only resolver setting and does not cover GitHub Actions, so this is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
       - name: Set up `uv` + `just`
         uses: ./.github/actions/setup
 
+      - name: Install dependencies
+        run: just install-audit
+
       - name: Scan dependencies for known CVEs
         run: just scan-deps
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
 
   # Validate GitHub Actions workflows and the Dependabot config against their JSON schemas.
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.3
+    rev: 0.38.0
     hooks:
       - id: check-github-workflows
       - id: check-github-actions

--- a/justfile
+++ b/justfile
@@ -71,6 +71,10 @@ install-benchmark: _check-uv
 install-docs: _check-uv
     uv sync --group docs
 
+# Install the audit group only (just `zizmor`). Frozen in CI.
+install-audit: _check-uv
+    uv sync --no-default-groups --group audit
+
 # Install the release group. Frozen in CI.
 install-release: _check-uv
     uv sync --group release
@@ -104,7 +108,7 @@ scan-deps:
 
 # Audit GitHub Actions workflows for security issues (`zizmor`)
 audit-workflows:
-    uvx zizmor --offline .github/workflows/
+    uv run zizmor --offline .github/workflows/
 
 # Generate a CycloneDX SBOM of the runtime dependency tree into `sbom/`. On-demand convenience only —
 # deliberately NOT wired into releases: the published wheel's `Requires-Dist` already declares deps,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,12 +57,20 @@ dev = [
     {include-group = "benchmark"},
     {include-group = "docs"},
     {include-group = "release"},
+    {include-group = "audit"},
 ]
 # `pytest-codspeed` provides the `benchmark` fixture and powers the `CodSpeed` CI job. Kept out of
 # the `test` group so the coverage-gated suite never pulls it (and the floor/ceiling runs stay lean).
 benchmark = [
     {include-group = "test"},
     "pytest-codspeed>=5.0.0",
+]
+# `zizmor` audits the workflows. Kept in its own group so CI's `Audit` job — deliberately
+#  independent of `lint`/`test` — installs this one tool instead of the whole lint env. Locked
+#  rather than run through `uvx`: a floating `uvx zizmor` gets none of the supply-chain guards the
+#  rest of the tree has — no `exclude-newer` cooldown, no lockfile hash, no `Dependabot` bump.
+audit = [
+    "zizmor>=1.29.0",
 ]
 release = [
     "git-cliff>=2.0.0",

--- a/scripts/trivy_scan.sh
+++ b/scripts/trivy_scan.sh
@@ -33,7 +33,7 @@ TRIVY_DB_REPOSITORY="${TRIVY_DB_REPOSITORY:-ghcr.io/aquasecurity/trivy-db:2@sha2
 
 # Pinned trivy image for the local/CI docker fallback below. Digest-pinned for
 # the same reproducibility reason as the DB.
-TRIVY_IMAGE="aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f"
+TRIVY_IMAGE="aquasec/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969"
 
 # MEDIUM included deliberately: the scan runs `--ignore-unfixed`, so the gate is
 # already bounded to findings that HAVE a fix (i.e. ones we can act on by bumping

--- a/uv.lock
+++ b/uv.lock
@@ -1289,6 +1289,9 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+audit = [
+    { name = "zizmor" },
+]
 benchmark = [
     { name = "inline-snapshot" },
     { name = "pydantic-extra-types" },
@@ -1317,6 +1320,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-examples" },
     { name = "ruff" },
+    { name = "zizmor" },
 ]
 docs = [
     { name = "mike" },
@@ -1349,6 +1353,7 @@ test = [
 requires-dist = [{ name = "pydantic", specifier = ">=2.13.0" }]
 
 [package.metadata.requires-dev]
+audit = [{ name = "zizmor", specifier = ">=1.29.0" }]
 benchmark = [
     { name = "inline-snapshot", specifier = ">=0.34.0" },
     { name = "pydantic-extra-types", specifier = ">=2.3.0" },
@@ -1377,6 +1382,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-examples", specifier = ">=0.0.18" },
     { name = "ruff", specifier = ">=0.12.10" },
+    { name = "zizmor", specifier = ">=1.29.0" },
 ]
 docs = [
     { name = "mike", specifier = ">=2.1.0" },
@@ -1860,4 +1866,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/f8/f4e3fc0b316d5241b6d6968e8fb702e28446bc7d3c1e2b229f4caa6eacf2/zizmor-1.29.0.tar.gz", hash = "sha256:60e34e83c67064e0036989c7c525d13413e897aa4c4f683f1efb2048cdb28a47", size = 571865, upload-time = "2026-08-01T21:09:19.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/97/667ef4db0ca9225ee402c1b947b5b6f17fd234d72c15a71db150b7695c62/zizmor-1.29.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ea72f84d610643d57f96430c655a3780d0b874e477d32e14eae8e910f6cce1fd", size = 9037504, upload-time = "2026-08-01T21:08:56.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d4/9fc7deaf75778e7516fa1d6c836377c3cb5d203dedc28899946b6f11ecdb/zizmor-1.29.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5aafe617d7b1e0c0c15d58fdf20495f360f74a791dfa136f76630b4cc06c2a34", size = 8654426, upload-time = "2026-08-01T21:08:59.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/6db714fb0aa08aeec62eb9d6ad6a443a1f4ed50d4c0b789944ae55fb83e4/zizmor-1.29.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:67644ae8d6d0394204b9a488f7d86f0dd66fe562f4ba85fc53e6105a6bfc7b6a", size = 8918927, upload-time = "2026-08-01T21:09:01.46Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/a12edc0c0c0a0101c54dbb9099ff08f8de2fcb35c36cb706db3deb2c2728/zizmor-1.29.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:81e4093fed5c8a41d6ae7bb773085a9d2e6c0b0a0b560d46a9c76d69be0a07ed", size = 8500655, upload-time = "2026-08-01T21:09:03.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f0/dfa67018b76bc4f2f50e265e8cbd1293833d1b1de5f3f02fbbb7487ae9c6/zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:587b99c2e1b34575c6c8565c2bfde415ca8bc0310f5589f19bc948c8dea10a20", size = 9351035, upload-time = "2026-08-01T21:09:06.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1b/93cdd5a06984b394d90001f9778008a21689052904109080a09952626c99/zizmor-1.29.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:061600f23c46f2e400bcdef666c236de7e5c0b07dd6ca046daa001eb1514b909", size = 8941717, upload-time = "2026-08-01T21:09:08.861Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f4/8d9e54405b477bc8e4b56c1a60123fca26c109ea6a762eea104fab32555e/zizmor-1.29.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:332546480be38aca95c149f835e0dcb7679ab5d74618a90c6ccb3fa6b8c7b99d", size = 8468289, upload-time = "2026-08-01T21:09:11.096Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/06d57ca830cc4653369c5aca22cccbf04c8c36ee84a67f351214e556bad8/zizmor-1.29.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a7462b9ab45d72a20ad5ab8193b430df8184c59e2bf46954ddd09496f2f00b45", size = 9446505, upload-time = "2026-08-01T21:09:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/253d9a3538e0ea6f96a3bcd69839c0c5a816a00299620b58a10b5bd1df59/zizmor-1.29.0-py3-none-win32.whl", hash = "sha256:8c759e68cd866375030ca39e19e2de47a056b7be7288c1620e2d5b4c274f631f", size = 7655723, upload-time = "2026-08-01T21:09:15.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2d/7919bc23475273ed8038a031fc24bc3f2005c78e608ce8df96746ef0fb98/zizmor-1.29.0-py3-none-win_amd64.whl", hash = "sha256:0fb85948ba5ffc7a8116eee36fe9cfc10167225c97bd2810e3378e66a9fd27c4", size = 8785519, upload-time = "2026-08-01T21:09:17.513Z" },
 ]


### PR DESCRIPTION
## What

Four independent maintenance commits, each reviewable on its own.

- **`Dependabot` never saw the composite action.** `directory: /` covers `.github/workflows/`
  and a *root* `action.yml` only, so `.github/actions/setup/action.yml` was invisible: its
  `setup-uv` pin sat at `v8.2.0` from the commit that introduced it (#71) while the duplicate
  pin in `release.yml` was bumped twice over the same period. Switched to `directories:` with
  the composite's own path added, and bumped the pin to `v10.0.1` to match #115. Both breaking
  changes between `v8` and `v10` are cache-behaviour only (`prune-cache` default, and
  `enable-cache: auto` opting out on `pull_request_target` / `workflow_run` / `release`), and
  `release.yml` triggers on `push: tags`, so nothing here changes.

- **`zizmor` ran unpinned.** `uvx zizmor` floated to the newest release on every commit — no
  lockfile hash, no `exclude-newer` cutoff, no update PR. It now lives in an `audit` dependency
  group and runs through `uv run`, so all three apply to it like every other tool. Its own
  group rather than `lint`, so the `Audit` job installs one package instead of the whole lint
  environment.

- **`trivy` `0.72.0` -> `0.74.0`**, digest-pinned as before. The vulnerability DB digest is
  deliberately left alone: the weekly floating rescan is green, so there is no new advisory for
  the frozen gate to pick up.

- **`check-jsonschema` `0.37.3` -> `0.38.0`**, which refreshes the vendored `dependabot` schema
  that validates the change above.

## Why

The first two are supply-chain gaps rather than staleness: one pin was outside every update
mechanism the repository has, and one tool was outside all of them at once, on a hook that runs
on every commit.

## How to test

`just lint`, `just test`, `just audit-workflows`, `just scan-deps` — all green locally, and the
`Audit` job exercises the last two in CI. `just install-audit` is the new step the job needs.
