### PR TITLE
ci(deps): cover the composite action with `Dependabot` and bump `setup-uv`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,12 @@
 name: Set up uv and just
-description: Install the pinned uv and just toolchain (single source for both action SHAs).
+description: Install the pinned uv and just toolchain (single source for both action SHAs; the
+  release workflow pins its own uncached copies).
 
 runs:
   using: composite
   steps:
     - name: Install `uv`
-      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
     - name: Install `just`
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,13 @@ updates:
           - "*"
 
   - package-ecosystem: github-actions
-    directory: /
+    # `/` scans `.github/workflows/` and a ROOT `action.yml` only, so the composite action at
+    #  `.github/actions/setup/action.yml` was never seen: its `setup-uv` pin sat at `v8.2.0` from
+    #  the commit that added it while `release.yml`'s duplicate of the same pin was bumped twice.
+    #  https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+    directories:
+      - /
+      - /.github/actions/setup
     schedule:
       interval: weekly
     # `exclude-newer` is a `uv`-only resolver setting and does not cover GitHub Actions, so this is


### PR DESCRIPTION
`Dependabot`'s `directory: /` scans `.github/workflows/` and a *root* `action.yml` only, so
`.github/actions/setup/action.yml` was invisible to it: the `setup-uv` pin there sat at `v8.2.0`
from the commit that introduced it (#71) while the duplicate pin in `release.yml` was bumped
twice over the same period — most recently to `v10.0.1` in #115, which again left the composite
behind.

Switching to `directories:` with the composite's own path added closes the gap, and this bumps
the stale pin to match.

Both breaking changes between `v8` and `v10` are cache behaviour only (the `prune-cache` default,
and `enable-cache: auto` opting out on `pull_request_target` / `workflow_run` / `release`).
`release.yml` triggers on `push: tags`, so neither applies here.
