### PR TITLE
ci(schedule): run the compatibility checks weekly instead of only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Weekly re-run on `main`. The per-PR jobs only ever exercise our own changes, so an upstream
+  #  release that breaks us stays invisible until somebody opens a PR — `test-ceil` resolves with
+  #  `--upgrade` and is what catches it.
+  schedule:
+    # Mondays 06:00 UTC — an hour after `cve-rescan.yml`, same weekly cadence.
+    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -1,18 +1,23 @@
 name: OS matrix
 
-# Manual-only cross-OS sanity sweep (e.g. before a release). Not run on PRs: this library has no
-# OS-specific runtime surface (pure in-memory schema -> model logic; no file I/O, paths, or
-# subprocess), so per-PR cross-OS testing is not worth the cost — the PR matrix stays ubuntu-only.
-# PyPy is omitted: its latest is 3.11, below our `requires-python = ">=3.12"`.
-# 3.15 is omitted: it is a prerelease that builds `pydantic-core` from source (no wheel) on every
-# OS, and it is already covered on ubuntu by the main CI.
+# Cross-OS sanity sweep. Not run on PRs: this library has no OS-specific runtime surface (pure
+#  in-memory schema -> model logic; no file I/O, paths, or subprocess), so per-PR cross-OS testing
+#  is not worth the cost — the PR matrix stays ubuntu-only. It runs weekly instead, because the
+#  compiled dependencies underneath us ship a different wheel per platform, and a break there would
+#  otherwise surface only when somebody remembered to dispatch this by hand.
+#  PyPy is omitted: its latest is 3.11, below our `requires-python = ">=3.12"`.
+#  3.15 is omitted: it is a prerelease that builds `pydantic-core` from source (no wheel) on every
+#  OS, and it is already covered on ubuntu by the main CI.
 on:
+  schedule:
+    # Mondays 07:00 UTC — after `ci.yml`'s weekly run, same cadence.
+    - cron: "0 7 * * 1"
   workflow_dispatch:
 
 permissions:
   contents: read
 
-# Cancel superseded runs: a new dispatch on the same ref aborts the in-flight one.
+# Cancel superseded runs: a new run on the same ref aborts the in-flight one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## What

`ci.yml` and `os-matrix.yml` now also run on a weekly cron:

- `CI` — Mondays 06:00 UTC, an hour after `cve-rescan.yml`.
- `OS matrix` — Mondays 07:00 UTC, after it.

No jobs were added, moved or duplicated. Only the `on:` blocks changed, plus the header comment on
`os-matrix.yml`, which claimed the workflow was manual-only.

## Why

Nothing here currently tests the library against anything but our own changes.

`test-ceil` resolves with `--upgrade`, so it is the one job that would notice a release upstream
breaking us — but it only ever runs when somebody opens a PR. Between PRs a broken dependency sits
undetected, and for a library the usual way that surfaces is a user filing an issue.

`os-matrix.yml` was `workflow_dispatch` only, so Windows and macOS were never exercised unless
someone remembered to press the button. The library itself has no OS-specific surface, but the
compiled dependencies underneath it ship a different wheel per platform.

A scheduled run that fails emails the repository owner, so no issue-filing machinery is needed.

## How to test

Both workflows keep `workflow_dispatch`, so either can be run manually to confirm nothing else
changed. The cron itself first fires on the next Monday.