### PR TITLE
ci(pr): key the title-check concurrency on the PR, not the base ref

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,9 +11,13 @@ on:
 permissions:
   pull-requests: read
 
-# Cancel superseded runs: a new push to the same ref aborts the in-flight run for it.
+# Cancel superseded runs of the SAME pull request. Keyed on the PR number rather than
+#  `github.ref`, which under `pull_request_target` is the repository DEFAULT branch: every PR
+#  into `main` then shared one group and each new one aborted the others' title check with
+#  `Canceling since a higher priority waiting request for PR-refs/heads/main exists`.
+#  https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Opening four pull requests back to back left two of them with a cancelled `Validate PR title`
check. The reason is in the cancellation message itself — it names the concurrency group that
evicted them:

```
Canceling since a higher priority waiting request for PR-refs/heads/main exists
```

The group is `${{ github.workflow }}-${{ github.ref }}`, and under `pull_request_target`
`github.ref` is the repository's default branch rather than the pull request. Every PR into `main`
therefore shared a single group, and with `cancel-in-progress: true` each new one aborted the title
check of all the others.

Keying on `github.event.pull_request.number` gives one group per pull request, which is what the
comment above the block already claimed it did: a later push to the same PR still cancels its own
in-flight run, and PRs no longer cancel each other.

Verified against the `Validate PR title` runs for #118 / #119 (cancelled) versus #120 / #121, which
happened to be the last two queued and survived.
