### PR TITLE
chore(pre-commit): bump `check-jsonschema` to `0.38.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
 
   # Validate GitHub Actions workflows and the Dependabot config against their JSON schemas.
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.3
+    rev: 0.38.0
     hooks:
       - id: check-github-workflows
       - id: check-github-actions


### PR DESCRIPTION
`0.37.3` -> `0.38.0`, which refreshes the vendored GitHub Actions and `Dependabot` schemas the
hook validates against.

`Dependabot` has no `pre-commit` ecosystem, so these revisions are bumped by hand.
