### PR TITLE
fix(applicators): render subschema branches through the active `GetJsonSchemaHandler`

### DIFF
--- a/pydantic_jsonschema/applicators/_base.py
+++ b/pydantic_jsonschema/applicators/_base.py
@@ -27,7 +27,7 @@ from pydantic import (
     ValidationError,
 )
 from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import CoreSchema
+from pydantic_core import CoreSchema, core_schema
 
 __all__ = [
     "AnnotationApplicator",
@@ -79,6 +79,35 @@ class Applicator:
             self._namespace[branch.__forward_arg__] if isinstance(branch, ForwardRef) else branch
         )
         return TypeAdapter(resolved)
+
+    @staticmethod
+    def _branch_schema(
+        adapter: TypeAdapter[AnnotationType],
+        /,
+        *,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Render a subschema branch into the JSON Schema document being generated.
+
+        :param adapter: The subschema adapter.
+        :param handler: The handler of the in-progress generation.
+        :returns: The branch schema, with the definitions it needs registered at the document root.
+        """
+        # `adapter.json_schema()` builds a *separate* document. A branch Pydantic cannot inline — a
+        #  recursive model — comes back as `{"$ref": "#/$defs/Model"}` carrying its own `$defs`,
+        #  and embedding only that fragment leaves the reference pointing at nothing:
+        #  `KeyError: '#/$defs/Model'` out of `GenerateJsonSchema.get_json_ref_counts`. The active
+        #  handler registers the definitions in the root document instead.
+        #  https://github.com/pydantic/pydantic/blob/cf67d4b3193c3fe43ede18612ed62785eee11382/pydantic/json_schema.py#L2435
+        #
+        # The empty `definitions_schema` wrapper is what makes that handler take the full path.
+        #  Called on a foreign schema it dispatches straight to the per-type method, skipping the
+        #  `pydantic_js_updates` metadata of the schema it was handed — a typeless branch
+        #  (`{"maxLength": 3}` -> `Annotated[Any, MaxLen(3)]`) then dumps as `{}`. The wrapper
+        #  re-enters `generate_inner`, which applies that metadata.
+        #  https://github.com/pydantic/pydantic/blob/cf67d4b3193c3fe43ede18612ed62785eee11382/pydantic/json_schema.py#L529
+        #  https://github.com/pydantic/pydantic/blob/cf67d4b3193c3fe43ede18612ed62785eee11382/pydantic/json_schema.py#L2103
+        return handler(core_schema.definitions_schema(adapter.core_schema, []))
 
     @staticmethod
     def _validates(
@@ -137,5 +166,9 @@ class ObjectApplicator(Applicator, ABC):
         """Validate the raw mapping, returning it unchanged or raising `ValueError`."""
 
     @abstractmethod
-    def json_schema_keyword(self) -> JsonSchemaValue:
+    def json_schema_keyword(
+        self,
+        handler: GetJsonSchemaHandler,
+        /,
+    ) -> JsonSchemaValue:
         """Return this applicator's keyword fragment for the dumped JSON Schema."""

--- a/pydantic_jsonschema/applicators/_contains.py
+++ b/pydantic_jsonschema/applicators/_contains.py
@@ -64,7 +64,7 @@ class Contains(AnnotationApplicator):
         """Restore the `contains` / `minContains` / `maxContains` keywords on dump."""
         json_schema = handler(schema)
 
-        json_schema["contains"] = self._get_adapter().json_schema()
+        json_schema["contains"] = self._branch_schema(self._get_adapter(), handler=handler)
         if self._min_contains != _DEFAULT_MIN_CONTAINS:
             json_schema["minContains"] = self._min_contains
         if self._max_contains is not None:

--- a/pydantic_jsonschema/applicators/_dependent_schemas.py
+++ b/pydantic_jsonschema/applicators/_dependent_schemas.py
@@ -5,7 +5,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.2.4
 
 from typing import override
 
-from pydantic import TypeAdapter
+from pydantic import GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 
 from ._base import AnnotationType, ObjectApplicator
@@ -48,11 +48,16 @@ class DependentSchemas(ObjectApplicator):
         return self._adapters
 
     @override
-    def json_schema_keyword(self) -> JsonSchemaValue:
+    def json_schema_keyword(
+        self,
+        handler: GetJsonSchemaHandler,
+        /,
+    ) -> JsonSchemaValue:
         """Return the `dependentSchemas` keyword fragment for the dumped JSON Schema."""
         return {
             "dependentSchemas": {
-                trigger: adapter.json_schema() for trigger, adapter in self._get_adapters().items()
+                trigger: self._branch_schema(adapter, handler=handler)
+                for trigger, adapter in self._get_adapters().items()
             }
         }
 

--- a/pydantic_jsonschema/applicators/_if_then_else.py
+++ b/pydantic_jsonschema/applicators/_if_then_else.py
@@ -64,19 +64,23 @@ class IfThenElse(AnnotationApplicator, ObjectApplicator):
     ) -> JsonSchemaValue:
         """Restore the `if` / `then` / `else` keywords on dump."""
         json_schema = handler(schema)
-        json_schema.update(self.json_schema_keyword())
+        json_schema.update(self.json_schema_keyword(handler))
         return json_schema
 
     @override
-    def json_schema_keyword(self) -> JsonSchemaValue:
+    def json_schema_keyword(
+        self,
+        handler: GetJsonSchemaHandler,
+        /,
+    ) -> JsonSchemaValue:
         """Return the `if` / `then` / `else` keyword fragment for the dumped JSON Schema."""
         if_adapter = self._build_adapters()
 
-        keyword: JsonSchemaValue = {"if": if_adapter.json_schema()}
+        keyword: JsonSchemaValue = {"if": self._branch_schema(if_adapter, handler=handler)}
         if self._then_adapter is not None:
-            keyword["then"] = self._then_adapter.json_schema()
+            keyword["then"] = self._branch_schema(self._then_adapter, handler=handler)
         if self._else_adapter is not None:
-            keyword["else"] = self._else_adapter.json_schema()
+            keyword["else"] = self._branch_schema(self._else_adapter, handler=handler)
 
         return keyword
 

--- a/pydantic_jsonschema/applicators/_not.py
+++ b/pydantic_jsonschema/applicators/_not.py
@@ -58,13 +58,17 @@ class Not(AnnotationApplicator, ObjectApplicator):
     ) -> JsonSchemaValue:
         """Restore the `not` keyword on dump (the wrap-validator drops it otherwise)."""
         json_schema = handler(schema)
-        json_schema.update(self.json_schema_keyword())
+        json_schema.update(self.json_schema_keyword(handler))
         return json_schema
 
     @override
-    def json_schema_keyword(self) -> JsonSchemaValue:
+    def json_schema_keyword(
+        self,
+        handler: GetJsonSchemaHandler,
+        /,
+    ) -> JsonSchemaValue:
         """Return the `not` keyword fragment for the dumped JSON Schema."""
-        return {"not": self._get_adapter().json_schema()}
+        return {"not": self._branch_schema(self._get_adapter(), handler=handler)}
 
     def matches(
         self,

--- a/pydantic_jsonschema/applicators/_pattern_properties.py
+++ b/pydantic_jsonschema/applicators/_pattern_properties.py
@@ -6,7 +6,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.2
 import re
 from typing import override
 
-from pydantic import TypeAdapter
+from pydantic import GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 
 from ._base import AnnotationType, ObjectApplicator
@@ -50,11 +50,16 @@ class PatternProperties(ObjectApplicator):
         return self._compiled
 
     @override
-    def json_schema_keyword(self) -> JsonSchemaValue:
+    def json_schema_keyword(
+        self,
+        handler: GetJsonSchemaHandler,
+        /,
+    ) -> JsonSchemaValue:
         """Return the `patternProperties` keyword fragment for the dumped JSON Schema."""
         return {
             "patternProperties": {
-                pattern.pattern: adapter.json_schema() for pattern, adapter in self._get_compiled()
+                pattern.pattern: self._branch_schema(adapter, handler=handler)
+                for pattern, adapter in self._get_compiled()
             }
         }
 

--- a/pydantic_jsonschema/applicators/_prefix_items.py
+++ b/pydantic_jsonschema/applicators/_prefix_items.py
@@ -63,10 +63,10 @@ class PrefixItems(AnnotationApplicator):
         self._build_adapters()
 
         json_schema["prefixItems"] = [
-            adapter.json_schema() for adapter in self._prefix_adapters or []
+            self._branch_schema(adapter, handler=handler) for adapter in self._prefix_adapters or []
         ]
         if self._tail_adapter is not None:
-            json_schema["items"] = self._tail_adapter.json_schema()
+            json_schema["items"] = self._branch_schema(self._tail_adapter, handler=handler)
 
         return json_schema
 

--- a/pydantic_jsonschema/applicators/_property_names.py
+++ b/pydantic_jsonschema/applicators/_property_names.py
@@ -5,7 +5,7 @@ See: https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.4
 
 from typing import override
 
-from pydantic import TypeAdapter
+from pydantic import GetJsonSchemaHandler, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 
 from ._base import AnnotationType, ObjectApplicator
@@ -46,9 +46,13 @@ class PropertyNames(ObjectApplicator):
         return self._adapter
 
     @override
-    def json_schema_keyword(self) -> JsonSchemaValue:
+    def json_schema_keyword(
+        self,
+        handler: GetJsonSchemaHandler,
+        /,
+    ) -> JsonSchemaValue:
         """Return the `propertyNames` keyword fragment for the dumped JSON Schema."""
-        return {"propertyNames": self._get_adapter().json_schema()}
+        return {"propertyNames": self._branch_schema(self._get_adapter(), handler=handler)}
 
     @override
     def validate(

--- a/pydantic_jsonschema/converters/_converter.py
+++ b/pydantic_jsonschema/converters/_converter.py
@@ -449,7 +449,7 @@ class SchemaConverter:
         ) -> JsonSchemaValue:
             json_schema = handler(schema)
             for applicator in applicators:
-                json_schema.update(applicator.json_schema_keyword())
+                json_schema.update(applicator.json_schema_keyword(handler))
             return json_schema
 
         wrapped = type(

--- a/tests/applicators/test_contains.py
+++ b/tests/applicators/test_contains.py
@@ -175,3 +175,48 @@ class TestContainsJsonSchema:
         assert model.model_json_schema()["properties"]["a"] == snapshot(
             {"contains": {"type": "integer"}, "items": {}, "title": "A", "type": "array"}
         )
+
+    def test_contains_recursive_ref_round_trips(self) -> None:
+        """A recursive `contains` branch keeps its `$ref` resolvable from the document root."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "array", "contains": {"$ref": "#/$defs/Node"}},
+                    },
+                    "required": ["a"],
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/$defs/Node"}},
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"next": {"$ref": "#/$defs/Model", "title": "Next"}},
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "additionalProperties": True,
+                "properties": {
+                    "a": {
+                        "contains": {"$ref": "#/$defs/Model"},
+                        "items": {},
+                        "title": "A",
+                        "type": "array",
+                    }
+                },
+                "required": ["a"],
+                "title": "Model",
+                "type": "object",
+            }
+        )

--- a/tests/applicators/test_dependent_schemas.py
+++ b/tests/applicators/test_dependent_schemas.py
@@ -120,9 +120,8 @@ class TestDependentSchemasJsonSchema:
 
         assert model.model_json_schema() == snapshot(
             {
-                "additionalProperties": True,
-                "dependentSchemas": {
-                    "a": {
+                "$defs": {
+                    "Model": {
                         "additionalProperties": True,
                         "properties": {"b": {"title": "B", "type": "integer"}},
                         "required": ["b"],
@@ -130,7 +129,45 @@ class TestDependentSchemasJsonSchema:
                         "type": "object",
                     }
                 },
+                "additionalProperties": True,
+                "dependentSchemas": {"a": {"$ref": "#/$defs/Model"}},
                 "properties": {},
+                "title": "Model",
+                "type": "object",
+            }
+        )
+
+    def test_dependent_schemas_recursive_ref_round_trips(self) -> None:
+        """A recursive `dependentSchemas` branch keeps its `$ref` resolvable from the root."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {"a": {"type": "string"}},
+                    "dependentSchemas": {"a": {"$ref": "#/$defs/Node"}},
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/$defs/Node"}},
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"next": {"$ref": "#/$defs/Model", "title": "Next"}},
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "additionalProperties": True,
+                "dependentSchemas": {"a": {"$ref": "#/$defs/Model"}},
+                "properties": {"a": {"title": "A", "type": "string"}},
                 "title": "Model",
                 "type": "object",
             }

--- a/tests/applicators/test_if_then_else.py
+++ b/tests/applicators/test_if_then_else.py
@@ -265,3 +265,52 @@ class TestIfThenElseJsonSchema:
                 "type": "object",
             }
         )
+
+    def test_if_then_else_recursive_ref_round_trips(self) -> None:
+        """Recursive `if` / `then` / `else` branches keep their `$ref` resolvable from the root."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "if": {"$ref": "#/$defs/Node"},
+                            "then": {"$ref": "#/$defs/Node"},
+                            "else": {"$ref": "#/$defs/Node"},
+                        },
+                    },
+                    "required": ["a"],
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/$defs/Node"}},
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"next": {"$ref": "#/$defs/Model", "title": "Next"}},
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "additionalProperties": True,
+                "properties": {
+                    "a": {
+                        "else": {"$ref": "#/$defs/Model"},
+                        "if": {"$ref": "#/$defs/Model"},
+                        "then": {"$ref": "#/$defs/Model"},
+                        "title": "A",
+                    }
+                },
+                "required": ["a"],
+                "title": "Model",
+                "type": "object",
+            }
+        )

--- a/tests/applicators/test_not.py
+++ b/tests/applicators/test_not.py
@@ -172,15 +172,54 @@ class TestNotJsonSchema:
 
         assert model.model_json_schema() == snapshot(
             {
-                "additionalProperties": True,
-                "not": {
-                    "additionalProperties": True,
-                    "properties": {"secret": {"title": "Secret", "type": "integer"}},
-                    "required": ["secret"],
-                    "title": "Model",
-                    "type": "object",
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"secret": {"title": "Secret", "type": "integer"}},
+                        "required": ["secret"],
+                        "title": "Model",
+                        "type": "object",
+                    }
                 },
+                "additionalProperties": True,
+                "not": {"$ref": "#/$defs/Model"},
                 "properties": {"role": {"title": "Role", "type": "string"}},
+                "title": "Model",
+                "type": "object",
+            }
+        )
+
+    def test_not_recursive_ref_round_trips(self) -> None:
+        """A recursive `not` branch keeps its `$ref` resolvable from the document root."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {"a": {"not": {"$ref": "#/$defs/Node"}}},
+                    "required": ["a"],
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/$defs/Node"}},
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"next": {"$ref": "#/$defs/Model", "title": "Next"}},
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "additionalProperties": True,
+                "properties": {"a": {"not": {"$ref": "#/$defs/Model"}, "title": "A"}},
+                "required": ["a"],
                 "title": "Model",
                 "type": "object",
             }

--- a/tests/applicators/test_pattern_properties.py
+++ b/tests/applicators/test_pattern_properties.py
@@ -129,3 +129,38 @@ class TestPatternPropertiesJsonSchema:
                 "type": "object",
             }
         )
+
+    def test_pattern_properties_recursive_ref_round_trips(self) -> None:
+        """A recursive `patternProperties` branch keeps its `$ref` resolvable from the root."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "patternProperties": {"^x": {"$ref": "#/$defs/Node"}},
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/$defs/Node"}},
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"next": {"$ref": "#/$defs/Model", "title": "Next"}},
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "additionalProperties": True,
+                "patternProperties": {"^x": {"$ref": "#/$defs/Model"}},
+                "properties": {},
+                "title": "Model",
+                "type": "object",
+            }
+        )

--- a/tests/applicators/test_prefix_items.py
+++ b/tests/applicators/test_prefix_items.py
@@ -161,3 +161,97 @@ class TestPrefixItemsJsonSchema:
         assert model.model_json_schema()["properties"]["a"] == snapshot(
             {"items": {}, "prefixItems": [{"type": "string"}], "title": "A", "type": "array"}
         )
+
+    def test_prefix_items_recursive_ref_round_trips(self) -> None:
+        """A recursive `prefixItems` branch keeps its `$ref` resolvable from the document root."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "array", "prefixItems": [{"$ref": "#/$defs/Node"}]},
+                    },
+                    "required": ["a"],
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/$defs/Node"}},
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"next": {"$ref": "#/$defs/Model", "title": "Next"}},
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "additionalProperties": True,
+                "properties": {
+                    "a": {
+                        "items": {},
+                        "prefixItems": [{"$ref": "#/$defs/Model"}],
+                        "title": "A",
+                        "type": "array",
+                    }
+                },
+                "required": ["a"],
+                "title": "Model",
+                "type": "object",
+            }
+        )
+
+    def test_items_tail_recursive_ref_round_trips(self) -> None:
+        """A recursive tail `items` branch keeps its `$ref` resolvable from the document root."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "type": "array",
+                            "prefixItems": [{"type": "string"}],
+                            "items": {"$ref": "#/$defs/Node"},
+                        },
+                    },
+                    "required": ["a"],
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/$defs/Node"}},
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"next": {"$ref": "#/$defs/Model", "title": "Next"}},
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "additionalProperties": True,
+                "properties": {
+                    "a": {
+                        "items": {"$ref": "#/$defs/Model"},
+                        "prefixItems": [{"type": "string"}],
+                        "title": "A",
+                        "type": "array",
+                    }
+                },
+                "required": ["a"],
+                "title": "Model",
+                "type": "object",
+            }
+        )

--- a/tests/applicators/test_property_names.py
+++ b/tests/applicators/test_property_names.py
@@ -89,3 +89,59 @@ class TestPropertyNamesJsonSchema:
                 "type": "object",
             }
         )
+
+    def test_property_names_typeless_branch_round_trips(self) -> None:
+        """A branch carrying only a constraint keeps that constraint on dump.
+
+        A typeless branch converts to `Annotated[Any, ...]`, whose keyword lives in the core
+        schema's own `pydantic_js_updates` metadata rather than in a nested schema — the one
+        place a branch renderer can drop it while every typed branch still round-trips.
+        """
+        model = to_model(
+            Schema.model_validate({"type": "object", "propertyNames": {"maxLength": 3}})
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "additionalProperties": True,
+                "properties": {},
+                "propertyNames": {"maxLength": 3},
+                "title": "Model",
+                "type": "object",
+            }
+        )
+
+    def test_property_names_recursive_ref_round_trips(self) -> None:
+        """A recursive `propertyNames` branch keeps its `$ref` resolvable from the document root."""
+        model = to_model(
+            Schema.model_validate(
+                {
+                    "type": "object",
+                    "propertyNames": {"$ref": "#/$defs/Node"},
+                    "$defs": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/$defs/Node"}},
+                        },
+                    },
+                }
+            )
+        )
+
+        assert model.model_json_schema() == snapshot(
+            {
+                "$defs": {
+                    "Model": {
+                        "additionalProperties": True,
+                        "properties": {"next": {"$ref": "#/$defs/Model", "title": "Next"}},
+                        "title": "Model",
+                        "type": "object",
+                    }
+                },
+                "additionalProperties": True,
+                "properties": {},
+                "propertyNames": {"$ref": "#/$defs/Model"},
+                "title": "Model",
+                "type": "object",
+            }
+        )


### PR DESCRIPTION
## What

Applicators rendered their subschema branches with `adapter.json_schema()`, which builds a
*separate* JSON Schema document. A branch Pydantic cannot inline — a recursive model — comes
back as `{"$ref": "#/$defs/Model"}` carrying its own `$defs`, and only the fragment was
embedded, so the reference pointed at nothing:

```python
to_model(
    Schema.model_validate(
        {
            "type": "object",
            "properties": {"a": {"not": {"$ref": "#/$defs/Node"}}},
            "required": ["a"],
            "$defs": {"Node": {"type": "object", "properties": {"next": {"$ref": "#/$defs/Node"}}}},
        }
    )
).model_json_schema()
# KeyError: '#/$defs/Model'  (pydantic/json_schema.py, GenerateJsonSchema.get_json_ref_counts)
```

A new shared `Applicator._branch_schema()` renders the branch through the `GetJsonSchemaHandler`
of the generation already in progress, so the definitions it needs get registered at the root of
the document being built. Eight paths were affected: `prefixItems`, `items` (tail), `contains`,
`not`, `if` / `then` / `else`, `propertyNames`, `patternProperties`, `dependentSchemas`.

The branch is wrapped in an empty `core_schema.definitions_schema(...)` rather than handed to the
handler directly. Called on a foreign core schema the handler dispatches straight to the per-type
method and skips that schema's own `pydantic_js_updates` metadata — a typeless branch
(`{"maxLength": 3}`, which converts to `Annotated[Any, MaxLen(3)]`) then dumps as `{}`. The
wrapper re-enters `generate_inner`, which applies it. `test_property_names_typeless_branch_round_trips`
covers that case; it was the one shape the suite had no test for.

## Behaviour change

An object-typed branch is now emitted as a definition and a reference instead of being inlined:

```
before: {"not": {"type": "object", "properties": {...}}}
after:  {"$defs": {"Model": {...}}, "not": {"$ref": "#/$defs/Model"}}
```

This is what the rest of the library already does — a plain nested object property has always
dumped as `$defs` + `$ref`. The inline form was an artifact of bypassing the generator, and it
is the same bypass that broke on recursion. Two existing snapshots move to the new shape; the
documents are semantically identical.

## How to test

`just test` — 772 passing, coverage still 100%. Nine regression tests were added, one per
affected path plus the typeless branch, each round-tripping a schema whose branch is a recursive
`$ref`.
