### PR TITLE
ci(lock-refresh): land the monthly lock PR automatically once `CI ok` is green

### DIFF
--- a/.github/workflows/lock-refresh.yml
+++ b/.github/workflows/lock-refresh.yml
@@ -59,6 +59,7 @@ jobs:
       # No-op when the lock is unchanged; otherwise reuses the `chore/lock-refresh` branch and
       #  updates the existing PR in place.
       - name: Open pull request
+        id: pull_request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -74,4 +75,21 @@ jobs:
             Automated monthly `uv lock --upgrade` — refreshes the transitive dependency tree.
 
             `tool.uv.exclude-newer` ("7 days") still applies, so no release younger than the
-            supply-chain quarantine window is included. Review the diff and merge if CI is green.
+            supply-chain quarantine window is included. Auto-merge is on, so this lands on its own
+            once the required `CI ok` check reports green.
+
+      # `--auto` queues the merge behind the required `CI ok`, so a lock that breaks the build stays
+      #  an open PR instead of landing. Only the PR this job just opened is reachable through the
+      #  step output, so no author guard is needed. Merged with the App token rather than
+      #  `GITHUB_TOKEN`, whose pushes cannot start workflows.
+      #  Gated on the PR number, not on `pull-request-operation`: the action sets the number whenever
+      #  an open PR differs from the base, but leaves the operation at `none` when the branch itself
+      #  needed no update — which is every re-run over an already-open lock PR.
+      #  https://github.com/peter-evans/create-pull-request/blob/5f6978faf089d4d20b00c7766989d076bb2fc7f1/src/create-pull-request.ts#L255
+      - name: Enable auto-merge
+        if: steps.pull_request.outputs.pull-request-number != ''
+        run: gh pr merge --auto --squash "$PR_NUMBER"
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pull_request.outputs.pull-request-number }}


### PR DESCRIPTION
## What

The monthly lock-refresh job now flips auto-merge on for the PR it just opened, so a routine
transitive relock lands without a manual click.

## Why

Nothing merged these PRs. The existing `Dependabot auto-merge` workflow is guarded on
`user.login == 'dependabot[bot]'`, and the lock PR is authored by the automation App, so that job
has always been skipped for it — #129 and #130 both sat open with green CI waiting on a human.

The step lives here rather than in the Dependabot workflow for two reasons:

- No author guard is needed. The only PR reachable through `steps.pull_request.outputs` is the one
  this job opened a moment earlier, so it cannot act on anything else.
- It merges with the App token. A merge performed by `GITHUB_TOKEN` does not start push workflows —
  `eae23869`, auto-merged by `github-actions[bot]`, has no push-triggered run, while every other
  commit on `main` has both `CI` and `CodSpeed`.

## Safety

`--auto` queues the merge behind the required `CI ok` check. A lock that breaks the build never
lands; the PR simply stays open. `tool.uv.exclude-newer` ("7 days") still keeps anything inside the
supply-chain quarantine window out of the lock in the first place.

`uv.lock` also has a narrow blast radius here: consumers of the published package resolve against
the bounds in `pyproject.toml`, so the lock only governs CI and local development.

## How to test

Run the `Refresh dependency lock` workflow manually. It should update the existing PR and turn on
auto-merge, and the PR should merge itself once `CI ok` reports green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Automation**
  - Pull requests created or refreshed by the automated workflow are now queued for automatic squash merging.
  - Merging proceeds once the required CI check passes, reducing the need for manual intervention.
  - Pull request messaging now clearly indicates the automatic merge conditions and expected process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->