### PR TITLE
ci(lock-refresh): mint a scoped `GitHub App` token so the monthly PR runs `CI`

### DIFF
--- a/.github/workflows/lock-refresh.yml
+++ b/.github/workflows/lock-refresh.yml
@@ -9,10 +9,10 @@ on:
     - cron: "0 5 1 * *"
   workflow_dispatch:
 
-# Least privilege: what `create-pull-request` needs to push a branch and open the PR.
+# The branch push and the PR both go through the App token minted below, so the workflow's own
+#  token only has to read the repository for the checkout.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}
@@ -38,15 +38,32 @@ jobs:
       - name: Upgrade lockfile
         run: uv lock --upgrade
 
+      # `GITHUB_TOKEN` cannot open a mergeable PR here, in either configuration. Its plain push
+      #  writes an unsigned commit and `main` requires verified signatures (#124:
+      #  `verified=false, reason=unsigned`). Turning on `sign-commits` fixes that but makes the PR
+      #  bot-authored, and a first-time author leaves every workflow `action_required`, so the
+      #  required `CI ok` is never reported (#127). An App token signs through the API and its
+      #  events start workflow runs normally, which closes both halves.
+      #  https://github.com/peter-evans/create-pull-request/blob/5f6978faf089d4d20b00c7766989d076bb2fc7f1/docs/concepts-guidelines.md
+      - name: Mint an App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          # Narrowed to what the step below needs — an unscoped token carries every permission the
+          #  App is installed with. https://docs.zizmor.sh/audits/#github-app
+          permission-contents: write
+          permission-pull-requests: write
+
       # No-op when the lock is unchanged; otherwise reuses the `chore/lock-refresh` branch and
       #  updates the existing PR in place.
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ steps.app-token.outputs.token }}
           add-paths: uv.lock
-          # `main` requires signed commits, and the action's default push writes an unsigned one:
-          #  the first run produced `verified=false, reason=unsigned` and a `BLOCKED` PR (#124).
-          #  `sign-commits` commits through the API instead, so GitHub signs it.
+          # Commits through the API so the result carries a verified signature.
           sign-commits: true
           branch: chore/lock-refresh
           delete-branch: true


### PR DESCRIPTION
## What

The monthly lock-refresh PR is opened with an App token instead of `GITHUB_TOKEN`, and the token
is scoped to `contents: write` + `pull-requests: write`. The workflow's own permissions drop to
`contents: read` — it now only needs to check the repository out.

## Why

`GITHUB_TOKEN` cannot open a mergeable PR here in either configuration:

- Plain push (before #126) writes an **unsigned** commit, and `main` requires verified signatures.
  #124 was blocked with `verified=false, reason=unsigned`.
- `sign-commits: true` (#126) fixes the signature — #127 got `committer=GitHub, verified=true` —
  but commits through the API make the PR **bot-authored**, and a first-time author leaves every
  workflow run sitting at `action_required`. The required `CI ok` check is then never reported, so
  #127 is blocked too.

`sign-commits` [ignores the `author`/`committer` inputs](https://github.com/peter-evans/create-pull-request/blob/5f6978faf089d4d20b00c7766989d076bb2fc7f1/docs/concepts-guidelines.md),
so there is no way to keep a human author and a signature at the same time. An App token signs
through the API and its events start workflow runs normally, which closes both halves.

## Setup required before this works

Two repository secrets, from a GitHub App installed on this repository with **Contents:
Read and write** and **Pull requests: Read and write**:

- `AUTOMATION_APP_ID`
- `AUTOMATION_APP_PRIVATE_KEY`

Until they exist the `Mint an App token` step fails, and the monthly job fails with it.

## How to test

Merge, then run the `Refresh dependency lock` workflow manually. The resulting PR should show a
verified signature and a green `CI ok`.