### PR TITLE
chore(security): bump the pinned `trivy` image to `0.74.0`

### DIFF
--- a/scripts/trivy_scan.sh
+++ b/scripts/trivy_scan.sh
@@ -33,7 +33,7 @@ TRIVY_DB_REPOSITORY="${TRIVY_DB_REPOSITORY:-ghcr.io/aquasecurity/trivy-db:2@sha2
 
 # Pinned trivy image for the local/CI docker fallback below. Digest-pinned for
 # the same reproducibility reason as the DB.
-TRIVY_IMAGE="aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f"
+TRIVY_IMAGE="aquasec/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969"
 
 # MEDIUM included deliberately: the scan runs `--ignore-unfixed`, so the gate is
 # already bounded to findings that HAVE a fix (i.e. ones we can act on by bumping


### PR DESCRIPTION
`0.72.0` -> `0.74.0`, digest-pinned as before.

The vulnerability DB digest is deliberately left alone: the weekly floating rescan is green, so
there is no new advisory for the frozen gate to pick up. Verified with `just scan-deps` on the new
image — `uv.lock | uv | 0` vulnerabilities.
