### PR TITLE
docs(contributing): document the conventions the linters cannot check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -60,7 +60,6 @@ reviews:
         - Functions neither accept nor return an anonymous tuple, and a `dict` in a signature is a
           missing model: use a `dataclass`, a `NamedTuple`, a `pydantic` model or a `TypedDict`.
         - Type aliases use the `type` statement and carry a `Type` suffix (`type IdType = UUID`).
-        - Generics use the PEP 695 syntax (`def convert[T](...)`), never `TypeVar` or `Generic`.
         - `import datetime as dt`, never `from datetime import datetime`.
 
         Modules and comments.
@@ -85,7 +84,6 @@ reviews:
           fully annotated, parameters included.
         - A fixture that returns a callable is typed with a `Protocol` in `conftest.py`, never
           `Callable` and never `Any`.
-        - No `**kwargs: Any` in builders or fixtures — list every parameter with its default.
         - Nothing reads the environment: no `os.environ`, no `os.getenv`, no `dotenv`. A fixture
           builds the prepared object once and tests take it as a parameter.
         - The test tree mirrors the source tree — one source module, one test module, same path.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,9 +2,8 @@
 language: en-US
 
 reviews:
-  # NOTE: `assertive` is the verbose profile — we start with maximum feedback
-  #       to evaluate the tool; downgrade to `chill` if the noise outweighs
-  #       the signal.
+  # `assertive` is the verbose profile — we start with maximum feedback to evaluate the tool;
+  #  downgrade to `chill` if the noise outweighs the signal.
   profile: assertive
   high_level_summary: true
   poem: false
@@ -14,6 +13,96 @@ reviews:
     - "!dist/**"
     - "!site/**"
     - "!sbom/**"
+
+  # The conventions below are the ones `ruff`, `mypy` and `pyright` have no rule for, so review is
+  #  the only place they are checked. Everything they DO cover is left out on purpose: a convention
+  #  restated here would be a second home for one rule, and the linter is the one that blocks.
+  #  Canonical prose version, written for contributors:
+  #  https://danipulok.github.io/pydantic-jsonschema/contributing/#code-style
+  path_instructions:
+    - path: "**/*.py"
+      instructions: |
+        Readability, in this order — a reader who has never seen the code should predict what it
+        does from the signature.
+
+        - Separate logical blocks with blank lines. Flag a run of eight or more sibling statements
+          at one indent with no blank line between them; five to seven is worth a nudge. A run of
+          plain declarations, or a table of `if <cond>: <container>[<key>] = <value>` lines writing
+          into one container, is a table rather than a paragraph — leave those unbroken.
+        - Guard clauses over nested `if` / `elif` chains. Each condition returns or raises early.
+        - Keep a `try` body to what can actually raise; the success path goes in `else`.
+        - A comment explaining why a branch exists goes ABOVE `except` / `else` / `elif` /
+          `finally`, at the same indent, not inside the block.
+
+        Naming and signatures.
+
+        - No abbreviated or single-letter names, in any scope — not in loops, comprehensions,
+          lambdas, parameters or attributes. The only allowed short names are `_`, `er`, `i`/`j`/`k`
+          for matrix indices, `x`/`y`/`z` for geometric coordinates, and `cls`/`self`.
+        - Exception variables are always named `er`, and the caught type is the narrowest one that
+          can occur. `except Exception` needs a comment saying why the boundary is broad.
+        - At most one positional parameter. Everything after it is keyword-only, behind `*`. This
+          does not apply to dunders, `@overload`, `@override`, or a signature a library fixes for
+          us — a `pydantic` callback, for instance.
+        - Calls with two or more keyword arguments put one argument per line, with a trailing comma.
+
+        Types and constants.
+
+        - Every constant carries `Final[type]` — module level and class level alike, never a bare
+          `Final`. A meaningful literal at a call site is a missing constant.
+        - Annotate an assignment when the right-hand side does not state its type (literals, `None`,
+          empty containers, arithmetic, a declaration with no value). Do NOT annotate one that does
+          (a typed call, a constructor, a comprehension) — the second copy drifts.
+        - `object` is never written as a type. `Any` is a last resort behind a concrete type, a
+          `Protocol`, then a union, and it needs a comment saying why.
+        - Callbacks are typed with a `Protocol` defining `__call__`, never `Callable` — `Callable`
+          loses the parameter names.
+        - Functions neither accept nor return an anonymous tuple, and a `dict` in a signature is a
+          missing model: use a `dataclass`, a `NamedTuple`, a `pydantic` model or a `TypedDict`.
+        - Type aliases use the `type` statement and carry a `Type` suffix (`type IdType = UUID`).
+        - Generics use the PEP 695 syntax (`def convert[T](...)`), never `TypeVar` or `Generic`.
+        - `import datetime as dt`, never `from datetime import datetime`.
+
+        Modules and comments.
+
+        - Every module defines `__all__`. Entry points, `conftest.py` and test modules are exempt.
+        - Imports live at the top of the module. An import inside a function needs a comment naming
+          the import cycle or the optional dependency that forces it.
+        - A comment says WHY in one plain line and ends with a period; code a comment would restate
+          needs no comment. A continuation line starts with `#` followed by two spaces, one more
+          than the first line takes.
+        - `# TODO:` is the only tag. No `NOTE:`, `FIXME:`, `HACK:` or `XXX:`.
+        - Wrap every code entity in backticks — identifiers, paths, flags, versions, config keys.
+        - A non-obvious workaround or guard carries the reason, what failed without it, and a
+          permalink pinned to a commit SHA.
+
+    - path: "tests/**/*.py"
+      instructions: |
+        Everything in the `**/*.py` instructions applies here too — tests are not exempt from any
+        of it, and the naming, typing and readability rules least of all.
+
+        - Every test function is annotated `-> None`, and every fixture, factory and helper is
+          fully annotated, parameters included.
+        - A fixture that returns a callable is typed with a `Protocol` in `conftest.py`, never
+          `Callable` and never `Any`.
+        - No `**kwargs: Any` in builders or fixtures — list every parameter with its default.
+        - Nothing reads the environment: no `os.environ`, no `os.getenv`, no `dotenv`. A fixture
+          builds the prepared object once and tests take it as a parameter.
+        - The test tree mirrors the source tree — one source module, one test module, same path.
+        - `tests/` holds tests, fixtures and `conftest.py` and nothing else. A one-off utility
+          belongs in `scripts/`, exposing a function the test imports.
+        - Prefer parametrized cases with explicit `pytest.param` ids over near-duplicate tests, and
+          assert on behavior rather than on implementation details.
+
+    - path: "**/*.md"
+      instructions: |
+        - Every fact lives in exactly one place. A statement already made elsewhere in the docs is
+          replaced by a link to it, never by a second copy that drifts.
+        - Wrap every code entity in backticks — identifiers, paths, commands, flags, env var names,
+          version numbers, config keys.
+        - Plain, short sentences. Technical precision over academic prose.
+        - Never name a contributor's personal paths, hostnames or credentials in an example; use
+          obvious placeholders such as `your-api-key-here` or `https://example.com`.
 
 chat:
   auto_reply: true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,11 +71,51 @@ of those code examples. The included `examples/*.py` files are still tested dire
 
 ## Code Style
 
+`just lint` runs Ruff, `mypy`, `pyright`, `codespell` and `markdownlint`, and it is the gate — if
+it passes, the mechanical half of the style is satisfied and no reviewer will argue about it.
+
 - Use Ruff for formatting and linting.
 - Add type hints to public APIs and internal code where type inference is not obvious.
 - Use Sphinx-style docstrings for public APIs (`:param:`, `:returns:`, `:raises:`).
 - Keep `mypy` strict mode passing.
 - Keep tests explicit about generated model behavior, validation errors, references, and formats.
+
+### Conventions the linters cannot check
+
+These are the ones review actually spends its time on, so they are worth knowing before you open a
+pull request. The theme behind all of them: a reader who has never seen the code should predict
+what it does from the signature.
+
+- **Separate logical blocks with blank lines.** A wall of statements at one indent is the single
+  most common thing sent back. A run of plain declarations or a table of one-line `if` assignments
+  is a table, not a paragraph — leave those unbroken.
+- **Guard clauses over nesting.** Each condition returns or raises early; `try` holds only what can
+  actually raise, and the success path goes in `else`.
+- **Full names everywhere.** No abbreviations and no single letters, in any scope. The exceptions
+  are `_`, `er` for exception variables, `i`/`j`/`k` for matrix indices, `x`/`y`/`z` for geometric
+  coordinates, and `cls`/`self`.
+- **At most one positional parameter**; everything after it is keyword-only, behind `*`. Signatures
+  a library fixes for us — a `pydantic` callback, a dunder, an `@overload` — are exempt.
+- **Catch the narrowest exception that can occur**, and bind it as `er`. A broad catch carries a
+  comment saying why the boundary is broad.
+- **Constants carry `Final[type]`**, module level and class level alike. A meaningful literal at a
+  call site is a missing constant.
+- **Annotate an assignment only when the right-hand side does not state its type.** Literals,
+  `None`, empty containers and arithmetic need one; a typed call, a constructor or a comprehension
+  already says it, and the second copy drifts.
+- **`object` is never a type, and `Any` is a last resort** behind a concrete type, a `Protocol` and
+  a union — with a comment saying why. Callbacks use a `Protocol` with `__call__`, not `Callable`.
+- **Structures have field names.** No anonymous tuples in signatures, and a `dict` in a signature
+  is a missing `dataclass`, `NamedTuple`, model or `TypedDict`. Raw dicts belong at the boundary.
+- **Every module defines `__all__`**, and imports live at the top of it.
+- **Comments say why, in one plain line, ending with a period.** A continuation line starts at
+  `#` followed by two spaces — one more than the first line takes. `# TODO:` is the only tag we use. A non-obvious workaround
+  names what failed without it and links a permalink pinned to a commit SHA.
+- **Backtick every code entity in prose** — identifiers, paths, flags, versions, config keys — in
+  comments, docstrings, documentation, commit messages and pull request descriptions alike.
+
+Tests are held to all of the above, without exception; see
+[Testing Requirements](#testing-requirements) for what they add on top.
 
 ## Testing Requirements
 
@@ -84,6 +124,13 @@ of those code examples. The included `examples/*.py` files are still tested dire
 - Prefer direct behavior assertions over implementation-detail assertions.
 - Include validation failure cases when schema constraints should reject input.
 - Add documentation examples when a behavior needs user-facing explanation.
+- Annotate every test `-> None`, and every fixture, factory and helper in full, parameters
+  included. A fixture returning a callable is typed with a `Protocol` in `conftest.py`.
+- Mirror the source tree: one source module, one test module, same path under `tests/`.
+- Keep the environment out of tests — no `os.environ`, no `os.getenv`, no `dotenv`. A fixture
+  builds the prepared object once and each test takes it as a parameter.
+- Keep `tests/` to tests, fixtures and `conftest.py`. A one-off utility belongs in `scripts/`,
+  exposing a function the test imports.
 
 ## Pull Request Process
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -91,11 +91,14 @@ what it does from the signature.
   is a table, not a paragraph — leave those unbroken.
 - **Guard clauses over nesting.** Each condition returns or raises early; `try` holds only what can
   actually raise, and the success path goes in `else`.
+- **A comment on why a branch exists goes above its keyword** — above `except` / `else` / `elif` /
+  `finally`, at the same indent, not inside the block.
 - **Full names everywhere.** No abbreviations and no single letters, in any scope. The exceptions
   are `_`, `er` for exception variables, `i`/`j`/`k` for matrix indices, `x`/`y`/`z` for geometric
   coordinates, and `cls`/`self`.
 - **At most one positional parameter**; everything after it is keyword-only, behind `*`. Signatures
   a library fixes for us — a `pydantic` callback, a dunder, an `@overload` — are exempt.
+- **Two or more keyword arguments in a call go one per line**, with a trailing comma.
 - **Catch the narrowest exception that can occur**, and bind it as `er`. A broad catch carries a
   comment saying why the boundary is broad.
 - **Constants carry `Final[type]`**, module level and class level alike. A meaningful literal at a
@@ -107,7 +110,11 @@ what it does from the signature.
   a union — with a comment saying why. Callbacks use a `Protocol` with `__call__`, not `Callable`.
 - **Structures have field names.** No anonymous tuples in signatures, and a `dict` in a signature
   is a missing `dataclass`, `NamedTuple`, model or `TypedDict`. Raw dicts belong at the boundary.
-- **Every module defines `__all__`**, and imports live at the top of it.
+- **Type aliases use the `type` statement and carry a `Type` suffix** — `type IdType = UUID`.
+- **`import datetime as dt`**, never `from datetime import datetime` — the module and the class
+  share a name, and the alias keeps every reference unambiguous.
+- **Every module defines `__all__`**, and imports live at the top of it. An import inside a function
+  carries a comment naming the import cycle or the optional dependency that forces it.
 - **Comments say why, in one plain line, ending with a period.** A continuation line starts at
   `#` followed by two spaces — one more than the first line takes. `# TODO:` is the only tag we use. A non-obvious workaround
   names what failed without it and links a permalink pinned to a commit SHA.
@@ -122,6 +129,8 @@ Tests are held to all of the above, without exception; see
 - Add tests for every new feature or behavior change.
 - Maintain 100% coverage.
 - Prefer direct behavior assertions over implementation-detail assertions.
+- Prefer one parametrized test with explicit `pytest.param` ids over near-duplicate tests — the id
+  is what a failing CI log names.
 - Include validation failure cases when schema constraints should reject input.
 - Add documentation examples when a behavior needs user-facing explanation.
 - Annotate every test `-> None`, and every fixture, factory and helper in full, parameters

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,12 +71,12 @@ of those code examples. The included `examples/*.py` files are still tested dire
 
 ## Code Style
 
-`just lint` runs Ruff, `mypy`, `pyright`, `codespell` and `markdownlint`, and it is the gate — if
+`just lint` runs `ruff`, `mypy`, `pyright`, `codespell` and `markdownlint`, and it is the gate — if
 it passes, the mechanical half of the style is satisfied and no reviewer will argue about it.
 
-- Use Ruff for formatting and linting.
+- Use `ruff` for formatting and linting.
 - Add type hints to public APIs and internal code where type inference is not obvious.
-- Use Sphinx-style docstrings for public APIs (`:param:`, `:returns:`, `:raises:`).
+- Use `Sphinx`-style docstrings for public APIs (`:param:`, `:returns:`, `:raises:`).
 - Keep `mypy` strict mode passing.
 - Keep tests explicit about generated model behavior, validation errors, references, and formats.
 


### PR DESCRIPTION
## What

- `docs/contributing.md`: the `Code Style` section now names `just lint` as the gate and adds
  `Conventions the linters cannot check` — the house rules that no `ruff`, `mypy` or `pyright`
  rule expresses (blank lines between logical blocks, guard clauses, full descriptive names,
  one positional parameter, `er` for narrow exception binds, `Final[type]` on constants, when
  to annotate an assignment and when not to, no `object`, `Protocol` over `Callable`, no
  anonymous tuples or bare dicts crossing a signature, `__all__` and top-level imports, comment
  style, backticks around code entities).
- `Testing Requirements` gains the four that apply inside `tests/`: every test annotated
  `-> None`, `Protocol` for fixture factories, the test tree mirrors the source tree, and no
  test reads the environment.
- `.coderabbit.yaml`: `path_instructions` for `**/*.py`, `tests/**/*.py` and `**/*.md`, so the
  reviewer checks the same list on every PR.

## Why

These conventions were only enforceable by remembering them, which is why they drift. The
linters already block everything they have a rule for; this is the remainder, written down once
for contributors and once for the reviewer.

The two copies are deliberate and one-directional: `.coderabbit.yaml` carries a pointer to the
prose version as its canonical source, and deliberately omits everything the linters already
cover so a rule never gets a second home.

## How to test

`just lint` (markdown lint covers the docs change) and check the rendered
[Contributing](https://danipulok.github.io/pydantic-jsonschema/contributing/#code-style) page
after this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contributor guidance with additional Python style, typing, naming, testing, and documentation conventions.
  * Updated linting instructions to include type checking.
  * Added guidance for organizing tests and keeping them isolated from environment access.

* **Chores**
  * Added automated review guidance for Python, test, and Markdown files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->