### PR TITLE
style(conventions): align comments, signatures and annotations with the house rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 # Automated dependency update PRs.
 #
 # NOTE: Dependabot does NOT respect `uv`'s `tool.uv.exclude-newer` — it always targets the latest
-# release. The two are separate systems that only collide at lock time: Dependabot runs `uv` to
-# update `uv.lock`, and `uv` then refuses any version inside the `exclude-newer` window, producing a
-# broken (unlockable) PR. `uv`'s own docs therefore recommend mirroring the cutoff as a `cooldown`.
-# `cooldown.default-days` is duplicated from `tool.uv.exclude-newer` ("7 days") in `pyproject.toml` —
-# keep the two values in sync. See: https://docs.astral.sh/uv/guides/integration/dependabot/
+#  release. The two are separate systems that only collide at lock time: Dependabot runs `uv` to
+#  update `uv.lock`, and `uv` then refuses any version inside the `exclude-newer` window, producing a
+#  broken (unlockable) PR. `uv`'s own docs therefore recommend mirroring the cutoff as a `cooldown`.
+#  `cooldown.default-days` is duplicated from `tool.uv.exclude-newer` ("7 days") in `pyproject.toml` —
+#  keep the two values in sync. See: https://docs.astral.sh/uv/guides/integration/dependabot/
 version: 2
 
 updates:
@@ -14,7 +14,7 @@ updates:
     schedule:
       interval: weekly
     # Canonical cutoff: `tool.uv.exclude-newer` in `pyproject.toml`. Mirrored here so Dependabot
-    # never opens a PR for a version `uv` would refuse to lock.
+    #  never opens a PR for a version `uv` would refuse to lock.
     cooldown:
       default-days: 7
     groups:
@@ -34,7 +34,7 @@ updates:
     schedule:
       interval: weekly
     # `exclude-newer` is a `uv`-only resolver setting and does not cover GitHub Actions, so this is
-    # the *only* supply-chain delay for action bumps. Matched to the Python cutoff for consistency.
+    #  the *only* supply-chain delay for action bumps. Matched to the Python cutoff for consistency.
     cooldown:
       default-days: 7
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # `UV_PYTHON` pins `uv` to the matrix interpreter — otherwise `uv` skips prereleases
-    # (like the `3.15` beta) and silently picks a stable one. (No `UV_NO_SYNC` here: the
-    # `justfile`'s top-level `UV_NO_SYNC`/`UV_FROZEN` exports auto-enable in CI, so `just test`
-    # runs on the `install-test` env without re-syncing.)
+    #  (like the `3.15` beta) and silently picks a stable one. (No `UV_NO_SYNC` here: the
+    #  `justfile`'s top-level `UV_NO_SYNC`/`UV_FROZEN` exports auto-enable in CI, so `just test`
+    #  runs on the `install-test` env without re-syncing.)
     env:
       UV_PYTHON: ${{ matrix.python-version }}
       # `pydantic-core` ships no `cp315` wheel yet, so on 3.15 `uv` builds it from source via
-      # `cargo`, whose crates.io downloads intermittently fail (transient TLS / unexpected EOF).
-      # Make `cargo` retry each download before the step-level retry kicks in.
+      #  `cargo`, whose crates.io downloads intermittently fail (transient TLS / unexpected EOF).
+      #  Make `cargo` retry each download before the step-level retry kicks in.
       CARGO_NET_RETRY: "10"
     strategy:
       fail-fast: false
@@ -82,7 +82,7 @@ jobs:
         uses: ./.github/actions/setup
 
       # Retry the whole install: on 3.15 it builds `pydantic-core` from source, so a flaky
-      # crates.io download (not a code fault) shouldn't fail the run. See `CARGO_NET_RETRY` above.
+      #  crates.io download (not a code fault) shouldn't fail the run. See `CARGO_NET_RETRY` above.
       - name: Install dependencies
         run: |
           for attempt in 1 2 3; do
@@ -114,7 +114,7 @@ jobs:
           flags: python-${{ matrix.python-version }}
 
   # Dependency floor / ceiling: the recipes pin Python and resolution, `uv` provisions the
-  # interpreter, so no `setup-python` is needed.
+  #  interpreter, so no `setup-python` is needed.
   test-floor:
     name: Test (dependency floor)
     runs-on: ubuntu-latest
@@ -152,8 +152,8 @@ jobs:
   audit:
     name: Audit
     # No `needs`: the security audit is independent of lint/test, so it starts immediately and in
-    # parallel instead of waiting for them. A CVE surfaces as its own signal even when a test fails,
-    # rather than being masked behind an unrelated failure. It is still gated by the `check` job.
+    #  parallel instead of waiting for them. A CVE surfaces as its own signal even when a test fails,
+    #  rather than being masked behind an unrelated failure. It is still gated by the `check` job.
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -199,7 +199,7 @@ jobs:
         run: just docs-build
 
   # Single required status check: branch protection points only at this job, so matrix legs
-  # can be added/removed without editing protection rules. Fails if any needed job failed.
+  #  can be added/removed without editing protection rules. Fails if any needed job failed.
   check:
     name: CI ok
     if: always()

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,8 +1,8 @@
 name: CodSpeed
 
 # Continuous benchmarking: runs the `tests/benchmarks/` suite under `CodSpeed`'s simulation
-# instrument and reports performance deltas on each PR (vs the `main` baseline). Not part of the
-# `CI` required-check gate — perf is informational and must never block a merge.
+#  instrument and reports performance deltas on each PR (vs the `main` baseline). Not part of the
+#  `CI` required-check gate — perf is informational and must never block a merge.
 on:
   push:
     branches: [main]
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
       # Tokenless upload for public repos: `CodSpeed` verifies the run via OIDC, so no
-      # `CODSPEED_TOKEN` secret is needed. See https://docs.codspeed.io/integrations/ci/github-actions
+      #  `CODSPEED_TOKEN` secret is needed. See https://docs.codspeed.io/integrations/ci/github-actions
       id-token: write
 
     steps:

--- a/.github/workflows/cve-rescan.yml
+++ b/.github/workflows/cve-rescan.yml
@@ -1,15 +1,15 @@
 name: CVE rescan
 
 # Layer 2 of the CVE gate — a signal, NOT a PR gate. The blocking gate (CI's `Audit`
-# job) scans against a digest-pinned, frozen vulnerability DB for reproducibility; this
-# job re-runs the same scan against the UNPINNED, latest DB to surface advisories
-# published since the pinned digest was last bumped.
+#  job) scans against a digest-pinned, frozen vulnerability DB for reproducibility; this
+#  job re-runs the same scan against the UNPINNED, latest DB to surface advisories
+#  published since the pinned digest was last bumped.
 #
 # When this fails, a new CVE affects the locked dependency graph. Resolve it by bumping
-# the dependency, or — if it cannot be fixed yet — add a scoped `.trivyignore.yaml`
-# entry; then bump the pinned DB digest in `scripts/trivy_scan.sh` so the blocking gate
-# picks the advisory up too. A failed scheduled run notifies via GitHub's standard
-# scheduled-workflow-failure email; no code change is needed to keep it running.
+#  the dependency, or — if it cannot be fixed yet — add a scoped `.trivyignore.yaml`
+#  entry; then bump the pinned DB digest in `scripts/trivy_scan.sh` so the blocking gate
+#  picks the advisory up too. A failed scheduled run notifies via GitHub's standard
+#  scheduled-workflow-failure email; no code change is needed to keep it running.
 #
 # Depends on `scripts/trivy_scan.sh` (added alongside the blocking gate).
 
@@ -42,10 +42,10 @@ jobs:
         uses: ./.github/actions/setup
 
       # `TRIVY_DB_REPOSITORY` overrides the digest pin in `scripts/trivy_scan.sh` with
-      # the floating `:2` tag, so `trivy` pulls the latest DB — the whole point of this
-      # layer. The script's cache-provenance guard drops any DB cached under the pinned
-      # digest before scanning, so the floating result cannot be served from a stale
-      # frozen cache.
+      #  the floating `:2` tag, so `trivy` pulls the latest DB — the whole point of this
+      #  layer. The script's cache-provenance guard drops any DB cached under the pinned
+      #  digest before scanning, so the floating result cannot be served from a stale
+      #  frozen cache.
       - name: Rescan dependencies against the latest CVE DB
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 name: Dependabot auto-merge
 
 # Flip on auto-merge for low-risk Dependabot PRs so patch/minor bumps land without manual clicks.
-# Major bumps and everything from a non-Dependabot author are left for a human to review.
+#  Major bumps and everything from a non-Dependabot author are left for a human to review.
 #
 # Prerequisites (repo settings, one-time):
 #   - Settings -> General -> "Allow auto-merge" must be enabled, or `gh pr merge --auto` errors.
@@ -10,7 +10,7 @@ name: Dependabot auto-merge
 on: pull_request
 
 # Least privilege: only what `gh pr merge --auto` needs. Elevated here (not repo-wide) and applied
-# to Dependabot's otherwise read-only `pull_request` token.
+#  to Dependabot's otherwise read-only `pull_request` token.
 permissions:
   contents: write
   pull-requests: write
@@ -33,8 +33,8 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
       # Only patch/minor auto-merge; `major` (and `lockFileMaintenance`-style) updates always need a
-      # human. `--auto` flips the PR's auto-merge flag, so the merge still waits for the required
-      # `CI ok` status. `--squash` matches the repo's squash-with-PR-title merge policy.
+      #  human. `--auto` flips the PR's auto-merge flag, so the merge still waits for the required
+      #  `CI ok` status. `--squash` matches the repo's squash-with-PR-title merge policy.
       - name: Enable auto-merge
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -34,9 +34,9 @@ jobs:
         # Subset of the canonical `ci.yml` `test` matrix — `3.15` omitted (see the file header).
         python-version: ["3.12", "3.13", "3.14"]
     # `UV_PYTHON` pins `uv` to the matrix interpreter. (The `justfile`'s top-level `UV_NO_SYNC`
-    # export auto-enables in CI, so `just test` stays on the test-only env from `install-test`
-    # without re-syncing — its `--no-default-groups --group test` skips the `docs` group, whose
-    # native deps, e.g. Pillow / imaging, are never pulled on macOS / Windows.)
+    #  export auto-enables in CI, so `just test` stays on the test-only env from `install-test`
+    #  without re-syncing — its `--no-default-groups --group test` skips the `docs` group, whose
+    #  native deps, e.g. Pillow / imaging, are never pulled on macOS / Windows.)
     env:
       UV_PYTHON: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,8 @@ jobs:
           path: dist/
 
       # PEP 740 build attestations (sigstore-signed provenance for each artifact). Already the
-      # default in v1.14.0, but pinned explicitly so a future default change can't silently drop
-      # release provenance. Requires Trusted Publishing + `id-token: write` (set on this job).
+      #  default in v1.14.0, but pinned explicitly so a future default change can't silently drop
+      #  release provenance. Requires Trusted Publishing + `id-token: write` (set on this job).
       - name: Publish distribution to `PyPI`
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,5 +1,5 @@
 # https://github.com/DavidAnson/markdownlint-cli2
-# https://github.com/DavidAnson/markdownlint#rules--aliases
+#  https://github.com/DavidAnson/markdownlint#rules--aliases
 
 globs:
   - "README.md"
@@ -32,8 +32,8 @@ config:
   no-inline-html: false
 
   # Need to disable in order to support PyMdown Tabbed extension and admonitions.
-  # https://facelessuser.github.io/pymdown-extensions/extensions/tabbed/
-  # https://squidfunk.github.io/mkdocs-material/reference/admonitions/
+  #  https://facelessuser.github.io/pymdown-extensions/extensions/tabbed/
+  #  https://squidfunk.github.io/mkdocs-material/reference/admonitions/
   code-block-style: false
 
   # Disabled in order to support references to API.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
       - id: check-ast
       - id: check-case-conflict
       # NOTE: `check-docstring-first` is intentionally omitted — it misreads PEP 224
-      # attribute docstrings (strings after assignments in `schema/_models.py` / `formats/_types.py`)
-      # as a second module docstring and aborts the commit.
+      #  attribute docstrings (strings after assignments in `schema/_models.py` / `formats/_types.py`)
+      #  as a second module docstring and aborts the commit.
       - id: check-executables-have-shebangs
       - id: check-json
       - id: check-shebang-scripts-are-executable
@@ -50,9 +50,9 @@ repos:
       - id: actionlint
 
   # `pre-commit`'s own meta hook: flag `exclude` patterns that no longer match any file.
-  # NOTE: `check-hooks-apply` is intentionally omitted — it would force removing the standard
-  # safety hooks (`check-json` / `check-xml` / ...) that currently match no files but are kept
-  # as cheap insurance for when such files appear.
+  #  NOTE: `check-hooks-apply` is intentionally omitted — it would force removing the standard
+  #  safety hooks (`check-json` / `check-xml` / ...) that currently match no files but are kept
+  #  as cheap insurance for when such files appear.
   - repo: meta
     hooks:
       - id: check-useless-excludes
@@ -92,9 +92,9 @@ repos:
         pass_filenames: false
 
       # NOTE: No dependency-CVE hook here on purpose. `just scan-deps` runs `trivy`
-      # via docker (image + DB pull), which is far too heavy for every commit; the
-      # frozen CVE gate lives in CI's `Audit` job and is available on demand as
-      # `just scan-deps`. The workflow audit below (`zizmor`) is cheap, so it stays.
+      #  via docker (image + DB pull), which is far too heavy for every commit; the
+      #  frozen CVE gate lives in CI's `Audit` job and is available on demand as
+      #  `just scan-deps`. The workflow audit below (`zizmor`) is cheap, so it stays.
       - id: audit-workflows
         name: Audit workflows
         entry: just

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,14 +1,14 @@
 # Accepted-finding ledger for the frozen CVE gate (`scripts/trivy_scan.sh`).
 #
 # Empty by default: we fix advisories rather than suppress them. The scan runs with
-# `--ignore-unfixed`, so a finding only reaches this gate once a FIX exists upstream.
-# Add an entry ONLY when that fix cannot be adopted yet (e.g. it is a breaking major
-# bump we need time to absorb) or the finding is provably not exploitable here.
+#  `--ignore-unfixed`, so a finding only reaches this gate once a FIX exists upstream.
+#  Add an entry ONLY when that fix cannot be adopted yet (e.g. it is a breaking major
+#  bump we need time to absorb) or the finding is provably not exploitable here.
 #
 # Policy: every entry MUST carry a future `expired_at`. trivy re-raises a finding once
-# that date passes, so a dated suppression cannot outlive its justification. An entry
-# WITHOUT the field never expires — trivy does not require it, so this rule is enforced
-# by review, not tooling: do not approve an entry that omits `expired_at`.
+#  that date passes, so a dated suppression cannot outlive its justification. An entry
+#  WITHOUT the field never expires — trivy does not require it, so this rule is enforced
+#  by review, not tooling: do not approve an entry that omits `expired_at`.
 #
 # Schema (trivy structured YAML ignorefile):
 #   vulnerabilities:

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,10 +1,10 @@
 # NOTE: The body/footer templates use careful `-%` whitespace control and
-# `trim = false` because `trim = true` strips trailing newlines from each
-# rendered body, collapsing the blank line between release sections.
-# The `postprocessors` regex collapses 3+ consecutive newlines into exactly 2
-# (one blank line), which satisfies markdownlint MD012 (no-multiple-blanks)
-# and MD022/MD032 (blanks-around-headings/lists).
-# Footer wraps URLs in `<...>` to satisfy markdownlint MD034 (no-bare-urls).
+#  `trim = false` because `trim = true` strips trailing newlines from each
+#  rendered body, collapsing the blank line between release sections.
+#  The `postprocessors` regex collapses 3+ consecutive newlines into exactly 2
+#  (one blank line), which satisfies markdownlint MD012 (no-multiple-blanks)
+#  and MD022/MD032 (blanks-around-headings/lists).
+#  Footer wraps URLs in `<...>` to satisfy markdownlint MD034 (no-bare-urls).
 
 [changelog]
 header = """# Changelog

--- a/examples/custom_formats.py
+++ b/examples/custom_formats.py
@@ -34,8 +34,8 @@ def validate_price(value: float) -> float:
 
 
 # A custom format is a Pydantic type, the same shape as the built-in formats
-# (e.g. `type Email = Annotated[str, AfterValidator(...)]`). The wrapper you pick
-# (`AfterValidator`, `BeforeValidator`, ...) controls when validation runs.
+#  (e.g. `type Email = Annotated[str, AfterValidator(...)]`). The wrapper you pick
+#  (`AfterValidator`, `BeforeValidator`, ...) controls when validation runs.
 type Sku = Annotated[str, AfterValidator(validate_sku)]
 type Price = Annotated[float, AfterValidator(validate_price)]
 

--- a/justfile
+++ b/justfile
@@ -1,16 +1,16 @@
 # Block installing known-malware dependencies (OSV MAL records) before any package code runs.
-# Exported here so every `uv sync` / `uv add` run through `just` is checked — CI and local alike.
-# `malware-check` is a `uv` preview feature; naming it also silences its experimental warning.
+#  Exported here so every `uv sync` / `uv add` run through `just` is checked — CI and local alike.
+#  `malware-check` is a `uv` preview feature; naming it also silences its experimental warning.
 export UV_MALWARE_CHECK := "1"
 export UV_PREVIEW_FEATURES := "malware-check"
 
 # In CI (`$CI` is set by GitHub Actions) skip the per-command auto-sync and pin the lockfile: the
-# environment is provisioned once, up front, by an `install-*` step, so there's no local/CI recipe
-# split — `just lint` / `just test` behave correctly in both. Locally `$CI` is empty, so these
-# resolve to `false` and `uv run` keeps auto-syncing for convenience.
+#  environment is provisioned once, up front, by an `install-*` step, so there's no local/CI recipe
+#  split — `just lint` / `just test` behave correctly in both. Locally `$CI` is empty, so these
+#  resolve to `false` and `uv run` keeps auto-syncing for convenience.
 #
 # NOTE: Normalized to `true`/`false` (not the raw `$CI` value). `just` exports a `:=` variable even
-# when empty, and `uv` rejects an empty boolean:
+#  when empty, and `uv` rejects an empty boolean:
 #   UV_NO_SYNC= uv run ...
 #   # -> error: Failed to parse environment variable `UV_NO_SYNC` with invalid value ``: expected a boolish value
 export UV_NO_SYNC := if env_var_or_default("CI", "") != "" { "true" } else { "false" }
@@ -20,9 +20,9 @@ export UV_FROZEN := if env_var_or_default("CI", "") != "" { "true" } else { "fal
 #  job, which `os-matrix.yml` subsets, sans `3.15`. Keep in sync.
 python_versions := "3.12 3.13 3.14 3.15"
 # Floor = oldest supported (dependency-floor run); ceiling = newest supported (dependency-ceiling
-# run) — currently the `3.15` beta, so breakage surfaces before the October stable release. `uv`
-# resolves `3.15` to the beta because no stable `3.15` exists yet; once one ships it takes over
-# automatically.
+#  run) — currently the `3.15` beta, so breakage surfaces before the October stable release. `uv`
+#  resolves `3.15` to the beta because no stable `3.15` exists yet; once one ships it takes over
+#  automatically.
 python_floor := "3.12"
 python_ceil := "3.15"
 
@@ -100,8 +100,8 @@ lint:
     npx --yes markdownlint-cli2
 
 # Scan the locked dependency graph for known CVEs against a digest-pinned vulnerability DB
-# (frozen for reproducibility). All flags and the DB pin live in `scripts/trivy_scan.sh`,
-# shared verbatim with the CI `Audit` job. Runs `trivy` via docker — no local install needed.
+#  (frozen for reproducibility). All flags and the DB pin live in `scripts/trivy_scan.sh`,
+#  shared verbatim with the CI `Audit` job. Runs `trivy` via docker — no local install needed.
 [doc("Scan uv.lock for known CVEs (frozen, digest-pinned DB)")]
 scan-deps:
     scripts/trivy_scan.sh fs
@@ -111,11 +111,11 @@ audit-workflows:
     uv run zizmor --offline .github/workflows/
 
 # Generate a CycloneDX SBOM of the runtime dependency tree into `sbom/`. On-demand convenience only —
-# deliberately NOT wired into releases: the published wheel's `Requires-Dist` already declares deps,
-# and `just scan-deps` (Trivy) covers active CVE scanning, so this is just a standardized bill-of-materials for
-# anyone who explicitly needs one. `--no-default-groups` restricts it to runtime deps; `uv export`
-# carries hashes for component integrity. `cyclonedx-py` has no native `uv` lockfile support, hence
-# the `requirements` bridge. See https://github.com/CycloneDX/cyclonedx-python/issues/857
+#  deliberately NOT wired into releases: the published wheel's `Requires-Dist` already declares deps,
+#  and `just scan-deps` (Trivy) covers active CVE scanning, so this is just a standardized bill-of-materials for
+#  anyone who explicitly needs one. `--no-default-groups` restricts it to runtime deps; `uv export`
+#  carries hashes for component integrity. `cyclonedx-py` has no native `uv` lockfile support, hence
+#  the `requirements` bridge. See https://github.com/CycloneDX/cyclonedx-python/issues/857
 [doc("Generate a CycloneDX SBOM of the runtime deps into sbom/")]
 sbom:
     #!/usr/bin/env bash
@@ -125,9 +125,9 @@ sbom:
     output_file="sbom/pydantic-jsonschema.cdx.json"
 
     # Export the runtime dependency tree (pinned, with hashes) as requirements, then convert it to a
-    # CycloneDX document. `cyclonedx-py` reads the requirements from stdin (the trailing `-`).
-    # `--frozen` here is explicit: this on-demand recipe must read the lockfile as-is and never
-    # mutate it (the CI-wide `UV_FROZEN` is off locally).
+    #  CycloneDX document. `cyclonedx-py` reads the requirements from stdin (the trailing `-`).
+    #  `--frozen` here is explicit: this on-demand recipe must read the lockfile as-is and never
+    #  mutate it (the CI-wide `UV_FROZEN` is off locally).
     uv export \
         --frozen \
         --no-default-groups \
@@ -178,28 +178,28 @@ test-fix-snapshots:
     uv run pytest --inline-snapshot=fix
 
 # Test the dependency FLOOR: lowest Python + lowest direct deps our bounds allow.
-# `--resolution lowest-direct` re-resolves direct deps to their declared minimums (e.g.
-# `pydantic>=2.13.0` -> `2.13.0`), proving the floor actually resolves and passes. Isolated env
-# (never touches `.venv`); no coverage gate.
+#  `--resolution lowest-direct` re-resolves direct deps to their declared minimums (e.g.
+#  `pydantic>=2.13.0` -> `2.13.0`), proving the floor actually resolves and passes. Isolated env
+#  (never touches `.venv`); no coverage gate.
 #
 # NOTE: `UV_NO_SYNC`/`UV_FROZEN` are forced off here — this recipe MUST sync a throwaway env and MUST
-# re-resolve, both of which conflict with the CI-wide defaults. With `UV_FROZEN=true` it would
-# silently install the *locked* versions instead of the floor, making the test meaningless.
+#  re-resolve, both of which conflict with the CI-wide defaults. With `UV_FROZEN=true` it would
+#  silently install the *locked* versions instead of the floor, making the test meaningless.
 [doc("Test the dependency floor (oldest Python, lowest direct deps)")]
 test-floor:
     UV_NO_SYNC=false UV_FROZEN=false UV_PROJECT_ENVIRONMENT=.venv-floor uv run --python {{python_floor}} --resolution lowest-direct --no-default-groups --group test pytest
 
 # Test the dependency CEILING: newest supported Python + highest resolvable deps.
-# `--upgrade` ignores the lockfile pins and re-resolves to the latest allowed versions (within
-# `tool.uv.exclude-newer` in `pyproject.toml`), catching breakage from a new dependency release
-# before it reaches the lockfile.
-# Isolated env; no coverage gate. See `test-floor` for why the CI-wide flags are cleared.
+#  `--upgrade` ignores the lockfile pins and re-resolves to the latest allowed versions (within
+#  `tool.uv.exclude-newer` in `pyproject.toml`), catching breakage from a new dependency release
+#  before it reaches the lockfile.
+#  Isolated env; no coverage gate. See `test-floor` for why the CI-wide flags are cleared.
 [doc("Test the dependency ceiling (newest supported Python, highest deps)")]
 test-ceil:
     UV_NO_SYNC=false UV_FROZEN=false UV_PROJECT_ENVIRONMENT=.venv-ceil uv run --python {{python_ceil}} --upgrade --no-default-groups --group test pytest
 
 # Run the `CodSpeed` benchmarks (`-m benchmark` overrides the suite-wide `not benchmark`). Locally
-# this measures wall-clock; in CI the `CodSpeedHQ/action` wraps it and records stable measurements.
+#  this measures wall-clock; in CI the `CodSpeedHQ/action` wraps it and records stable measurements.
 [doc("Run the CodSpeed benchmarks")]
 bench:
     uv run pytest --codspeed -m benchmark tests/benchmarks
@@ -243,13 +243,13 @@ docs-delete version:
     uv run mike delete --push {{version}}
 
 # Deploy versioned docs to a single-commit `gh-pages` in CI (history never grows). Kept `ci-`-prefixed
-# because, unlike `docs-deploy`, it configures a bot git identity and force-pushes the remote branch.
+#  because, unlike `docs-deploy`, it configures a bot git identity and force-pushes the remote branch.
 #
 # `mike` keeps every version in the `gh-pages` *tree*, but each `mike deploy --push` adds a
-# commit carrying a full site snapshot, so the branch history balloons over time. Instead we
-# deploy locally (no `--push`), then collapse the whole branch into one orphan commit and
-# force-push it — each release replaces `gh-pages` rather than appending to it.
-# See: https://github.com/ag2ai/ag2/pull/2989
+#  commit carrying a full site snapshot, so the branch history balloons over time. Instead we
+#  deploy locally (no `--push`), then collapse the whole branch into one orphan commit and
+#  force-push it — each release replaces `gh-pages` rather than appending to it.
+#  See: https://github.com/ag2ai/ag2/pull/2989
 [doc("Deploy versioned docs to a single-commit gh-pages branch in CI")]
 ci-docs-deploy version: _ci-configure-git
     #!/usr/bin/env bash
@@ -294,15 +294,15 @@ build:
     uv run twine check dist/*
 
 # Smoke-test a just-published release: install it FROM PyPI into a throwaway env and verify it
-# imports and converts a real schema. `--isolated --no-project` builds the env from the index only
-# (ignores the local source), so this exercises the actual published wheel. `UV_NO_SYNC=false`
-# suppresses uv's "`--no-sync` has no effect with `--no-project`" warning under the CI-wide default.
+#  imports and converts a real schema. `--isolated --no-project` builds the env from the index only
+#  (ignores the local source), so this exercises the actual published wheel. `UV_NO_SYNC=false`
+#  suppresses uv's "`--no-sync` has no effect with `--no-project`" warning under the CI-wide default.
 #
 # NOTE: `--exclude-newer-package "pydantic-jsonschema=2999-12-31"` is required. Our `exclude-newer`
-# cooldown (canonical: `tool.uv.exclude-newer = "7 days"` in `pyproject.toml`) is read because `just`
-# runs inside the repo, so it rejects the just-released version as "too new" (0 days old). The
-# override lifts the cutoff for OUR
-# package only (a far-future date = no limit); dependencies keep the cooldown. Without it:
+#  cooldown (canonical: `tool.uv.exclude-newer = "7 days"` in `pyproject.toml`) is read because `just`
+#  runs inside the repo, so it rejects the just-released version as "too new" (0 days old). The
+#  override lifts the cutoff for OUR
+#  package only (a far-future date = no limit); dependencies keep the cooldown. Without it:
 #   uv run --with 'pydantic-jsonschema==<fresh version>' ...
 #   # -> error: ... filtered by `exclude-newer` ... requirements are unsatisfiable
 [doc("Smoke-test a published release installed from PyPI")]
@@ -337,7 +337,7 @@ release version: (_check-release-version version)
     set -euo pipefail
     version="{{version}}"
     # The changelog lands on `main` via the release PR (`just release-pr`); the tag is a
-    # separate ref, so pushing it never pushes `main` itself.
+    #  separate ref, so pushing it never pushes `main` itself.
     if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
         printf 'Releases are tagged from `main`; current branch is `%s`.\n' "$(git rev-parse --abbrev-ref HEAD)" >&2
         exit 2
@@ -384,7 +384,7 @@ clean:
     rm -rf site
     rm -rf sbom
     # Remove throwaway envs (`.venv312`-`.venv315`, `.venv-floor`, `.venv-ceil`) but keep the
-    # main `.venv` so a clean doesn't force a full re-sync of the working environment.
+    #  main `.venv` so a clean doesn't force a full re-sync of the working environment.
     find . -maxdepth 1 -type d -name ".venv*" ! -name ".venv" -exec rm -rf {} +
     find . -type d -name __pycache__ -exec rm -rf {} +
     find . -type f -name "*.pyc" -delete

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,7 +184,7 @@ plugins:
             members_order: source
             show_bases: true
             # Hide implementation noise: raw attribute values, `type` alias values
-            # (`Email = Annotated[...]`), and the `module-attribute` / `class-attribute` badges.
+            #  (`Email = Annotated[...]`), and the `module-attribute` / `class-attribute` badges.
             show_attribute_values: false
             show_value: false
             show_labels: false
@@ -197,7 +197,7 @@ plugins:
             group_by_category: true
             summary: false
             # `model_config` has no docstring, but the `types` page turns on
-            # `show_if_no_docstring` to list `Schema` fields, so filter it out there.
+            #  `show_if_no_docstring` to list `Schema` fields, so filter it out there.
             filters:
               - "!^_"
               - "!^model_config$"

--- a/pydantic_jsonschema/_utils.py
+++ b/pydantic_jsonschema/_utils.py
@@ -1,13 +1,14 @@
 """Internal utilities for identifier sanitization."""
 
 import re
+from typing import Final
 
 __all__ = [
     "sanitize_identifier",
 ]
 
-_LEADING_NON_ALPHA: re.Pattern[str] = re.compile(r"^[^a-zA-Z_]+")
-_INVALID_CHARS: re.Pattern[str] = re.compile(r"[^a-zA-Z0-9_]")
+_LEADING_NON_ALPHA: Final[re.Pattern[str]] = re.compile(r"^[^a-zA-Z_]+")
+_INVALID_CHARS: Final[re.Pattern[str]] = re.compile(r"[^a-zA-Z0-9_]")
 
 
 def sanitize_identifier(name: str) -> str:

--- a/pydantic_jsonschema/applicators/_base.py
+++ b/pydantic_jsonschema/applicators/_base.py
@@ -83,8 +83,9 @@ class Applicator:
     @staticmethod
     def _validates(
         adapter: TypeAdapter[AnnotationType],
-        value: AnnotationType,
         /,
+        *,
+        value: AnnotationType,
     ) -> bool:
         """Return whether a value validates against a subschema adapter.
 

--- a/pydantic_jsonschema/applicators/_contains.py
+++ b/pydantic_jsonschema/applicators/_contains.py
@@ -88,7 +88,7 @@ class Contains(AnnotationApplicator):
         :param item: An array element (already parsed by the array's item type).
         :returns: `True` when the element validates against `contains`.
         """
-        return self._validates(self._get_adapter(), item)
+        return self._validates(self._get_adapter(), value=item)
 
     def _validate(
         self,

--- a/pydantic_jsonschema/applicators/_contains.py
+++ b/pydantic_jsonschema/applicators/_contains.py
@@ -40,6 +40,7 @@ class Contains(AnnotationApplicator):
         :param max_contains: Maximum number of matching elements (`maxContains`), or `None`.
         """
         super().__init__()
+
         self._branch: AnnotationType = branch
         self._min_contains: int = min_contains
         self._max_contains: int | None = max_contains
@@ -62,11 +63,13 @@ class Contains(AnnotationApplicator):
     ) -> JsonSchemaValue:
         """Restore the `contains` / `minContains` / `maxContains` keywords on dump."""
         json_schema = handler(schema)
+
         json_schema["contains"] = self._get_adapter().json_schema()
         if self._min_contains != _DEFAULT_MIN_CONTAINS:
             json_schema["minContains"] = self._min_contains
         if self._max_contains is not None:
             json_schema["maxContains"] = self._max_contains
+
         return json_schema
 
     def _get_adapter(self) -> TypeAdapter[AnnotationType]:

--- a/pydantic_jsonschema/applicators/_dependent_schemas.py
+++ b/pydantic_jsonschema/applicators/_dependent_schemas.py
@@ -74,7 +74,7 @@ class DependentSchemas(ObjectApplicator):
         for trigger, adapter in self._get_adapters().items():
             if trigger not in data:
                 continue
-            if not self._validates(adapter, data):
+            if not self._validates(adapter, value=data):
                 msg = f"Property `{trigger}` does not satisfy its `dependentSchemas` schema"
                 raise ValueError(msg)
 

--- a/pydantic_jsonschema/applicators/_if_then_else.py
+++ b/pydantic_jsonschema/applicators/_if_then_else.py
@@ -39,6 +39,7 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
         :param else_branch: The `else` subschema applied on no match, or `None`.
         """
         super().__init__()
+
         self._if: AnnotationType = if_branch
         self._then: AnnotationType | None = then_branch
         self._else: AnnotationType | None = else_branch
@@ -70,11 +71,13 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
     def json_schema_keyword(self) -> JsonSchemaValue:
         """Return the `if` / `then` / `else` keyword fragment for the dumped JSON Schema."""
         if_adapter = self._build_adapters()
+
         keyword: JsonSchemaValue = {"if": if_adapter.json_schema()}
         if self._then_adapter is not None:
             keyword["then"] = self._then_adapter.json_schema()
         if self._else_adapter is not None:
             keyword["else"] = self._else_adapter.json_schema()
+
         return keyword
 
     def _build_adapters(self) -> TypeAdapter[AnnotationType]:
@@ -87,10 +90,12 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
 
         if_adapter: TypeAdapter[AnnotationType] = self._build_adapter(self._if)
         self._if_adapter = if_adapter
+
         if self._then is not None:
             self._then_adapter = self._build_adapter(self._then)
         if self._else is not None:
             self._else_adapter = self._build_adapter(self._else)
+
         return if_adapter
 
     @override

--- a/pydantic_jsonschema/applicators/_if_then_else.py
+++ b/pydantic_jsonschema/applicators/_if_then_else.py
@@ -107,11 +107,15 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
         """
         if_adapter = self._build_adapters()
 
-        if self._validates(if_adapter, value):
-            if self._then_adapter is not None and not self._validates(self._then_adapter, value):
+        if self._validates(if_adapter, value=value):
+            if self._then_adapter is not None and not self._validates(
+                self._then_adapter, value=value
+            ):
                 msg = "Value matches `if` but not `then`"
                 raise ValueError(msg)
-        elif self._else_adapter is not None and not self._validates(self._else_adapter, value):
+        elif self._else_adapter is not None and not self._validates(
+            self._else_adapter, value=value
+        ):
             msg = "Value does not match `if` and not `else`"
             raise ValueError(msg)
 

--- a/pydantic_jsonschema/applicators/_if_then_else.py
+++ b/pydantic_jsonschema/applicators/_if_then_else.py
@@ -111,20 +111,18 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
         :raises ValueError: When the selected branch does not validate the value.
         """
         if_adapter = self._build_adapters()
+        matched = self._validates(if_adapter, value=value)
 
-        if self._validates(if_adapter, value=value):
-            if self._then_adapter is not None and not self._validates(
-                self._then_adapter, value=value
-            ):
-                msg = "Value matches `if` but not `then`"
-                raise ValueError(msg)
-        elif self._else_adapter is not None and not self._validates(
-            self._else_adapter, value=value
-        ):
-            msg = "Value does not match `if` and not `else`"
-            raise ValueError(msg)
+        branch_adapter = self._then_adapter if matched else self._else_adapter
+        if branch_adapter is None or self._validates(branch_adapter, value=value):
+            return value
 
-        return value
+        msg = (
+            "Value matches `if` but not `then`"
+            if matched
+            else "Value does not match `if` and not `else`"
+        )
+        raise ValueError(msg)
 
     def _validate(
         self,

--- a/pydantic_jsonschema/applicators/_not.py
+++ b/pydantic_jsonschema/applicators/_not.py
@@ -76,7 +76,7 @@ class Not(AnnotationApplicator, ObjectApplicator):
         :param value: The raw input value.
         :returns: `True` when the value validates against `not` (and so must be rejected).
         """
-        return self._validates(self._get_adapter(), value)
+        return self._validates(self._get_adapter(), value=value)
 
     @override
     def validate(

--- a/pydantic_jsonschema/applicators/_one_of.py
+++ b/pydantic_jsonschema/applicators/_one_of.py
@@ -91,7 +91,7 @@ class OneOf(AnnotationApplicator):
         :raises ValueError: If the value does not match exactly one branch.
         """
         matched_count: int = sum(
-            1 for adapter in self._get_adapters() if self._validates(adapter, value)
+            1 for adapter in self._get_adapters() if self._validates(adapter, value=value)
         )
 
         if matched_count != 1:

--- a/pydantic_jsonschema/applicators/_pattern_properties.py
+++ b/pydantic_jsonschema/applicators/_pattern_properties.py
@@ -78,7 +78,7 @@ class PatternProperties(ObjectApplicator):
                 # ECMA-262 `patternProperties` is unanchored; `re.search` matches anywhere.
                 if not pattern.search(str(name)):
                     continue
-                if not self._validates(adapter, value):
+                if not self._validates(adapter, value=value):
                     msg = f"Property `{name}` does not satisfy its `patternProperties` schema"
                     raise ValueError(msg)
 

--- a/pydantic_jsonschema/applicators/_prefix_items.py
+++ b/pydantic_jsonschema/applicators/_prefix_items.py
@@ -37,6 +37,7 @@ class PrefixItems(AnnotationApplicator):
             is absent (extra elements are then unconstrained).
         """
         super().__init__()
+
         self._prefixes: tuple[AnnotationType, ...] = tuple(prefixes)
         self._tail: AnnotationType | None = tail
         self._prefix_adapters: list[TypeAdapter[AnnotationType]] | None = None
@@ -60,11 +61,13 @@ class PrefixItems(AnnotationApplicator):
         """Restore the `prefixItems` (and tail `items`) keywords on dump."""
         json_schema = handler(schema)
         self._build_adapters()
+
         json_schema["prefixItems"] = [
             adapter.json_schema() for adapter in self._prefix_adapters or []
         ]
         if self._tail_adapter is not None:
             json_schema["items"] = self._tail_adapter.json_schema()
+
         return json_schema
 
     def _build_adapters(self) -> None:

--- a/pydantic_jsonschema/applicators/_property_names.py
+++ b/pydantic_jsonschema/applicators/_property_names.py
@@ -67,7 +67,7 @@ class PropertyNames(ObjectApplicator):
 
         adapter = self._get_adapter()
         for name in data:
-            if not self._validates(adapter, name):
+            if not self._validates(adapter, value=name):
                 msg = f"Property name `{name}` does not satisfy the `propertyNames` schema"
                 raise ValueError(msg)
 

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -1,8 +1,8 @@
 """Convert a JSON Schema `Schema` into a Pydantic model (`to_model` / `SchemaConverter`)."""
 
 # NOTE: `Schema` fields use `X | MISSING` unions (see `schema/_models.py`). mypy doesn't
-# recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
-# and flags every `is not MISSING` check as a non-overlapping identity comparison.
+#  recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
+#  and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
 from collections.abc import Generator
@@ -70,10 +70,10 @@ _DEFAULT_MODEL_NAME: Final[str] = "Model"
 _MIN_DISCRIMINATED_UNION_MEMBERS: Final[int] = 2
 
 # NOTE: `ARRAY` / `OBJECT` entries are only reachable from multi-type unions
-# (`{"type": ["object", "string"]}`) — single `array` / `object` schemas are handled
-# by `_type_annotation` before the mapping is consulted.
-# `OBJECT` must not map to `Any`: `Union[Any, str]` collapses to `Any`,
-# and the union stops rejecting anything.
+#  (`{"type": ["object", "string"]}`) — single `array` / `object` schemas are handled
+#  by `_type_annotation` before the mapping is consulted.
+#  `OBJECT` must not map to `Any`: `Union[Any, str]` collapses to `Any`,
+#  and the union stops rejecting anything.
 _DATA_TYPE_ANNOTATION_MAPPING: Final[dict[DataType, type]] = {
     DataType.NULL: NoneType,
     DataType.STRING: str,
@@ -289,8 +289,8 @@ class SchemaConverter:
             return self._create_root_model(schema, model_name=model_name)
 
         # Root object without `properties` but with schema-valued `additionalProperties`
-        # -> `RootModel[dict[str, ...]]`, so values are validated the same way as in
-        # nested objects (a plain `BaseModel` with `extra="allow"` would not check them).
+        #  -> `RootModel[dict[str, ...]]`, so values are validated the same way as in
+        #  nested objects (a plain `BaseModel` with `extra="allow"` would not check them).
         if (
             schema.properties is MISSING
             and schema.all_of is MISSING
@@ -348,8 +348,8 @@ class SchemaConverter:
         applicators = self._build_object_applicators(schema)
 
         # For some reason, `create_model` "accepts" `fields` values as `tuple[str, Any]`,
-        # when in reality it accepts `tuple[type, FieldInfo]`. Neither `mypy` nor `pyright` can
-        # match the `**fields` splat to a `create_model` overload.
+        #  when in reality it accepts `tuple[type, FieldInfo]`. Neither `mypy` nor `pyright` can
+        #  match the `**fields` splat to a `create_model` overload.
         created_model = create_model(  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue]
             model_name,
             __config__=model_config,
@@ -537,8 +537,8 @@ class SchemaConverter:
         defs = get_inline_defs(schema)
 
         # Convert each def with its ref marked in-progress, so a body that references the def
-        # currently being built (a recursive / mutual `$ref`) defers to a `ForwardRef` instead
-        # of recursing forever. `_rebuild_def_models` binds those refs once every model exists.
+        #  currently being built (a recursive / mutual `$ref`) defers to a `ForwardRef` instead
+        #  of recursing forever. `_rebuild_def_models` binds those refs once every model exists.
         for ref, schema_def in defs.items():
             self._defs_cache[ref] = schema_def
             self._building.add(ref)
@@ -668,14 +668,15 @@ class SchemaConverter:
 
                 if isinstance(field_schema, Reference):
                     # Defer a recursive / mutual ref (its target def is still building) to a
-                    # `ForwardRef`, bound later by `_rebuild_def_models`. Otherwise resolve
-                    # eagerly, so an unknown `$ref` still raises here instead of silently deferring.
+                    #  `ForwardRef`, bound later by `_rebuild_def_models`. Otherwise resolve
+                    #  eagerly, so an unknown `$ref` still raises here instead of silently
+                    #  deferring.
                     if field_schema.ref in self._building:
                         annotation = ForwardRef(sanitize_identifier(field_schema.ref))
                     else:
                         annotation = self._get_model(field_schema.ref)
                     # A local `$ref` carries its own field metadata in `$defs`; an unknown
-                    # ref (external / pre-built) contributes none, so fall back to an empty schema.
+                    #  ref (external / pre-built) contributes none, so fall back to an empty schema.
                     schema_for_field = self._defs_cache.get(field_schema.ref, Schema())
                 else:
                     schema_for_field = field_schema
@@ -718,8 +719,8 @@ class SchemaConverter:
         format_type = self._formats[schema.format]
 
         # Built-in format types (`Email`, `UUID`, ...) are PEP 695 `type` aliases, i.e.
-        # `TypeAliasType`. Unwrap to the actual `Annotated` / class they alias so the field
-        # annotation stays clean (`str`, `uuid.UUID`) instead of the alias wrapper.
+        #  `TypeAliasType`. Unwrap to the actual `Annotated` / class they alias so the field
+        #  annotation stays clean (`str`, `uuid.UUID`) instead of the alias wrapper.
         if isinstance(format_type, TypeAliasType):
             format_type = format_type.__value__
 
@@ -833,8 +834,8 @@ class SchemaConverter:
             )
 
         # `not` and `if` / `then` / `else` are checked against the raw value before the host type,
-        # attached as `Annotated` wrap-validator metadata (the path used for every shape that has a
-        # host annotation; root object models take the `before`-validator path instead).
+        #  attached as `Annotated` wrap-validator metadata (the path used for every shape that has a
+        #  host annotation; root object models take the `before`-validator path instead).
         if schema.not_ is not MISSING:
             annotation = cast("type", Annotated[annotation, self._build_not(schema)])
         if self._has_conditional(schema):
@@ -993,8 +994,8 @@ class SchemaConverter:
         :returns: Resolved model or `ForwardRef` for later resolution.
         """
         # A ref to a def whose model is still being built (a recursive or mutual `$ref`)
-        # must defer: returning its half-built model would recurse forever. The `ForwardRef`
-        # is bound once every def model exists (`_rebuild_def_models` / `_bind_forward_refs`).
+        #  must defer: returning its half-built model would recurse forever. The `ForwardRef`
+        #  is bound once every def model exists (`_rebuild_def_models` / `_bind_forward_refs`).
         if reference.ref in self._building:
             return ForwardRef(sanitize_identifier(reference.ref))
 
@@ -1016,7 +1017,7 @@ class SchemaConverter:
         values = schema.enum if schema.enum is not MISSING else (schema.const,)
 
         # An empty `enum` has no valid value; `Literal[()]` makes Pydantic raise a bare
-        # `AssertionError` deep in schema generation, so reject it with a library error instead.
+        #  `AssertionError` deep in schema generation, so reject it with a library error instead.
         if not values:
             msg = "`enum` must contain at least one value"
             raise SchemaConversionError(msg)
@@ -1074,7 +1075,7 @@ class SchemaConverter:
         discriminator = discriminator_property(schema.one_of, defs_cache=self._defs_cache)
 
         # A discriminated union needs >= 2 concrete members to introspect the tag field.
-        # Unresolved `ForwardRef` branches keep the `OneOf` lazy path.
+        #  Unresolved `ForwardRef` branches keep the `OneOf` lazy path.
         if (
             discriminator is not None
             and len(union_args) >= _MIN_DISCRIMINATED_UNION_MEMBERS
@@ -1109,7 +1110,7 @@ class SchemaConverter:
             return make_union(union_args)
 
         # `Any` is a valid annotation but is not a `type`, so `pyright` rejects it under the
-        # `-> type` return; the same `Any`-as-annotation pattern recurs below for `item_type`.
+        #  `-> type` return; the same `Any`-as-annotation pattern recurs below for `item_type`.
         return Any  # pyright: ignore[reportReturnType]
 
     def _array_annotation(
@@ -1123,8 +1124,8 @@ class SchemaConverter:
         :returns: `list[...]` annotation, wrapped with array constraint metadata when set.
         """
         # With `prefixItems`, element types are positional, so the base stays `list[Any]` and
-        # `PrefixItems` validates each position (including the `items` tail). Without it, `items`
-        # is the homogeneous element type.
+        #  `PrefixItems` validates each position (including the `items` tail). Without it, `items`
+        #  is the homogeneous element type.
         prefix_items = self._build_prefix_items(schema)
 
         item_type: type | ForwardRef = Any  # pyright: ignore[reportAssignmentType]

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -165,7 +165,7 @@ class SchemaConverter:
         self._build_defs_cache(schema)
 
         model = self._build_model(schema, model_name=model_name)
-        model = self._wrap_root_value_assertions(model, schema)
+        model = self._wrap_root_value_assertions(model, schema=schema)
         self._bind_forward_refs()
 
         return model
@@ -173,8 +173,9 @@ class SchemaConverter:
     def _wrap_root_value_assertions(
         self,
         model: type[BaseModel],
-        schema: Schema,
         /,
+        *,
+        schema: Schema,
     ) -> type[BaseModel]:
         """Attach `not` / `if` / `then` / `else` to a root object model.
 
@@ -195,7 +196,7 @@ class SchemaConverter:
             applicators.append(self._build_not(schema))
         if self._has_conditional(schema):
             applicators.append(self._build_conditional(schema))
-        return self._wrap_object_applicators(model, applicators)
+        return self._wrap_object_applicators(model, applicators=applicators)
 
     def _register[ApplicatorT: Applicator](
         self,
@@ -359,7 +360,10 @@ class SchemaConverter:
             __validators__=validators,
             **fields,  # pyright: ignore[reportArgumentType]
         )
-        return self._wrap_object_applicators(cast("type[BaseModel]", created_model), applicators)
+        return self._wrap_object_applicators(
+            cast("type[BaseModel]", created_model),
+            applicators=applicators,
+        )
 
     def _build_object_validators(
         self,
@@ -402,8 +406,9 @@ class SchemaConverter:
     def _wrap_object_applicators(
         self,
         model: type[BaseModel],
-        applicators: list[ObjectApplicator],
         /,
+        *,
+        applicators: list[ObjectApplicator],
     ) -> type[BaseModel]:
         """Subclass an object model so its applicators validate and round-trip into JSON Schema.
 
@@ -694,8 +699,9 @@ class SchemaConverter:
     def _apply_format(
         self,
         annotation: AnnotationType,
-        schema: Schema,
         /,
+        *,
+        schema: Schema,
     ) -> AnnotationType:
         """Apply the registered format type for the schema's `format`, if any.
 
@@ -771,7 +777,7 @@ class SchemaConverter:
         else:
             valid_annotation = annotation
 
-        valid_annotation = self._apply_format(valid_annotation, schema)
+        valid_annotation = self._apply_format(valid_annotation, schema=schema)
 
         default = get_field_default(schema, field_kind=field_kind)
 
@@ -846,8 +852,9 @@ class SchemaConverter:
     def _apply_sibling_type(
         self,
         annotation: type,
-        schema: Schema,
         /,
+        *,
+        schema: Schema,
     ) -> type:
         """Enforce a `type` declared alongside `anyOf` / `oneOf` / `allOf`.
 
@@ -916,7 +923,7 @@ class SchemaConverter:
         if isinstance(schema, Reference):
             return annotation
 
-        annotation = self._apply_format(annotation, schema)
+        annotation = self._apply_format(annotation, schema=schema)
         kwargs = build_field_kwargs(schema, include_metadata=not union_branch)
 
         if kwargs and not (union_branch and annotation is Any):
@@ -1050,7 +1057,7 @@ class SchemaConverter:
         else:
             return None
 
-        return self._apply_sibling_type(annotation, schema)
+        return self._apply_sibling_type(annotation, schema=schema)
 
     def _one_of_annotation(
         self,
@@ -1142,7 +1149,7 @@ class SchemaConverter:
         if contains is not None:
             metadata.append(contains)
 
-        return annotate(list_annotation, metadata)
+        return annotate(list_annotation, metadata=metadata)
 
     def _build_prefix_items(
         self,
@@ -1219,9 +1226,9 @@ class SchemaConverter:
             with self._track_path("additionalProperties"):
                 value_annotation = self._schema_to_annotation(schema.additional_properties)
                 dict_annotation = dict[str, value_annotation]  # type: ignore[valid-type]
-                return annotate(dict_annotation, object_dict_metadata(schema))
+                return annotate(dict_annotation, metadata=object_dict_metadata(schema))
 
-        return annotate(dict[str, Any], object_dict_metadata(schema))
+        return annotate(dict[str, Any], metadata=object_dict_metadata(schema))
 
 
 def to_model(

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -1086,7 +1086,7 @@ class SchemaConverter:
         if (
             discriminator is not None
             and len(union_args) >= _MIN_DISCRIMINATED_UNION_MEMBERS
-            and not any(isinstance(arg, ForwardRef) for arg in union_args)
+            and not any(isinstance(member, ForwardRef) for member in union_args)
         ):
             discriminated = Annotated[make_union(union_args), Field(discriminator=discriminator)]  # type: ignore[valid-type]
             return cast("type", discriminated)

--- a/pydantic_jsonschema/converters/_discriminator.py
+++ b/pydantic_jsonschema/converters/_discriminator.py
@@ -6,8 +6,8 @@ probing `OneOf` validator.
 """
 
 # NOTE: `Schema` fields use `X | MISSING` unions (see `schema/_models.py`). mypy doesn't
-# recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
-# and flags every `is not MISSING` check as a non-overlapping identity comparison.
+#  recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
+#  and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
 from types import NoneType
@@ -53,7 +53,7 @@ def discriminator_property(
             tags_by_property.setdefault(name, []).append(tag)
 
     # A discriminator tags every branch (count of tags == branch count)
-    # with a distinct value (count of unique tags == branch count).
+    #  with a distinct value (count of unique tags == branch count).
     qualified: list[str] = [
         name
         for name, tags in tags_by_property.items()
@@ -110,9 +110,9 @@ def _branch_tag_values(
             continue
 
         # NOTE: Only scalar tags are accepted. `discriminator_property` puts these
-        # values in a `set()` to check distinctness across branches, so a non-hashable
-        # `const` (array/object) would crash. `float` is excluded on purpose:
-        # float-equality discrimination is fragile, so such unions fall back to `OneOf`.
+        #  values in a `set()` to check distinctness across branches, so a non-hashable
+        #  `const` (array/object) would crash. `float` is excluded on purpose:
+        #  float-equality discrimination is fragile, so such unions fall back to `OneOf`.
         if isinstance(tag, (str, int, NoneType)):
             tags[name] = tag
 

--- a/pydantic_jsonschema/converters/_field_kwargs.py
+++ b/pydantic_jsonschema/converters/_field_kwargs.py
@@ -1,8 +1,8 @@
 """`FieldInfo` kwargs and defaults derived from JSON Schema constraints."""
 
 # NOTE: `Schema` fields use `X | MISSING` unions (see `schema/_models.py`). mypy doesn't
-# recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
-# and flags every `is not MISSING` check as a non-overlapping identity comparison.
+#  recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
+#  and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
 from types import EllipsisType
@@ -24,7 +24,7 @@ __all__ = [
 type FieldKindType = Literal["required", "optional", "root"]  # How a field is used in a model
 
 # Pydantic's "required, no default" marker for a field default (`...`).
-# See: https://github.com/pydantic/pydantic/blob/6800281ba87625346daf5826563740ded8a9851b/pydantic/fields.py#L241-L247
+#  See: https://github.com/pydantic/pydantic/blob/6800281ba87625346daf5826563740ded8a9851b/pydantic/fields.py#L241-L247
 _PYDANTIC_DEFAULT_MISSING: Final[EllipsisType] = ...
 
 
@@ -110,13 +110,13 @@ def get_field_default(
         return schema.default
 
     # Root model values have no "absent" concept:
-    # a bare `{"type": "string"}` root schema always validates a value.
+    #  a bare `{"type": "string"}` root schema always validates a value.
     if field_kind == "root":
         return _PYDANTIC_DEFAULT_MISSING
 
     # Optional field without explicit default -> `MISSING` sentinel, so the
-    # field is omitted from dumps instead of carrying a fabricated `None`
-    # default that would not even validate against the annotation.
+    #  field is omitted from dumps instead of carrying a fabricated `None`
+    #  default that would not even validate against the annotation.
     return MISSING
 
 

--- a/pydantic_jsonschema/converters/_metadata.py
+++ b/pydantic_jsonschema/converters/_metadata.py
@@ -81,8 +81,10 @@ def object_dict_metadata(schema: Schema, /) -> list[Any]:
     :returns: Length metadata for `minProperties` / `maxProperties` (add a keyword's check here).
     """
     metadata: list[Any] = []
+
     if schema.min_properties is not MISSING:
         metadata.append(annotated_types.MinLen(schema.min_properties))
     if schema.max_properties is not MISSING:
         metadata.append(annotated_types.MaxLen(schema.max_properties))
+
     return metadata

--- a/pydantic_jsonschema/converters/_metadata.py
+++ b/pydantic_jsonschema/converters/_metadata.py
@@ -49,7 +49,7 @@ def _ensure_unique_items(value: list[Any], /) -> list[Any]:
     return value
 
 
-def annotate(annotation: AnnotationType, metadata: list[Any], /) -> type:
+def annotate(annotation: AnnotationType, /, *, metadata: list[Any]) -> type:
     """Wrap an annotation with `Annotated` metadata (validators / constraints).
 
     :param annotation: Base annotation (e.g. `list[int]`, `dict[str, int]`).

--- a/pydantic_jsonschema/converters/_metadata.py
+++ b/pydantic_jsonschema/converters/_metadata.py
@@ -1,8 +1,8 @@
 """`Annotated` metadata helpers for array / object value annotations."""
 
 # NOTE: `Schema` fields use `X | MISSING` unions (see `schema/_models.py`). mypy doesn't
-# recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
-# and flags every `is not MISSING` check as a non-overlapping identity comparison.
+#  recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
+#  and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
 from typing import Annotated, Any, cast

--- a/pydantic_jsonschema/converters/_object_keywords.py
+++ b/pydantic_jsonschema/converters/_object_keywords.py
@@ -7,8 +7,8 @@ converter-aware ones (`dependentSchemas` / `patternProperties` / `propertyNames`
 """
 
 # NOTE: `Schema` fields use `X | MISSING` unions (see `schema/_models.py`). mypy doesn't
-# recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
-# and flags every `is not MISSING` check as a non-overlapping identity comparison.
+#  recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
+#  and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
 from typing import Any

--- a/pydantic_jsonschema/converters/_refs.py
+++ b/pydantic_jsonschema/converters/_refs.py
@@ -7,8 +7,8 @@ circular, or dangling targets. They are stateless: alias resolution depends only
 """
 
 # NOTE: `Schema` fields use `X | MISSING` unions (see `schema/_models.py`). mypy doesn't
-# recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
-# and flags every `is not MISSING` check as a non-overlapping identity comparison.
+#  recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
+#  and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
 from typing import Final
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 # JSON Schema 2020-12 definitions key
-# See: https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.4
+#  See: https://json-schema.org/draft/2020-12/json-schema-core#section-8.2.4
 DEFS_KEY: Final[str] = "$defs"
 
 

--- a/pydantic_jsonschema/converters/_utils.py
+++ b/pydantic_jsonschema/converters/_utils.py
@@ -1,8 +1,8 @@
 """Small shared utilities for the converter package."""
 
 # NOTE: `Schema` fields use `X | MISSING` unions (see `schema/_models.py`). mypy doesn't
-# recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
-# and flags every `is not MISSING` check as a non-overlapping identity comparison.
+#  recognize `MISSING` as a type, so it infers fields without the `Sentinel` branch
+#  and flags every `is not MISSING` check as a non-overlapping identity comparison.
 # mypy: disable-error-code="comparison-overlap"
 
 from typing import Any, Union, cast

--- a/pydantic_jsonschema/formats/_email.py
+++ b/pydantic_jsonschema/formats/_email.py
@@ -17,20 +17,20 @@ __all__ = [
 ]
 
 # See: https://www.rfc-editor.org/rfc/rfc5321#section-4.1.2
-# Local part: dot-separated atoms of atext characters (letters, digits, and specials).
+#  Local part: dot-separated atoms of atext characters (letters, digits, and specials).
 _LOCAL_RE: Final[re.Pattern[str]] = re.compile(
     r"^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*$",
 )
 
 # See: https://www.rfc-editor.org/rfc/rfc6531#section-3.3
-# SMTPUTF8 extends atext with any non-ASCII character (`UTF8-non-ascii`).
+#  SMTPUTF8 extends atext with any non-ASCII character (`UTF8-non-ascii`).
 _IDN_LOCAL_RE: Final[re.Pattern[str]] = re.compile(
     r"^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~\u0080-\U0010FFFF-]+"
     r"(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~\u0080-\U0010FFFF-]+)*$",
 )
 
 # See: https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1
-# RFC 6531 keeps the same octet limits, so IDN checks count UTF-8 bytes.
+#  RFC 6531 keeps the same octet limits, so IDN checks count UTF-8 bytes.
 _MAX_LOCAL_LENGTH: Final[int] = 64
 _MAX_EMAIL_LENGTH: Final[int] = 254
 

--- a/pydantic_jsonschema/formats/_hostname.py
+++ b/pydantic_jsonschema/formats/_hostname.py
@@ -16,17 +16,17 @@ __all__ = [
 ]
 
 # See: https://www.rfc-editor.org/rfc/rfc1123#section-2.1
-# Each label: 1-63 alphanumeric/hyphen chars, no leading/trailing hyphen.
-# Trailing dot allowed (absolute FQDN).
-# Case-insensitive.
+#  Each label: 1-63 alphanumeric/hyphen chars, no leading/trailing hyphen.
+#  Trailing dot allowed (absolute FQDN).
+#  Case-insensitive.
 _HOSTNAME_RE: Final[re.Pattern[str]] = re.compile(
     r"^(?!-)[-A-Z\d]{1,63}(?<!-)(?:\.(?!-)[-A-Z\d]{1,63}(?<!-))*\.?$",
     re.IGNORECASE,
 )
 
 # See: https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4
-# RFC 1035 specifies 255 octets in wire format (length-prefixed labels + null terminator).
-# Text representation replaces those 2 overhead bytes with dot separators: 255 - 2 = 253.
+#  RFC 1035 specifies 255 octets in wire format (length-prefixed labels + null terminator).
+#  Text representation replaces those 2 overhead bytes with dot separators: 255 - 2 = 253.
 _MAX_HOSTNAME_LENGTH: Final[int] = 253
 
 

--- a/pydantic_jsonschema/formats/_json_pointer.py
+++ b/pydantic_jsonschema/formats/_json_pointer.py
@@ -15,15 +15,15 @@ __all__ = [
 ]
 
 # See: https://www.rfc-editor.org/rfc/rfc6901#section-3
-# Zero or more `/`-prefixed reference tokens; `~` is only valid as `~0` / `~1`.
-# The empty string is a valid pointer (it references the whole document).
-# NOTE: `S105` is a false positive: "reference-token" is the RFC 6901 ABNF rule
-# name for a pointer segment, not a credential.
+#  Zero or more `/`-prefixed reference tokens; `~` is only valid as `~0` / `~1`.
+#  The empty string is a valid pointer (it references the whole document).
+#  NOTE: `S105` is a false positive: "reference-token" is the RFC 6901 ABNF rule
+#  name for a pointer segment, not a credential.
 _REFERENCE_TOKEN: Final[str] = r"(?:[^/~]|~[01])*"  # noqa: S105
 _JSON_POINTER_RE: Final[re.Pattern[str]] = re.compile(rf"^(?:/{_REFERENCE_TOKEN})*$")
 
 # See: https://datatracker.ietf.org/doc/html/draft-bhutton-relative-json-pointer-00#section-3
-# Non-negative integer without leading zeros, followed by `#` or a JSON Pointer.
+#  Non-negative integer without leading zeros, followed by `#` or a JSON Pointer.
 _RELATIVE_JSON_POINTER_RE: Final[re.Pattern[str]] = re.compile(
     rf"^(?:0|[1-9][0-9]*)(?:#|(?:/{_REFERENCE_TOKEN})*)$",
 )

--- a/pydantic_jsonschema/formats/_uri.py
+++ b/pydantic_jsonschema/formats/_uri.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 # See: https://www.rfc-editor.org/rfc/rfc3986#appendix-B
-# Decompose a URI-reference into scheme, authority, path, query, and fragment.
+#  Decompose a URI-reference into scheme, authority, path, query, and fragment.
 #
 # NOTE: Quantifiers are possessive (`++`/`*+`) to keep matching linear: the `scheme`,
 #       `authority`, `path`, and query character classes overlap, so on non-matching
@@ -34,12 +34,12 @@ _URI_RE: Final[re.Pattern[str]] = re.compile(
 )
 
 # See: https://www.rfc-editor.org/rfc/rfc3986#section-3.1
-# Scheme starts with a letter, followed by any combination of letters, digits, `+`, `-`, `.`.
+#  Scheme starts with a letter, followed by any combination of letters, digits, `+`, `-`, `.`.
 _SCHEME_RE: Final[re.Pattern[str]] = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*$")
 
 # See: https://www.rfc-editor.org/rfc/rfc3986#section-3.2
-# Authority = [userinfo@]host[:port]. Host is either an IPv6 literal in brackets or a reg-name.
-# Port must be digits-only; non-numeric port or unclosed IPv6 bracket fails to match.
+#  Authority = [userinfo@]host[:port]. Host is either an IPv6 literal in brackets or a reg-name.
+#  Port must be digits-only; non-numeric port or unclosed IPv6 bracket fails to match.
 _AUTHORITY_RE: Final[re.Pattern[str]] = re.compile(
     r"^(?:[^@]*@)?"
     r"(?:\[(?P<ipv6>[^\]]+)\]|(?P<host>[^:\[\]]*))"
@@ -47,7 +47,7 @@ _AUTHORITY_RE: Final[re.Pattern[str]] = re.compile(
 )
 
 # See: https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
-# IPv4 address: four decimal octets (0-255) separated by dots.
+#  IPv4 address: four decimal octets (0-255) separated by dots.
 _IPV4_RE: Final[re.Pattern[str]] = re.compile(r"^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$")
 
 _MAX_IPV4_OCTET: Final[int] = 255

--- a/pydantic_jsonschema/formats/_uri_template.py
+++ b/pydantic_jsonschema/formats/_uri_template.py
@@ -17,12 +17,12 @@ _VARNAME: Final[str] = rf"{_VARCHAR}(?:\.?{_VARCHAR})*"
 _VARSPEC: Final[str] = rf"{_VARNAME}(?::[1-9][0-9]{{0,3}}|\*)?"
 
 # See: https://www.rfc-editor.org/rfc/rfc6570#section-2.2
-# Expression = `{` + optional operator + comma-separated varspec list + `}`.
+#  Expression = `{` + optional operator + comma-separated varspec list + `}`.
 _EXPRESSION: Final[str] = rf"\{{[+#./;?&=,!@|]?{_VARSPEC}(?:,{_VARSPEC})*\}}"
 
 # See: https://www.rfc-editor.org/rfc/rfc6570#section-2.1
-# Literals: any character except controls, space, and `" ' % < > \ ^ ` { | }`;
-# `%` is only allowed as a percent-encoded triplet.
+#  Literals: any character except controls, space, and `" ' % < > \ ^ ` { | }`;
+#  `%` is only allowed as a percent-encoded triplet.
 _LITERAL: Final[str] = r"(?:[^\x00-\x20\x7f\"'%<>\\^`{|}]|%[0-9A-Fa-f]{2})"
 
 _URI_TEMPLATE_RE: Final[re.Pattern[str]] = re.compile(rf"^(?:{_LITERAL}|{_EXPRESSION})*$")

--- a/pydantic_jsonschema/schema/_models.py
+++ b/pydantic_jsonschema/schema/_models.py
@@ -5,8 +5,8 @@ Validation: https://json-schema.org/draft/2020-12/json-schema-validation
 """
 
 # NOTE: `pydantic.experimental.missing_sentinel.MISSING` is a `Sentinel` instance,
-# not a type — mypy rejects `field: X | MISSING` as invalid. Pydantic itself
-# handles the union correctly at runtime via `from __future__ import annotations`.
+#  not a type — mypy rejects `field: X | MISSING` as invalid. Pydantic itself
+#  handles the union correctly at runtime via `from __future__ import annotations`.
 # mypy: disable-error-code="valid-type"
 
 from __future__ import annotations as _annotations
@@ -130,8 +130,8 @@ class Schema(BaseModel):
     """The `oneOf` keyword: must match exactly one subschema. [Core §10.2.1.3](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.3)."""
 
     # NOTE: `not` / `if` / `else` are Python reserved words, so the fields use a trailing
-    # underscore with an explicit alias. `populate_by_name=True` keeps both forms loadable
-    # (e.g. `Schema(if_=...)` and `Schema.model_validate({"if": ...})`); dumps use the alias.
+    #  underscore with an explicit alias. `populate_by_name=True` keeps both forms loadable
+    #  (e.g. `Schema(if_=...)` and `Schema.model_validate({"if": ...})`); dumps use the alias.
     not_: SchemaOrRefType | MISSING = Field(default=MISSING, alias="not")
     """The `not` keyword: must NOT match this subschema. [Core §10.2.1.4](https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.4)."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
 ]
 dependencies = [
     # NOTE: `2.12.0` is the floor for `pydantic.experimental.missing_sentinel`,
-    # but `2.12.x` emits `PydanticSerializationUnexpectedValue` warnings on every
-    # `Schema.model_dump()` with nested schemas. Clean from `2.13.0`.
+    #  but `2.12.x` emits `PydanticSerializationUnexpectedValue` warnings on every
+    #  `Schema.model_dump()` with nested schemas. Clean from `2.13.0`.
     #
     # Reproduce on `2.12.5`:
     #   uv run --with 'pydantic==2.12.5' -m pytest -q
@@ -60,7 +60,7 @@ dev = [
     {include-group = "audit"},
 ]
 # `pytest-codspeed` provides the `benchmark` fixture and powers the `CodSpeed` CI job. Kept out of
-# the `test` group so the coverage-gated suite never pulls it (and the floor/ceiling runs stay lean).
+#  the `test` group so the coverage-gated suite never pulls it (and the floor/ceiling runs stay lean).
 benchmark = [
     {include-group = "test"},
     "pytest-codspeed>=5.0.0",
@@ -112,11 +112,11 @@ docs = [
 ]
 
 # NOTE: Supply-chain safety net — only resolve packages published at least
-# 7 days ago so a compromised or typo-squatted release has time to be caught
-# and yanked before it lands in our lockfile.
+#  7 days ago so a compromised or typo-squatted release has time to be caught
+#  and yanked before it lands in our lockfile.
 #
 # This is the canonical cutoff. It is mirrored as `cooldown.default-days` in
-# `.github/dependabot.yml` (Dependabot ignores `exclude-newer`) — keep both in sync.
+#  `.github/dependabot.yml` (Dependabot ignores `exclude-newer`) — keep both in sync.
 [tool.uv]
 exclude-newer = "7 days"
 
@@ -148,9 +148,9 @@ local_partial_types = true
 warn_return_any = true
 warn_unused_configs = true
 # NOTE: `warn_unreachable` and the `redundant-expr` code are intentionally NOT enabled — the
-# `X | MISSING` sentinel fields (see `schema/_models.py`) defeat mypy's flow analysis (it doesn't
-# model `MISSING` as a type), so both flag dozens of false "unreachable" / "always true|false"
-# errors. Same root cause as the per-file `comparison-overlap` disables.
+#  `X | MISSING` sentinel fields (see `schema/_models.py`) defeat mypy's flow analysis (it doesn't
+#  model `MISSING` as a type), so both flag dozens of false "unreachable" / "always true|false"
+#  errors. Same root cause as the per-file `comparison-overlap` disables.
 enable_error_code = [
     "truthy-bool",
     "truthy-iterable",
@@ -166,24 +166,24 @@ enable_error_code = [
 files = ["pydantic_jsonschema", "tests", "examples"]
 
 # Second type checker alongside `mypy`: the two disagree often enough that running both
-# catches issues neither finds alone (e.g. `pyright` flagged the `examples/custom_formats.py`
-# alias that used bare `X = Annotated[...]` instead of the canonical `type X = ...`).
+#  catches issues neither finds alone (e.g. `pyright` flagged the `examples/custom_formats.py`
+#  alias that used bare `X = Annotated[...]` instead of the canonical `type X = ...`).
 #
 # `tests` are intentionally excluded: `pyright` has no Pydantic plugin, so it (a) cannot resolve
-# field aliases (`$ref`, `if_`, `else_`, `not_`) and (b) flags the deliberate "wrong" inputs our
-# validation tests feed to coercing fields. `mypy` (with `pydantic.mypy`) covers `tests`.
+#  field aliases (`$ref`, `if_`, `else_`, `not_`) and (b) flags the deliberate "wrong" inputs our
+#  validation tests feed to coercing fields. `mypy` (with `pydantic.mypy`) covers `tests`.
 [tool.pyright]
 # https://github.com/microsoft/pyright/blob/main/docs/configuration.md
 venvPath = "."
 venv = ".venv"
 typeCheckingMode = "standard"
 # Scoped to the library source. `tests` and `examples` *consume* the models that `to_model`
-# builds at runtime, whose attributes/types are unknowable statically (`post.comments`,
-# `Reference(ref=...)` wanting the `$ref` alias, raw strings fed to coercing fields) — `pyright`
-# can only add `# pyright: ignore` noise there. `mypy` (+ `pydantic.mypy`) already covers both.
+#  builds at runtime, whose attributes/types are unknowable statically (`post.comments`,
+#  `Reference(ref=...)` wanting the `$ref` alias, raw strings fed to coercing fields) — `pyright`
+#  can only add `# pyright: ignore` noise there. `mypy` (+ `pydantic.mypy`) already covers both.
 include = ["pydantic_jsonschema"]
 # `# type: ignore` belongs to `mypy`; `pyright` uses `# pyright: ignore`. Without this, `pyright`
-# flags `mypy`-only ignores as unnecessary (and vice versa) when both checkers run.
+#  flags `mypy`-only ignores as unnecessary (and vice versa) when both checkers run.
 enableTypeIgnoreComments = false
 reportUnusedImport = "error"
 reportUnnecessaryCast = "error"
@@ -213,8 +213,8 @@ ignore = [
     "TD003",    # Missing issue link on the line following this _TODO
 
     # Per-file copyright headers are not this project's convention — the root `LICENSE` covers
-    # everything. The rule was preview-only (so `ALL` skipped it) until `ruff` `0.16.0` stabilized
-    # it, at which point it flagged every single module.
+    #  everything. The rule was preview-only (so `ALL` skipped it) until `ruff` `0.16.0` stabilized
+    #  it, at which point it flagged every single module.
     #
     # Reproduce on `ruff` `0.16.0` without this entry:
     #   uv run ruff check
@@ -268,8 +268,8 @@ addopts = [
     "--strict-markers",     # Raise error for unregistered markers
     "--strict-config",      # Raise error for unknown config options
     # Benchmarks (`tests/benchmarks/`) need `pytest-codspeed` and run only in the `CodSpeed` job,
-    # which overrides this with `-m benchmark`. Excluding them here keeps the normal suite plugin-free
-    # and out of the 100% coverage gate.
+    #  which overrides this with `-m benchmark`. Excluding them here keeps the normal suite plugin-free
+    #  and out of the 100% coverage gate.
     "-m", "not benchmark",
 ]
 markers = [
@@ -278,7 +278,7 @@ markers = [
 xfail_strict = true         # An `xfail` test that unexpectedly passes is a failure
 filterwarnings = ["error"]  # Any warning is an error — catches deprecations early (e.g. in the
                             # dependency-ceiling run); add targeted `ignore::...` entries if a
-                            # third-party warning is genuinely out of our control
+                            #  third-party warning is genuinely out of our control
 
 # https://coverage.readthedocs.io/en/latest/config.html#run
 [tool.coverage.run]

--- a/scripts/trivy_scan.sh
+++ b/scripts/trivy_scan.sh
@@ -1,21 +1,21 @@
 #!/bin/sh
 # Frozen CVE gate over the locked dependency graph (`uv.lock`) — the single home
-# of the scan flags and the pinned vulnerability DB, invoked by BOTH the CI
-# `Audit` job and the local `just scan-deps` recipe, so local and CI runs execute
-# the identical scan and can never disagree just because they ran on different
-# days.
+#  of the scan flags and the pinned vulnerability DB, invoked by BOTH the CI
+#  `Audit` job and the local `just scan-deps` recipe, so local and CI runs execute
+#  the identical scan and can never disagree just because they ran on different
+#  days.
 #
 # Usage: scripts/trivy_scan.sh fs
 #
 # Reproducibility is the whole point: `TRIVY_DB_REPOSITORY` pins the vulnerability
-# DB by digest, so a freshly published advisory can no longer turn a green commit
-# red with no code change. The weekly floating rescan re-invokes this same script
-# with `TRIVY_DB_REPOSITORY` overridden to the unpinned `:2` tag, surfacing new
-# advisories on a controlled cadence instead of at random.
+#  DB by digest, so a freshly published advisory can no longer turn a green commit
+#  red with no code change. The weekly floating rescan re-invokes this same script
+#  with `TRIVY_DB_REPOSITORY` overridden to the unpinned `:2` tag, surfacing new
+#  advisories on a controlled cadence instead of at random.
 #
 # Accepted findings that cannot be fixed yet live in `.trivyignore.yaml`, each
-# scoped to its package and carrying an `expired_at` date so a suppression cannot
-# rot silently.
+#  scoped to its package and carrying an `expired_at` date so a suppression cannot
+#  rot silently.
 set -eu
 
 MODE="${1:?usage: trivy_scan.sh fs}"
@@ -25,38 +25,38 @@ if [ "$MODE" != "fs" ]; then
 fi
 
 # The pinned vulnerability DB. A digest — not a floating tag — is what makes the
-# gate reproducible; bumping it is a deliberate, reviewable change. Overridable
-# via the environment so the weekly floating rescan can point at the unpinned
-# `:2` tag. Kept here rather than in the workflow so CI and `just scan-deps` share
-# one source of truth for the pin.
+#  gate reproducible; bumping it is a deliberate, reviewable change. Overridable
+#  via the environment so the weekly floating rescan can point at the unpinned
+#  `:2` tag. Kept here rather than in the workflow so CI and `just scan-deps` share
+#  one source of truth for the pin.
 TRIVY_DB_REPOSITORY="${TRIVY_DB_REPOSITORY:-ghcr.io/aquasecurity/trivy-db:2@sha256:620c338424c30aa0141ccec1b5791aec4e1cc2559b26d9bfe8af6238aa1ab5c0}"
 
 # Pinned trivy image for the local/CI docker fallback below. Digest-pinned for
-# the same reproducibility reason as the DB.
+#  the same reproducibility reason as the DB.
 TRIVY_IMAGE="aquasec/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969"
 
 # MEDIUM included deliberately: the scan runs `--ignore-unfixed`, so the gate is
-# already bounded to findings that HAVE a fix (i.e. ones we can act on by bumping
-# the dependency), and the `.trivyignore.yaml` ledger absorbs the few whose fix
-# cannot be adopted immediately.
+#  already bounded to findings that HAVE a fix (i.e. ones we can act on by bumping
+#  the dependency), and the `.trivyignore.yaml` ledger absorbs the few whose fix
+#  cannot be adopted immediately.
 TRIVY_SEVERITY="${TRIVY_SEVERITY:-MEDIUM,HIGH,CRITICAL}"
 
 # trivy auto-discovers only the legacy plain `.trivyignore`, never the structured
-# YAML form, so the ledger has to be named explicitly. Left unnamed it does not
-# error — it simply stops suppressing, turning every accepted finding back into a
-# gate failure.
+#  YAML form, so the ledger has to be named explicitly. Left unnamed it does not
+#  error — it simply stops suppressing, turning every accepted finding back into a
+#  gate failure.
 TRIVY_IGNOREFILE="${TRIVY_IGNOREFILE:-.trivyignore.yaml}"
 
 export TRIVY_DB_REPOSITORY TRIVY_SEVERITY TRIVY_IGNOREFILE
 
 # Everything below assumes the repo root as cwd (`uv.lock` and `.trivyignore.yaml`
-# lookup). The script `cd`s here on both the host and the container re-exec.
+#  lookup). The script `cd`s here on both the host and the container re-exec.
 cd "$(dirname "$0")/.."
 
 # CI runners and local machines have no `trivy` binary — re-exec inside the pinned
-# image. The exported `TRIVY_*` vars cross the boundary so the in-container run
-# uses the identical flags, DB pin and ignorefile. Inside the container `trivy` is
-# on `PATH`, so this branch is not re-entered.
+#  image. The exported `TRIVY_*` vars cross the boundary so the in-container run
+#  uses the identical flags, DB pin and ignorefile. Inside the container `trivy` is
+#  on `PATH`, so this branch is not re-entered.
 if ! command -v trivy >/dev/null 2>&1; then
     exec docker run --rm \
         -v "$PWD:/repo" \
@@ -71,15 +71,15 @@ if ! command -v trivy >/dev/null 2>&1; then
 fi
 
 # NOTE: trivy reuses a cached DB purely on age — it records no provenance
-# (`db/metadata.json` holds only `Version`/`UpdatedAt`/`NextUpdate`/
-# `DownloadedAt`), so a cache populated under a DIFFERENT `TRIVY_DB_REPOSITORY`
-# (e.g. the weekly floating rescan's unpinned DB) is served without complaint,
-# silently defeating the pin. Guard with a marker file: when the requested
-# repository changes, drop the DB (`--vuln-db` removes `db/` only; the scan cache
-# survives) and record the new one.
+#  (`db/metadata.json` holds only `Version`/`UpdatedAt`/`NextUpdate`/
+#  `DownloadedAt`), so a cache populated under a DIFFERENT `TRIVY_DB_REPOSITORY`
+#  (e.g. the weekly floating rescan's unpinned DB) is served without complaint,
+#  silently defeating the pin. Guard with a marker file: when the requested
+#  repository changes, drop the DB (`--vuln-db` removes `db/` only; the scan cache
+#  survives) and record the new one.
 #
 # Reproduce (warm cache + a nonexistent digest -> exits 0, downloads nothing; the
-# same command on a cold cache dies with MANIFEST_UNKNOWN):
+#  same command on a cold cache dies with MANIFEST_UNKNOWN):
 #   docker run --rm -v pydantic_jsonschema_trivy_cache:/root/.cache/trivy \
 #     --entrypoint trivy aquasec/trivy:0.72.0 image --download-db-only \
 #     --db-repository ghcr.io/aquasecurity/trivy-db:2@sha256:$(printf '0%.0s' $(seq 64))
@@ -87,21 +87,21 @@ trivy_cache_dir="${TRIVY_CACHE_DIR:-${HOME:-/root}/.cache/trivy}"
 db_ref_marker="$trivy_cache_dir/.db-repository"
 if [ "$(cat "$db_ref_marker" 2>/dev/null || true)" != "$TRIVY_DB_REPOSITORY" ]; then
     # Fail closed: the marker is written ONLY after a successful purge. If `trivy clean`
-    # is swallowed (e.g. `|| true`) and the marker is written anyway, the next run sees
-    # marker == requested repo, skips the purge, and serves the STALE DB under the new
-    # pin — silently defeating the reproducibility the pin exists to guarantee. `set -e`
-    # aborts the run on a nonzero `trivy clean`, leaving the marker unchanged so the
-    # purge is retried next time. `trivy clean --vuln-db` exits 0 on an empty cache, so
-    # the first run is unaffected.
+    #  is swallowed (e.g. `|| true`) and the marker is written anyway, the next run sees
+    #  marker == requested repo, skips the purge, and serves the STALE DB under the new
+    #  pin — silently defeating the reproducibility the pin exists to guarantee. `set -e`
+    #  aborts the run on a nonzero `trivy clean`, leaving the marker unchanged so the
+    #  purge is retried next time. `trivy clean --vuln-db` exits 0 on an empty cache, so
+    #  the first run is unaffected.
     trivy clean --vuln-db >/dev/null
     mkdir -p "$trivy_cache_dir"
     printf '%s\n' "$TRIVY_DB_REPOSITORY" >"$db_ref_marker"
 fi
 
 # `--include-dev-deps`: match the coverage of the `uv audit` this replaces — gate
-# dev/test/docs dependencies too, not just runtime. The advisory that motivated
-# freezing the DB (`pymdown-extensions`, GHSA-9xwg-3r6f-jcx2) was a docs-group
-# dep, which trivy suppresses by default.
+#  dev/test/docs dependencies too, not just runtime. The advisory that motivated
+#  freezing the DB (`pymdown-extensions`, GHSA-9xwg-3r6f-jcx2) was a docs-group
+#  dep, which trivy suppresses by default.
 trivy fs \
     --scanners vuln \
     --severity "$TRIVY_SEVERITY" \

--- a/tests/benchmarks/test_conversion.py
+++ b/tests/benchmarks/test_conversion.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 __all__: list[str] = []
 
 # A wide, flat object: many primitive properties exercising every scalar branch plus the
-# common constraint keywords (bounds, length, pattern, enum, format).
+#  common constraint keywords (bounds, length, pattern, enum, format).
 _WIDE_SCHEMA: Final[dict[str, Any]] = {
     "type": "object",
     "properties": {
@@ -46,7 +46,7 @@ _WIDE_SCHEMA: Final[dict[str, Any]] = {
 }
 
 # A deep, recursive shape: `$defs` + `$ref`, `allOf` composition, and arrays of nested objects —
-# the paths most likely to regress when the reference resolver or composition logic changes.
+#  the paths most likely to regress when the reference resolver or composition logic changes.
 _NESTED_SCHEMA: Final[dict[str, Any]] = {
     "$defs": {
         "Address": {

--- a/tests/converters/test_converter.py
+++ b/tests/converters/test_converter.py
@@ -609,9 +609,9 @@ class TestConverterCaching:
         model = converter.convert_schema(schema)
 
         # `required` keeps the bare model annotation: both fields share the `$ref`
-        # cache, so the annotation is the same model object. Optional fields would
-        # wrap it as `User | MISSING`, whose identity is not stable across Python
-        # versions (`X | Y` is no longer interned on 3.15+), making `is` fail there.
+        #  cache, so the annotation is the same model object. Optional fields would
+        #  wrap it as `User | MISSING`, whose identity is not stable across Python
+        #  versions (`X | Y` is no longer interned on 3.15+), making `is` fail there.
         assert model.model_fields["user1"].annotation is model.model_fields["user2"].annotation
 
     def test_model_generation_with_uncached_ref(self) -> None:

--- a/tests/converters/test_converter.py
+++ b/tests/converters/test_converter.py
@@ -629,6 +629,7 @@ class TestConverterCaching:
                 test_schema = Schema(type="object", properties={"value": Schema(type="string")})
                 ref = "#/$defs/TestType"
                 self._defs_cache[ref] = test_schema
+
                 return self._get_model(ref)
 
         converter = TestableConverter()

--- a/tests/converters/test_discriminator.py
+++ b/tests/converters/test_discriminator.py
@@ -206,7 +206,7 @@ class TestDiscriminatedOneOf:
         model = to_model(schema)
 
         # Tag says `cat`, so the `cat` branch is checked: its required `meow` is missing.
-        # The error is branch-specific (`pet.cat.meow`), not "matches N oneOf branches".
+        #  The error is branch-specific (`pet.cat.meow`), not "matches N oneOf branches".
         with pytest.raises(ValidationError) as exc_info:
             model(pet={"type": "cat", "bark": True})
 
@@ -392,7 +392,7 @@ class TestDiscriminatedOneOf:
         model = to_model(schema)
 
         # No tag field: both untagged branches match, so the `OneOf` validator
-        # reports the multi-branch match instead of routing by a discriminator.
+        #  reports the multi-branch match instead of routing by a discriminator.
         with pytest.raises(ValidationError) as exc_info:
             model(value={"x": 1})
 

--- a/tests/converters/test_formats.py
+++ b/tests/converters/test_formats.py
@@ -32,11 +32,11 @@ class TestFormats:
     def test_annotated_validator_basic(self) -> None:
         """Test basic Annotated type as validator."""
 
-        def validate_positive(v: int) -> int:
-            if v <= 0:
+        def validate_positive(value: int) -> int:
+            if value <= 0:
                 msg = "Must be positive"
                 raise ValueError(msg)
-            return v
+            return value
 
         PositiveInt = Annotated[int, AfterValidator(validate_positive)]  # noqa: N806
 
@@ -68,14 +68,14 @@ class TestFormats:
     def test_annotated_validator_with_transformation(self) -> None:
         """Test Annotated type with value transformation."""
 
-        def double(v: int) -> int:
-            return v * 2
+        def double(value: int) -> int:
+            return value * 2
 
-        def check_even(v: int) -> int:
-            if v % 2 != 0:
+        def check_even(value: int) -> int:
+            if value % 2 != 0:
                 msg = "Must be even"
                 raise ValueError(msg)
-            return v
+            return value
 
         DoubledEvenInt = Annotated[int, AfterValidator(double), AfterValidator(check_even)]  # noqa: N806
 
@@ -96,11 +96,11 @@ class TestFormats:
     def test_annotated_str_validator(self) -> None:
         """Test an `Annotated` string type as a format."""
 
-        def validate_email_simple(v: str) -> str:
-            if "@" not in v:
+        def validate_email_simple(value: str) -> str:
+            if "@" not in value:
                 msg = "Invalid email"
                 raise ValueError(msg)
-            return v
+            return value
 
         EmailSimple = Annotated[str, AfterValidator(validate_email_simple)]  # noqa: N806
 
@@ -132,17 +132,17 @@ class TestFormats:
     def test_mixed_validators(self) -> None:
         """Test multiple format types in one schema."""
 
-        def validate_positive(v: int) -> int:
-            if v <= 0:
+        def validate_positive(value: int) -> int:
+            if value <= 0:
                 msg = "Must be positive"
                 raise ValueError(msg)
-            return v
+            return value
 
-        def validate_uppercase(v: str) -> str:
-            if not v.isupper():
+        def validate_uppercase(value: str) -> str:
+            if not value.isupper():
                 msg = "Must be uppercase"
                 raise ValueError(msg)
-            return v
+            return value
 
         PositiveInt = Annotated[int, AfterValidator(validate_positive)]  # noqa: N806
         Uppercase = Annotated[str, AfterValidator(validate_uppercase)]  # noqa: N806
@@ -467,7 +467,7 @@ class TestFormatAcceptedForms:
         self,
         format_type: type | TypeAliasType,
         value: str,
-        expected: object,
+        expected: IPv4Address | str,
     ) -> None:
         """Each accepted form (raw `Annotated`, plain class, PEP 695 alias) is applied."""
         schema = Schema.model_validate(

--- a/tests/converters/test_formats.py
+++ b/tests/converters/test_formats.py
@@ -262,6 +262,7 @@ class TestFormats:
         )
 
         annotations = model.model_fields
+
         assert annotations["created_at"].annotation is datetime
         assert annotations["email"].annotation is str
         assert annotations["id"].annotation is UUID
@@ -273,6 +274,7 @@ class TestFormats:
             id="550e8400-e29b-41d4-a716-446655440000",
             ip="192.168.1.1",
         )
+
         assert isinstance(instance.created_at, datetime)  # type: ignore[attr-defined]
         assert isinstance(instance.email, str)  # type: ignore[attr-defined]
         assert isinstance(instance.id, UUID)  # type: ignore[attr-defined]

--- a/tests/converters/test_metadata.py
+++ b/tests/converters/test_metadata.py
@@ -4,7 +4,7 @@ from typing import Annotated, get_args, get_origin
 
 import annotated_types
 import pytest
-from pydantic import AfterValidator
+from pydantic import AfterValidator, JsonValue
 
 from pydantic_jsonschema.converters._metadata import (
     _ensure_unique_items,
@@ -51,7 +51,7 @@ class TestArrayMetadata:
             pytest.param({"type": "array", "uniqueItems": False}, id="false"),
         ],
     )
-    def test_no_unique_items_no_metadata(self, schema_raw: dict[str, object]) -> None:
+    def test_no_unique_items_no_metadata(self, schema_raw: dict[str, JsonValue]) -> None:
         """Absent or `false` `uniqueItems` imposes no constraint."""
         assert array_metadata(Schema.model_validate(schema_raw)) == []
 
@@ -85,11 +85,11 @@ class TestEnsureUniqueItems:
         [
             pytest.param([1, 1], id="scalars"),
             pytest.param([{"a": 1}, {"a": 1}], id="unhashable-dicts"),
-            # NOTE: Python equates `True == 1`, so this is treated as a duplicate.
+            # Python equates `True == 1`, so this is treated as a duplicate.
             pytest.param([True, 1], id="bool-int-edge"),
         ],
     )
-    def test_duplicates_rejected(self, items: list[object]) -> None:
+    def test_duplicates_rejected(self, items: list[JsonValue]) -> None:
         """Equal items (including the `True == 1` edge) raise `ValueError`."""
         with pytest.raises(ValueError, match="Array items must be unique"):
             _ensure_unique_items(items)

--- a/tests/converters/test_metadata.py
+++ b/tests/converters/test_metadata.py
@@ -23,12 +23,12 @@ class TestAnnotate:
     def test_no_metadata_returns_annotation_unchanged(self) -> None:
         """With no metadata the base annotation is returned as-is."""
         base = list[int]
-        assert annotate(base, []) is base
+        assert annotate(base, metadata=[]) is base
 
     def test_metadata_wraps_in_annotated(self) -> None:
         """With metadata the base becomes `Annotated[base, *metadata]`."""
         marker = annotated_types.MinLen(1)
-        result = annotate(list[int], [marker])
+        result = annotate(list[int], metadata=[marker])
 
         assert get_origin(result) is Annotated
         assert get_args(result) == (list[int], marker)

--- a/tests/converters/test_utils.py
+++ b/tests/converters/test_utils.py
@@ -1,8 +1,14 @@
 """Tests for converter utility functions."""
 
+# `MISSING` is a `Sentinel` instance rather than a type, so mypy rejects the
+#  `X | MISSING` union the `Schema` fields themselves use — see the same
+#  suppression in `pydantic_jsonschema/schema/_models.py`.
+# mypy: disable-error-code="valid-type"
+
 from typing import get_args
 
 import pytest
+from pydantic import JsonValue
 from pydantic.experimental.missing_sentinel import MISSING
 
 from pydantic_jsonschema.converters._utils import make_union, unwrap
@@ -22,7 +28,12 @@ class TestUnwrap:
             pytest.param(MISSING, 42, 42, id="missing-falls-back"),
         ],
     )
-    def test_unwrap(self, value: object, default: object, expected: object) -> None:
+    def test_unwrap(
+        self,
+        value: JsonValue | MISSING,
+        default: JsonValue,
+        expected: JsonValue,
+    ) -> None:
         """A present value is returned; the `MISSING` sentinel falls back to the default."""
         assert unwrap(value, default=default) == expected
 

--- a/tests/formats/test_email.py
+++ b/tests/formats/test_email.py
@@ -280,7 +280,7 @@ class TestInvalidIdnEmails:
     def test_total_too_long_in_octets(self) -> None:
         """RFC 6531 keeps the 254-octet total limit, counted in UTF-8 bytes."""
         # Local: 64 octets (valid alone); domain: 253 chars (valid alone);
-        # total: 64 + 1 + 253 = 318 octets > 254.
+        #  total: 64 + 1 + 253 = 318 octets > 254.
         local: str = "ю" * 32
         domain: str = "b" * 63 + "." + "c" * 63 + "." + "d" * 63 + "." + "e" * 61
         with pytest.raises(ValueError, match="Invalid IDN email format"):

--- a/tests/formats/test_uri.py
+++ b/tests/formats/test_uri.py
@@ -9,6 +9,7 @@ https://github.com/python-hyper/rfc3986/blob/0dc64f8de4327709e34e4a3039df01c46fa
 """
 
 import time
+from typing import Final
 
 import pytest
 
@@ -381,7 +382,9 @@ class TestValidIriReference:
 
     def test_ascii_uri_reference_also_valid(self) -> None:
         """ASCII URI references are also valid IRI references."""
-        assert validate_iri_reference("/relative/path") == "/relative/path"
+        reference: Final[str] = "/relative/path"
+
+        assert validate_iri_reference(reference) == reference
 
 
 class TestInvalidIriReference:

--- a/tests/formats/test_uri.py
+++ b/tests/formats/test_uri.py
@@ -249,7 +249,7 @@ class TestInvalidUri:
         elapsed = time.perf_counter() - started_at
 
         # The possessive regex finishes in ~0.1ms even on slow runners; the quadratic
-        # regression takes ~8.6s on this payload, so 1s separates them by orders of magnitude.
+        #  regression takes ~8.6s on this payload, so 1s separates them by orders of magnitude.
         assert elapsed < 1.0
 
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -31,12 +31,14 @@ def _configure(eval_example: EvalExample, /) -> None:
     :param eval_example: Fixture for evaluating examples.
     """
     config: dict[str, Any] = {"ruff_ignore": RUFF_IGNORE}
+
     if LINE_LENGTH is not None:
         config["line_length"] = LINE_LENGTH
     if TARGET_VERSION is not None:
         config["target_version"] = TARGET_VERSION
     if QUOTES is not None:
         config["quotes"] = QUOTES
+
     eval_example.set_config(**config)
 
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -84,7 +84,7 @@ def test_docs_examples(example: CodeExample, eval_example: EvalExample) -> None:
         eval_example.run_print_check(example)
 
 
-@pytest.mark.parametrize("example_file", get_example_files(), ids=lambda p: p.name)
+@pytest.mark.parametrize("example_file", get_example_files(), ids=lambda path: path.name)
 def test_example_files(example_file: Path, eval_example: EvalExample) -> None:
     """Test that Python example files run correctly.
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -10,9 +10,9 @@ from pytest_examples import CodeExample, EvalExample, find_examples
 __all__ = []
 
 # `pytest-examples` has no native `pyproject.toml` support, so source its settings here instead of
-# hardcoding them: `line-length` / `target-version` / `quote-style` track `[tool.ruff]`, and the
-# doc/example-only `ruff` ignores live in `[tool.pytest-examples]`. A `None` (key absent) means
-# "leave the `pytest-examples` default" — the value is simply not forwarded to `set_config`.
+#  hardcoding them: `line-length` / `target-version` / `quote-style` track `[tool.ruff]`, and the
+#  doc/example-only `ruff` ignores live in `[tool.pytest-examples]`. A `None` (key absent) means
+#  "leave the `pytest-examples` default" — the value is simply not forwarded to `set_config`.
 _PYPROJECT_TOML_DATA: Final[dict[str, Any]] = tomllib.loads(
     (Path(__file__).parent.parent / "pyproject.toml").read_text(encoding="utf-8"),
 )
@@ -61,8 +61,8 @@ def get_examples() -> list[CodeExample]:
     paths = [readme, *(path for path in docs_dir.glob("*.md") if path.name != "examples.md")]
 
     # NOTE: `list(...)` is required — `find_examples` returns a generator, and `parametrize`
-    # deprecated non-`Collection` iterables (`PytestRemovedIn10Warning`, surfaced by the ceiling
-    # test on a newer pytest). Reproduce:
+    #  deprecated non-`Collection` iterables (`PytestRemovedIn10Warning`, surfaced by the ceiling
+    #  test on a newer pytest). Reproduce:
     #   uv run --upgrade pytest -W error -q   # -> error during collection of `tests/test_docs.py`
     return list(find_examples(*paths))
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -129,6 +129,7 @@ class TestSchemaObjects:
         }
         schema = Schema.model_validate(raw)
         dumped: dict[str, Any] = schema.model_dump()
+
         assert dumped == snapshot(
             {
                 "$defs": {
@@ -338,6 +339,7 @@ class TestSchemaSerialization:
         }
         schema = Schema.model_validate(schema_raw)
         dumped: dict[str, Any] = schema.model_dump()
+
         assert dumped == snapshot(
             {
                 "type": DataType.OBJECT,
@@ -495,10 +497,12 @@ class TestSchemaConditionalKeywords:
                 "not": {"const": 5},
             }
         )
+
         assert isinstance(schema.if_, Schema)
         assert isinstance(schema.then, Schema)
         assert isinstance(schema.else_, Schema)
         assert isinstance(schema.not_, Schema)
+
         assert schema.model_dump() == snapshot(
             {
                 "type": DataType.INTEGER,


### PR DESCRIPTION
## What

Four mechanical style passes, one commit each, no behavior change:

- **Comment continuations** — every wrapped `#` comment now starts at `#  `, so a
  two-line comment reads as one block instead of two adjacent comments. 271 lines
  across 36 files; nothing but leading whitespace inside comments changed.
- **Keyword-only helper parameters** — six internal helpers took two positional
  arguments behind a `/` marker. The second one is now keyword-only, which makes
  the call sites say what they pass: `self._validates(adapter, value=name)` rather
  than `self._validates(adapter, name)`.
- **Precise annotations** — `object` is gone from the test signatures. JSON payload
  parameters take `JsonValue` (already the idiom in `tests/converters/test_field_kwargs.py`),
  and the rest take the concrete union they actually hold. The two `re.Pattern`
  constants in `_utils.py` gained `Final`, and abbreviated locals (`v`, `p`, `arg`)
  are spelled out.
- **Blank lines between logical blocks** — constructor bodies, the JSON Schema
  keyword builders and a handful of arrange/act/assert test bodies were single
  unbroken runs of five to eight statements.

## Why

These are the rules the linter has no rule for, so they drift silently. The one
change worth a second look is the keyword-only pass: it touches signatures, but
every one of the six is private (leading underscore or a private module), none is
re-exported from `pydantic_jsonschema/__init__.py`, and all seventeen call sites
are in this repository.

## How to test

`just lint` and `just test` — 763 passed, coverage still 100%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON Schema generation now preserves `prefixItems` and trailing `items` definitions for array schemas, ensuring complete schema output.

* **Documentation**
  * Clarified comments and explanations across configuration, schema conversion, and security scanning guidance.

* **Refactor**
  * Improved parameter consistency and type annotations without changing existing validation behavior.

* **Style**
  * Standardized comment formatting and whitespace throughout the project and development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->